### PR TITLE
Go バージョンを 1.26.2 に更新

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.2'
 
       - name: Install dependencies
         run: go mod download
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.2'
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.2'
 
       - name: Install dependencies
         run: go mod download

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## プロジェクト概要
 
-Go 1.25 製の株価データ収集システム。**j-Quants API** を主軸に Yahoo Finance API からデータを取得し MySQL に保存する。REST API / gRPC API / CLI の3つの実行形態を持つが、**コアはデータ収集 CLI**。Raspberry Pi 上で常時稼働する想定。モジュールパス: `github.com/Code0716/stock-price-repository`。
+Go 1.26 製の株価データ収集システム。**j-Quants API** を主軸に Yahoo Finance API からデータを取得し MySQL に保存する。REST API / gRPC API / CLI の3つの実行形態を持つが、**コアはデータ収集 CLI**。Raspberry Pi 上で常時稼働する想定。モジュールパス: `github.com/Code0716/stock-price-repository`。
 
 **応答言語**: コード説明・レビュー・提案はすべて日本語で行う。
 

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine
+FROM golang:1.26.2-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine
+FROM golang:1.26.2-alpine
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Code0716/stock-price-repository
 
-go 1.25.9
+go 1.26.2
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0


### PR DESCRIPTION
## Summary

- `go.mod`: `go 1.25.9` → `go 1.26.2`
- `.github/workflows/test.yml`: CI の `go-version` を 3箇所すべて `1.26.2` に更新
- `Dockerfile.api` / `Dockerfile.grpc`: ベースイメージを `golang:1.26-alpine` → `golang:1.26.2-alpine` に更新
- `CLAUDE.md`: プロジェクト概要のバージョン記述を更新

## Test plan

- [ ] CI (lint / vuln_check / test) が Go 1.26.2 で正常に通ること
- [ ] `go build ./...` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)