### PR TITLE
分析履歴一覧 API を追加

### DIFF
--- a/di/wire.go
+++ b/di/wire.go
@@ -79,6 +79,7 @@ func InitializeCli(ctx context.Context) (*cli.Runner, func(), error) {
 var apiSet = wire.NewSet(
 	handler.NewStockPriceHandler,
 	handler.NewStockBrandHandler,
+	handler.NewAnalyzeStockBrandPriceHistoryHandler,
 	router.NewRouter,
 )
 

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -97,7 +97,8 @@ func InitializeApiServer(ctx context.Context) (*http.ServeMux, func(), error) {
 	analyzeStockBrandPriceHistoryRepository := database.NewAnalyzeStockBrandPriceHistoryRepositoryImpl(gormDB)
 	stockBrandInteractor := usecase.NewStockBrandInteractor(transaction, stockBrandRepository, stockBrandsDailyPriceRepository, analyzeStockBrandPriceHistoryRepository, stockBrandsDailyPriceForAnalyzeRepository, stockAPIClient, client)
 	stockBrandHandler := handler.NewStockBrandHandler(stockBrandInteractor, httpServer, logger)
-	serveMux := router.NewRouter(stockPriceHandler, stockBrandHandler)
+	analyzeStockBrandPriceHistoryHandler := handler.NewAnalyzeStockBrandPriceHistoryHandler(stockBrandInteractor, httpServer, logger)
+	serveMux := router.NewRouter(stockPriceHandler, stockBrandHandler, analyzeStockBrandPriceHistoryHandler)
 	return serveMux, func() {
 		cleanup()
 	}, nil
@@ -140,7 +141,7 @@ var cliSet = wire.NewSet(cli.NewRunner, commands.NewHealthCheckCommand, commands
 
 var databaseSet = wire.NewSet(database.NewTransaction, database.NewStockBrandRepositoryImpl, database.NewNikkeiRepositoryImpl, database.NewDjiRepositoryImpl, database.NewStockBrandsDailyPriceRepositoryImpl, database.NewAnalyzeStockBrandPriceHistoryRepositoryImpl, database.NewStockBrandsDailyPriceForAnalyzeRepositoryImpl, database.NewHighVolumeStockBrandRepositoryImpl, database.NewAppliedStockSplitsHistoryRepositoryImpl, database.NewAppliedStockConsolidationsHistoryRepositoryImpl)
 
-var apiSet = wire.NewSet(handler.NewStockPriceHandler, handler.NewStockBrandHandler, router.NewRouter)
+var apiSet = wire.NewSet(handler.NewStockPriceHandler, handler.NewStockBrandHandler, handler.NewAnalyzeStockBrandPriceHistoryHandler, router.NewRouter)
 
 var grpcSet = wire.NewSet(server.NewStockServiceServer, usecase.NewGetHighVolumeStockBrandsUseCase, wire.Struct(new(GrpcServerComponents), "*"))
 

--- a/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
+++ b/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
@@ -1,0 +1,126 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/Code0716/stock-price-repository/driver"
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/Code0716/stock-price-repository/usecase"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultAnalyzeStockBrandPriceHistoryLimit = 100
+	maxAnalyzeStockBrandPriceHistoryLimit     = 1000
+)
+
+type GetAnalyzeStockBrandPriceHistoriesResponse struct {
+	Histories  []*models.AnalyzeStockBrandPriceHistory `json:"histories"`
+	Pagination *PaginationInfo                         `json:"pagination,omitempty"`
+}
+
+type getAnalyzeStockBrandPriceHistoriesParams struct {
+	symbol string
+	action string
+	method string
+	cursor string
+	limit  int
+}
+
+type AnalyzeStockBrandPriceHistoryHandler struct {
+	usecase    usecase.StockBrandInteractor
+	httpServer driver.HTTPServer
+	logger     *zap.Logger
+}
+
+func NewAnalyzeStockBrandPriceHistoryHandler(u usecase.StockBrandInteractor, h driver.HTTPServer, l *zap.Logger) *AnalyzeStockBrandPriceHistoryHandler {
+	return &AnalyzeStockBrandPriceHistoryHandler{
+		usecase:    u,
+		httpServer: h,
+		logger:     l,
+	}
+}
+
+func (h *AnalyzeStockBrandPriceHistoryHandler) validateGetAnalyzeStockBrandPriceHistoriesParams(r *http.Request) (*getAnalyzeStockBrandPriceHistoriesParams, error) {
+	params := &getAnalyzeStockBrandPriceHistoriesParams{
+		limit: defaultAnalyzeStockBrandPriceHistoryLimit,
+	}
+
+	params.symbol = h.httpServer.GetQueryParam(r, "symbol")
+	if params.symbol != "" {
+		if len(params.symbol) > 10 {
+			return nil, &validationError{message: "symbolが長すぎます"}
+		}
+		if !alphanumericOptionalRegex.MatchString(params.symbol) {
+			return nil, &validationError{message: "symbolは英数字である必要があります"}
+		}
+	}
+
+	params.action = h.httpServer.GetQueryParam(r, "action")
+	if params.action != "" &&
+		params.action != models.AnalyzeStockBrandPriceHistoryActionBuy &&
+		params.action != models.AnalyzeStockBrandPriceHistoryActionSell {
+		return nil, &validationError{message: "actionはBuyまたはSellである必要があります"}
+	}
+
+	params.method = h.httpServer.GetQueryParam(r, "method")
+	if len(params.method) > 255 {
+		return nil, &validationError{message: "methodが長すぎます"}
+	}
+
+	params.cursor = h.httpServer.GetQueryParam(r, "cursor")
+	if len(params.cursor) > 36 {
+		return nil, &validationError{message: "cursorが長すぎます"}
+	}
+
+	limitStr := h.httpServer.GetQueryParam(r, "limit")
+	if limitStr != "" {
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			return nil, &validationError{message: "limitは数値である必要があります"}
+		}
+		if limit <= 0 {
+			return nil, &validationError{message: "limitは正の整数である必要があります"}
+		}
+		if limit > maxAnalyzeStockBrandPriceHistoryLimit {
+			return nil, &validationError{message: "limitは1000以下である必要があります"}
+		}
+		params.limit = limit
+	}
+
+	return params, nil
+}
+
+func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistories(w http.ResponseWriter, r *http.Request) {
+	params, err := h.validateGetAnalyzeStockBrandPriceHistoriesParams(r)
+	if err != nil {
+		if verr, ok := err.(*validationError); ok {
+			http.Error(w, verr.message, http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+
+	result, err := h.usecase.GetAnalyzeStockBrandPriceHistories(r.Context(), &models.AnalyzeStockBrandPriceHistoryFilter{
+		TickerSymbol: params.symbol,
+		Action:       params.action,
+		Method:       params.method,
+		Cursor:       params.cursor,
+		Limit:        params.limit,
+	})
+	if err != nil {
+		h.logger.Error("failed to get analyze stock brand price histories", zap.Error(err))
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, h.logger, &GetAnalyzeStockBrandPriceHistoriesResponse{
+		Histories: result.Histories,
+		Pagination: &PaginationInfo{
+			NextCursor: result.NextCursor,
+			Limit:      result.Limit,
+		},
+	})
+}

--- a/entrypoint/api/router/router.go
+++ b/entrypoint/api/router/router.go
@@ -6,13 +6,16 @@ import (
 	"github.com/Code0716/stock-price-repository/entrypoint/api/handler"
 )
 
-func NewRouter(stockPriceHandler *handler.StockPriceHandler, stockBrandHandler *handler.StockBrandHandler) *http.ServeMux {
+func NewRouter(stockPriceHandler *handler.StockPriceHandler, stockBrandHandler *handler.StockBrandHandler, analyzeStockBrandPriceHistoryHandler *handler.AnalyzeStockBrandPriceHistoryHandler) *http.ServeMux {
 	mux := http.NewServeMux()
 	if stockPriceHandler != nil {
 		mux.HandleFunc("/daily-prices", stockPriceHandler.GetDailyPrices)
 	}
 	if stockBrandHandler != nil {
 		mux.HandleFunc("/stock-brands", stockBrandHandler.GetStockBrands)
+	}
+	if analyzeStockBrandPriceHistoryHandler != nil {
+		mux.HandleFunc("/analyze-stock-brand-price-histories", analyzeStockBrandPriceHistoryHandler.GetAnalyzeStockBrandPriceHistories)
 	}
 	return mux
 }

--- a/entrypoint/api/router/router_test.go
+++ b/entrypoint/api/router/router_test.go
@@ -27,7 +27,7 @@ func TestNewRouter(t *testing.T) {
 
 	stockPriceHandler := handler.NewStockPriceHandler(mockDailyPriceUsecase, mockHTTPServer, zap.NewNop())
 	stockBrandHandler := handler.NewStockBrandHandler(mockStockBrandUsecase, mockHTTPServer, zap.NewNop())
-	mux := NewRouter(stockPriceHandler, stockBrandHandler)
+	mux := NewRouter(stockPriceHandler, stockBrandHandler, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/daily-prices", nil)
 	w := httptest.NewRecorder()
@@ -46,7 +46,7 @@ func TestNewRouter_WithNilStockBrandHandler(t *testing.T) {
 	mockHTTPServer := mock_driver.NewMockHTTPServer(ctrl)
 
 	stockPriceHandler := handler.NewStockPriceHandler(mockDailyPriceUsecase, mockHTTPServer, zap.NewNop())
-	mux := NewRouter(stockPriceHandler, nil)
+	mux := NewRouter(stockPriceHandler, nil, nil)
 
 	// /stock-brands エンドポイントにアクセスしても、404が返るはず（パニックしない）
 	req := httptest.NewRequest(http.MethodGet, "/stock-brands", nil)
@@ -65,7 +65,7 @@ func TestNewRouter_WithNilStockPriceHandler(t *testing.T) {
 	mockHTTPServer := mock_driver.NewMockHTTPServer(ctrl)
 
 	stockBrandHandler := handler.NewStockBrandHandler(mockStockBrandUsecase, mockHTTPServer, zap.NewNop())
-	mux := NewRouter(nil, stockBrandHandler)
+	mux := NewRouter(nil, stockBrandHandler, nil)
 
 	// /daily-prices エンドポイントにアクセスしても、404が返るはず（パニックしない）
 	req := httptest.NewRequest(http.MethodGet, "/daily-prices", nil)
@@ -77,7 +77,7 @@ func TestNewRouter_WithNilStockPriceHandler(t *testing.T) {
 }
 
 func TestNewRouter_WithBothNil(t *testing.T) {
-	mux := NewRouter(nil, nil)
+	mux := NewRouter(nil, nil, nil)
 
 	// どちらのエンドポイントにアクセスしても、404が返るはず（パニックしない）
 	tests := []struct {

--- a/infrastructure/database/analyze_stock_brand_price_history.go
+++ b/infrastructure/database/analyze_stock_brand_price_history.go
@@ -3,8 +3,10 @@ package database
 
 import (
 	"context"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/shopspring/decimal"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -16,12 +18,101 @@ import (
 
 type AnalyzeStockBrandPriceHistoryRepositoryImpl struct {
 	query *genQuery.Query
+	db    *gorm.DB
 }
 
 func NewAnalyzeStockBrandPriceHistoryRepositoryImpl(db *gorm.DB) repositories.AnalyzeStockBrandPriceHistoryRepository {
 	return &AnalyzeStockBrandPriceHistoryRepositoryImpl{
 		query: genQuery.Use(db),
+		db:    db,
 	}
+}
+
+type analyzeStockBrandPriceHistoryRow struct {
+	ID           string
+	StockBrandID string
+	Name         string
+	TickerSymbol string
+	TradePrice   float64
+	CurrentPrice float64
+	Action       string
+	Method       string
+	Memo         *string
+	CreatedAt    time.Time
+}
+
+// FindWithFilter 条件に一致する分析履歴を取得する
+func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error) {
+	db := ai.db.WithContext(ctx).
+		Table("analyze_stock_brand_price_history AS h").
+		Select(`
+			h.id,
+			h.stock_brand_id,
+			COALESCE(s.name, '') AS name,
+			h.ticker_symbol,
+			h.trade_price,
+			h.current_price,
+			h.action,
+			h.method,
+			h.memo,
+			h.created_at
+		`).
+		Joins("LEFT JOIN stock_brand AS s ON s.id = h.stock_brand_id AND s.deleted_at IS NULL")
+
+	if filter.TickerSymbol != "" {
+		db = db.Where("h.ticker_symbol = ?", filter.TickerSymbol)
+	}
+	if filter.Action != "" {
+		db = db.Where("h.action = ?", filter.Action)
+	}
+	if filter.Method != "" {
+		db = db.Where("h.method = ?", filter.Method)
+	}
+	if filter.Cursor != "" {
+		var cursorRow struct {
+			CreatedAt time.Time
+			ID        string
+		}
+		if err := ai.db.WithContext(ctx).
+			Table("analyze_stock_brand_price_history").
+			Select("created_at, id").
+			Where("id = ?", filter.Cursor).
+			Take(&cursorRow).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, nil
+			}
+			return nil, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.FindWithFilter cursor error")
+		}
+		db = db.Where("(h.created_at < ? OR (h.created_at = ? AND h.id < ?))", cursorRow.CreatedAt, cursorRow.CreatedAt, cursorRow.ID)
+	}
+
+	db = db.Order("h.created_at DESC").Order("h.id DESC")
+	if filter.Limit > 0 {
+		db = db.Limit(filter.Limit)
+	}
+
+	var rows []*analyzeStockBrandPriceHistoryRow
+	if err := db.Find(&rows).Error; err != nil {
+		return nil, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.FindWithFilter error")
+	}
+
+	histories := make([]*models.AnalyzeStockBrandPriceHistory, 0, len(rows))
+	for _, row := range rows {
+		histories = append(histories, models.NewAnalyzeStockBrandPriceHistory(
+			row.ID,
+			row.StockBrandID,
+			row.Name,
+			row.TickerSymbol,
+			decimal.NewFromFloat(row.TradePrice),
+			decimal.NewFromFloat(row.CurrentPrice),
+			row.Action,
+			row.Method,
+			row.Memo,
+			row.CreatedAt,
+		))
+	}
+
+	return histories, nil
 }
 
 // DeleteByStockBrandIDs 銘柄IDと一致したものを削除する

--- a/mock/repositories/analyze_stock_brand_price_history.go
+++ b/mock/repositories/analyze_stock_brand_price_history.go
@@ -41,6 +41,21 @@ func (m *MockAnalyzeStockBrandPriceHistoryRepository) EXPECT() *MockAnalyzeStock
 	return m.recorder
 }
 
+// FindWithFilter mocks base method.
+func (m *MockAnalyzeStockBrandPriceHistoryRepository) FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindWithFilter", ctx, filter)
+	ret0, _ := ret[0].([]*models.AnalyzeStockBrandPriceHistory)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindWithFilter indicates an expected call of FindWithFilter.
+func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) FindWithFilter(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindWithFilter", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).FindWithFilter), ctx, filter)
+}
+
 // CreateOrUpdate mocks base method.
 func (m *MockAnalyzeStockBrandPriceHistoryRepository) CreateOrUpdate(ctx context.Context, histories []*models.AnalyzeStockBrandPriceHistory) error {
 	m.ctrl.T.Helper()

--- a/mock/usecase/stock_brands_interactor.go
+++ b/mock/usecase/stock_brands_interactor.go
@@ -42,6 +42,21 @@ func (m *MockStockBrandInteractor) EXPECT() *MockStockBrandInteractorMockRecorde
 	return m.recorder
 }
 
+// GetAnalyzeStockBrandPriceHistories mocks base method.
+func (m *MockStockBrandInteractor) GetAnalyzeStockBrandPriceHistories(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (*models.PaginatedAnalyzeStockBrandPriceHistories, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAnalyzeStockBrandPriceHistories", ctx, filter)
+	ret0, _ := ret[0].(*models.PaginatedAnalyzeStockBrandPriceHistories)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAnalyzeStockBrandPriceHistories indicates an expected call of GetAnalyzeStockBrandPriceHistories.
+func (mr *MockStockBrandInteractorMockRecorder) GetAnalyzeStockBrandPriceHistories(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnalyzeStockBrandPriceHistories", reflect.TypeOf((*MockStockBrandInteractor)(nil).GetAnalyzeStockBrandPriceHistories), ctx, filter)
+}
+
 // GetStockBrands mocks base method.
 func (m *MockStockBrandInteractor) GetStockBrands(ctx context.Context, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error) {
 	m.ctrl.T.Helper()

--- a/models/analyze_stock_brand_price_history.go
+++ b/models/analyze_stock_brand_price_history.go
@@ -28,6 +28,20 @@ type AnalyzeStockBrandPriceHistory struct {
 	CreatedAt    time.Time       `json:"createdAt"`
 }
 
+type AnalyzeStockBrandPriceHistoryFilter struct {
+	TickerSymbol string
+	Action       string
+	Method       string
+	Cursor       string
+	Limit        int
+}
+
+type PaginatedAnalyzeStockBrandPriceHistories struct {
+	Histories  []*AnalyzeStockBrandPriceHistory
+	NextCursor *string
+	Limit      int
+}
+
 func NewAnalyzeStockBrandPriceHistory(
 	id string, // uuid
 	stockBrandID string, // 銘柄IDs

--- a/repositories/analyze_stock_brand_price_history.go
+++ b/repositories/analyze_stock_brand_price_history.go
@@ -8,6 +8,8 @@ import (
 )
 
 type AnalyzeStockBrandPriceHistoryRepository interface {
+	// FindWithFilter 条件に一致する分析履歴を取得する
+	FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error)
 	// DeleteByStockBrandIDs 銘柄IDで一致したものを削除する
 	DeleteByStockBrandIDs(ctx context.Context, ids []string) error
 	// CreateOrUpdate 銘柄の価格を更新する

--- a/test/e2e/api_get_daily_prices_test.go
+++ b/test/e2e/api_get_daily_prices_test.go
@@ -68,7 +68,7 @@ func TestE2E_GetDailyPrices(t *testing.T) {
 	httpServer := driver.NewHTTPServer()
 	stockPriceHandler := handler.NewStockPriceHandler(interactor, httpServer, zap.NewNop())
 	// StockBrandHandlerはこのテストでは使用しないためnilを渡す
-	mux := router.NewRouter(stockPriceHandler, nil)
+	mux := router.NewRouter(stockPriceHandler, nil, nil)
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 

--- a/test/e2e/api_get_stock_brands_test.go
+++ b/test/e2e/api_get_stock_brands_test.go
@@ -78,7 +78,7 @@ func TestE2E_GetStockBrands(t *testing.T) {
 	httpServer := driver.NewHTTPServer()
 	stockBrandHandler := handler.NewStockBrandHandler(stockBrandInteractor, httpServer, zap.NewNop())
 	stockPriceHandler := handler.NewStockPriceHandler(dailyPriceInteractor, httpServer, zap.NewNop())
-	mux := router.NewRouter(stockPriceHandler, stockBrandHandler)
+	mux := router.NewRouter(stockPriceHandler, stockBrandHandler, nil)
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 

--- a/usecase/get_analyze_stock_brand_price_histories.go
+++ b/usecase/get_analyze_stock_brand_price_histories.go
@@ -1,0 +1,42 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/pkg/errors"
+)
+
+// GetAnalyzeStockBrandPriceHistories 分析履歴一覧を取得する
+func (si *stockBrandInteractorImpl) GetAnalyzeStockBrandPriceHistories(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (*models.PaginatedAnalyzeStockBrandPriceHistories, error) {
+	if filter == nil {
+		filter = &models.AnalyzeStockBrandPriceHistoryFilter{}
+	}
+
+	limit := filter.Limit
+	fetchLimit := limit
+	if limit > 0 {
+		fetchLimit = limit + 1
+	}
+
+	repoFilter := *filter
+	repoFilter.Limit = fetchLimit
+
+	histories, err := si.analyzeStockBrandPriceHistoryRepository.FindWithFilter(ctx, &repoFilter)
+	if err != nil {
+		return nil, errors.Wrap(err, "分析履歴一覧の取得に失敗しました")
+	}
+
+	result := &models.PaginatedAnalyzeStockBrandPriceHistories{
+		Histories: histories,
+		Limit:     limit,
+	}
+
+	if limit > 0 && len(histories) > limit {
+		nextHistory := histories[limit]
+		result.NextCursor = &nextHistory.ID
+		result.Histories = histories[:limit]
+	}
+
+	return result, nil
+}

--- a/usecase/stock_brands_interactor.go
+++ b/usecase/stock_brands_interactor.go
@@ -25,6 +25,7 @@ type stockBrandInteractorImpl struct {
 type StockBrandInteractor interface {
 	UpdateStockBrands(ctx context.Context, t time.Time) error
 	GetStockBrands(ctx context.Context, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error)
+	GetAnalyzeStockBrandPriceHistories(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (*models.PaginatedAnalyzeStockBrandPriceHistories, error)
 }
 
 func NewStockBrandInteractor(


### PR DESCRIPTION
## Summary
- add GET /analyze-stock-brand-price-histories
- support symbol/action/method/cursor/limit filters
- join stock_brand to include display name

## Tests
- go test -mod=readonly ./entrypoint/api/...
- go test -mod=readonly ./entrypoint/api/... ./usecase/... ./infrastructure/database -run '^$'
- curl 'http://127.0.0.1:8080/analyze-stock-brand-price-histories?limit=3'