### PR TITLE
fix: migration から明示的な COLLATE 指定を削除

### DIFF
--- a/sql/migrations/000004_create_applied_stock_consolidations_history.up.sql
+++ b/sql/migrations/000004_create_applied_stock_consolidations_history.up.sql
@@ -5,7 +5,7 @@ CREATE TABLE applied_stock_consolidations_history (
     ratio DECIMAL(10, 4) NOT NULL COMMENT '併合比率（旧株数/新株数。例: 5株を1株に併合なら 5.0000）',
     applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT '適用日時',
     UNIQUE KEY uq_symbol_consolidation_date (symbol, consolidation_date)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 検索効率向上のためのインデックス
 CREATE INDEX idx_applied_stock_consolidations_history_symbol_date ON applied_stock_consolidations_history(symbol, consolidation_date);


### PR DESCRIPTION
## Summary

- `000004_create_applied_stock_consolidations_history.up.sql` の `COLLATE=utf8mb4_0900_ai_ci` を削除
- `utf8mb4_0900_ai_ci` は MySQL 8.0.1 以降のデフォルトであり、Raspberry Pi 環境の MySQL バージョンによっては非対応でエラーになる可能性があるため、明示指定を外してサーバーデフォルトに委ねる

## Test plan

- [ ] migration を実行して `applied_stock_consolidations_history` テーブルが正常に作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)