### PR TITLE
feat: 複数シグナル集計API追加 + ユニークキーにcreated_at追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
 
       - name: Install dependencies
         run: go mod download
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
@@ -83,7 +83,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.2'
+          go-version: '1.26.3'
 
       - name: Install dependencies
         run: go mod download

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@ make migrate-file name=<名前>  # 新規マイグレーションファイル作
 make migrate-up                # 未適用マイグレーションを全適用
 make migrate-down              # 直近1件をロールバック
 
+# DB 直接確認（コンテナ名: stock-price-repository-db）
+docker exec stock-price-repository-db mysql -u root -proot -e "SHOW INDEX FROM stock_price_repository.<テーブル名>;"
+docker exec stock-price-repository-db mysql -u root -proot -e "SELECT * FROM stock_price_repository.<テーブル名> LIMIT 10;"
+docker exec stock-price-repository-db mysql -u root -proot stock_price_repository -e "<SQL>"
+
 # テスト・品質管理
 make test                   # unit + e2e + 脆弱性スキャン（CI相当）
 make test-unit              # ユニットテストのみ (ENVCODE=unit)

--- a/di/wire.go
+++ b/di/wire.go
@@ -80,6 +80,7 @@ var apiSet = wire.NewSet(
 	handler.NewStockPriceHandler,
 	handler.NewStockBrandHandler,
 	handler.NewAnalyzeStockBrandPriceHistoryHandler,
+	handler.NewMultipleSignalStocksHandler,
 	router.NewRouter,
 )
 

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -98,7 +98,8 @@ func InitializeApiServer(ctx context.Context) (*http.ServeMux, func(), error) {
 	stockBrandInteractor := usecase.NewStockBrandInteractor(transaction, stockBrandRepository, stockBrandsDailyPriceRepository, analyzeStockBrandPriceHistoryRepository, stockBrandsDailyPriceForAnalyzeRepository, stockAPIClient, client)
 	stockBrandHandler := handler.NewStockBrandHandler(stockBrandInteractor, httpServer, logger)
 	analyzeStockBrandPriceHistoryHandler := handler.NewAnalyzeStockBrandPriceHistoryHandler(stockBrandInteractor, httpServer, logger)
-	serveMux := router.NewRouter(stockPriceHandler, stockBrandHandler, analyzeStockBrandPriceHistoryHandler)
+	multipleSignalStocksHandler := handler.NewMultipleSignalStocksHandler(stockBrandInteractor, httpServer, logger)
+	serveMux := router.NewRouter(stockPriceHandler, stockBrandHandler, analyzeStockBrandPriceHistoryHandler, multipleSignalStocksHandler)
 	return serveMux, func() {
 		cleanup()
 	}, nil
@@ -141,7 +142,7 @@ var cliSet = wire.NewSet(cli.NewRunner, commands.NewHealthCheckCommand, commands
 
 var databaseSet = wire.NewSet(database.NewTransaction, database.NewStockBrandRepositoryImpl, database.NewNikkeiRepositoryImpl, database.NewDjiRepositoryImpl, database.NewStockBrandsDailyPriceRepositoryImpl, database.NewAnalyzeStockBrandPriceHistoryRepositoryImpl, database.NewStockBrandsDailyPriceForAnalyzeRepositoryImpl, database.NewHighVolumeStockBrandRepositoryImpl, database.NewAppliedStockSplitsHistoryRepositoryImpl, database.NewAppliedStockConsolidationsHistoryRepositoryImpl)
 
-var apiSet = wire.NewSet(handler.NewStockPriceHandler, handler.NewStockBrandHandler, handler.NewAnalyzeStockBrandPriceHistoryHandler, router.NewRouter)
+var apiSet = wire.NewSet(handler.NewStockPriceHandler, handler.NewStockBrandHandler, handler.NewAnalyzeStockBrandPriceHistoryHandler, handler.NewMultipleSignalStocksHandler, router.NewRouter)
 
 var grpcSet = wire.NewSet(server.NewStockServiceServer, usecase.NewGetHighVolumeStockBrandsUseCase, wire.Struct(new(GrpcServerComponents), "*"))
 

--- a/entrypoint/api/handler/multiple_signal_stocks_handler.go
+++ b/entrypoint/api/handler/multiple_signal_stocks_handler.go
@@ -1,0 +1,110 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/Code0716/stock-price-repository/driver"
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/Code0716/stock-price-repository/usecase"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultMultipleSignalStocksLimit = 100
+	maxMultipleSignalStocksLimit     = 500
+)
+
+type GetMultipleSignalStocksResponse struct {
+	Stocks     []*models.MultipleSignalStock `json:"stocks"`
+	Pagination *PaginationInfo               `json:"pagination,omitempty"`
+}
+
+type MultipleSignalStocksHandler struct {
+	usecase    usecase.StockBrandInteractor
+	httpServer driver.HTTPServer
+	logger     *zap.Logger
+}
+
+func NewMultipleSignalStocksHandler(u usecase.StockBrandInteractor, h driver.HTTPServer, l *zap.Logger) *MultipleSignalStocksHandler {
+	return &MultipleSignalStocksHandler{
+		usecase:    u,
+		httpServer: h,
+		logger:     l,
+	}
+}
+
+type getMultipleSignalStocksParams struct {
+	date   *time.Time
+	cursor string
+	limit  int
+}
+
+func (h *MultipleSignalStocksHandler) validateGetMultipleSignalStocksParams(r *http.Request) (*getMultipleSignalStocksParams, error) {
+	params := &getMultipleSignalStocksParams{
+		limit: defaultMultipleSignalStocksLimit,
+	}
+
+	dateStr := h.httpServer.GetQueryParam(r, "date")
+	if dateStr != "" {
+		t, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			return nil, &validationError{message: "dateはYYYY-MM-DD形式で指定してください"}
+		}
+		params.date = &t
+	}
+
+	params.cursor = h.httpServer.GetQueryParam(r, "cursor")
+	if len(params.cursor) > 20 {
+		return nil, &validationError{message: "cursorが長すぎます"}
+	}
+
+	limitStr := h.httpServer.GetQueryParam(r, "limit")
+	if limitStr != "" {
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			return nil, &validationError{message: "limitは数値である必要があります"}
+		}
+		if limit <= 0 {
+			return nil, &validationError{message: "limitは正の整数である必要があります"}
+		}
+		if limit > maxMultipleSignalStocksLimit {
+			return nil, &validationError{message: "limitは500以下である必要があります"}
+		}
+		params.limit = limit
+	}
+
+	return params, nil
+}
+
+func (h *MultipleSignalStocksHandler) GetMultipleSignalStocks(w http.ResponseWriter, r *http.Request) {
+	params, err := h.validateGetMultipleSignalStocksParams(r)
+	if err != nil {
+		if verr, ok := err.(*validationError); ok {
+			http.Error(w, verr.message, http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+
+	result, err := h.usecase.GetMultipleSignalStocks(r.Context(), &models.MultipleSignalStockFilter{
+		Date:   params.date,
+		Cursor: params.cursor,
+		Limit:  params.limit,
+	})
+	if err != nil {
+		h.logger.Error("failed to get multiple signal stocks", zap.Error(err))
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, h.logger, &GetMultipleSignalStocksResponse{
+		Stocks: result.Stocks,
+		Pagination: &PaginationInfo{
+			NextCursor: result.NextCursor,
+			Limit:      result.Limit,
+		},
+	})
+}

--- a/entrypoint/api/router/router.go
+++ b/entrypoint/api/router/router.go
@@ -6,7 +6,7 @@ import (
 	"github.com/Code0716/stock-price-repository/entrypoint/api/handler"
 )
 
-func NewRouter(stockPriceHandler *handler.StockPriceHandler, stockBrandHandler *handler.StockBrandHandler, analyzeStockBrandPriceHistoryHandler *handler.AnalyzeStockBrandPriceHistoryHandler) *http.ServeMux {
+func NewRouter(stockPriceHandler *handler.StockPriceHandler, stockBrandHandler *handler.StockBrandHandler, analyzeStockBrandPriceHistoryHandler *handler.AnalyzeStockBrandPriceHistoryHandler, multipleSignalStocksHandler *handler.MultipleSignalStocksHandler) *http.ServeMux {
 	mux := http.NewServeMux()
 	if stockPriceHandler != nil {
 		mux.HandleFunc("/daily-prices", stockPriceHandler.GetDailyPrices)
@@ -16,6 +16,9 @@ func NewRouter(stockPriceHandler *handler.StockPriceHandler, stockBrandHandler *
 	}
 	if analyzeStockBrandPriceHistoryHandler != nil {
 		mux.HandleFunc("/analyze-stock-brand-price-histories", analyzeStockBrandPriceHistoryHandler.GetAnalyzeStockBrandPriceHistories)
+	}
+	if multipleSignalStocksHandler != nil {
+		mux.HandleFunc("/multiple-signal-stocks", multipleSignalStocksHandler.GetMultipleSignalStocks)
 	}
 	return mux
 }

--- a/entrypoint/api/router/router_test.go
+++ b/entrypoint/api/router/router_test.go
@@ -27,7 +27,7 @@ func TestNewRouter(t *testing.T) {
 
 	stockPriceHandler := handler.NewStockPriceHandler(mockDailyPriceUsecase, mockHTTPServer, zap.NewNop())
 	stockBrandHandler := handler.NewStockBrandHandler(mockStockBrandUsecase, mockHTTPServer, zap.NewNop())
-	mux := NewRouter(stockPriceHandler, stockBrandHandler, nil)
+	mux := NewRouter(stockPriceHandler, stockBrandHandler, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/daily-prices", nil)
 	w := httptest.NewRecorder()
@@ -46,7 +46,7 @@ func TestNewRouter_WithNilStockBrandHandler(t *testing.T) {
 	mockHTTPServer := mock_driver.NewMockHTTPServer(ctrl)
 
 	stockPriceHandler := handler.NewStockPriceHandler(mockDailyPriceUsecase, mockHTTPServer, zap.NewNop())
-	mux := NewRouter(stockPriceHandler, nil, nil)
+	mux := NewRouter(stockPriceHandler, nil, nil, nil)
 
 	// /stock-brands エンドポイントにアクセスしても、404が返るはず（パニックしない）
 	req := httptest.NewRequest(http.MethodGet, "/stock-brands", nil)
@@ -65,7 +65,7 @@ func TestNewRouter_WithNilStockPriceHandler(t *testing.T) {
 	mockHTTPServer := mock_driver.NewMockHTTPServer(ctrl)
 
 	stockBrandHandler := handler.NewStockBrandHandler(mockStockBrandUsecase, mockHTTPServer, zap.NewNop())
-	mux := NewRouter(nil, stockBrandHandler, nil)
+	mux := NewRouter(nil, stockBrandHandler, nil, nil)
 
 	// /daily-prices エンドポイントにアクセスしても、404が返るはず（パニックしない）
 	req := httptest.NewRequest(http.MethodGet, "/daily-prices", nil)
@@ -77,7 +77,7 @@ func TestNewRouter_WithNilStockPriceHandler(t *testing.T) {
 }
 
 func TestNewRouter_WithBothNil(t *testing.T) {
-	mux := NewRouter(nil, nil, nil)
+	mux := NewRouter(nil, nil, nil, nil)
 
 	// どちらのエンドポイントにアクセスしても、404が返るはず（パニックしない）
 	tests := []struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Code0716/stock-price-repository
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/alicebob/miniredis/v2 v2.37.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.7.0 h1:JxUKI6+CVBgCO2WToKy/nQk0sS+amI9z9EjVmdaocj4=

--- a/infrastructure/database/analyze_stock_brand_price_history.go
+++ b/infrastructure/database/analyze_stock_brand_price_history.go
@@ -3,6 +3,8 @@ package database
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -117,6 +119,88 @@ func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindWithFilter(ctx contex
 	}
 
 	return histories, nil
+}
+
+// FindMultipleSignals 同一日に2つ以上のシグナルが出た銘柄を集計して返す
+func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindMultipleSignals(ctx context.Context, filter *models.MultipleSignalStockFilter) ([]*models.MultipleSignalStock, error) {
+	type multipleSignalRow struct {
+		StockBrandID string
+		Name         string
+		TickerSymbol string
+		Date         time.Time
+		Methods      string
+		SignalCount  int
+		CurrentPrice float64
+	}
+
+	var dateCondition string
+	args := make([]interface{}, 0, 3)
+
+	if filter.Date != nil {
+		dateCondition = "DATE(h.created_at) = DATE(?)"
+		args = append(args, *filter.Date)
+	} else {
+		dateCondition = "DATE(h.created_at) = (SELECT DATE(MAX(created_at)) FROM analyze_stock_brand_price_history)"
+	}
+
+	whereClause := dateCondition
+	if filter.Cursor != "" {
+		whereClause += " AND h.ticker_symbol > ?"
+		args = append(args, filter.Cursor)
+	}
+
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	args = append(args, limit)
+
+	query := fmt.Sprintf(`
+		SELECT
+			h.stock_brand_id,
+			COALESCE(s.name, '') AS name,
+			h.ticker_symbol,
+			DATE(h.created_at) AS date,
+			GROUP_CONCAT(DISTINCT h.method ORDER BY h.method ASC SEPARATOR ',') AS methods,
+			COUNT(DISTINCT h.method) AS signal_count,
+			COALESCE(d.close_price, 0) AS current_price
+		FROM analyze_stock_brand_price_history h
+		LEFT JOIN stock_brand AS s ON s.id = h.stock_brand_id AND s.deleted_at IS NULL
+		LEFT JOIN stock_brands_daily_price AS d ON d.id = (
+			SELECT id FROM stock_brands_daily_price
+			WHERE ticker_symbol = h.ticker_symbol AND deleted_at IS NULL
+			ORDER BY date DESC LIMIT 1
+		)
+		WHERE %s
+		GROUP BY h.stock_brand_id, h.ticker_symbol, DATE(h.created_at)
+		HAVING COUNT(DISTINCT h.method) >= 2
+		ORDER BY h.ticker_symbol ASC
+		LIMIT ?
+	`, whereClause)
+
+	var rows []*multipleSignalRow
+	if err := ai.db.WithContext(ctx).Raw(query, args...).Scan(&rows).Error; err != nil {
+		return nil, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.FindMultipleSignals error")
+	}
+
+	stocks := make([]*models.MultipleSignalStock, 0, len(rows))
+	for _, r := range rows {
+		var methods []string
+		if r.Methods != "" {
+			methods = strings.Split(r.Methods, ",")
+		}
+		stocks = append(stocks, &models.MultipleSignalStock{
+			StockBrandID: r.StockBrandID,
+			Name:         r.Name,
+			TickerSymbol: r.TickerSymbol,
+			Date:         r.Date,
+			Methods:      methods,
+			SignalCount:  r.SignalCount,
+			CurrentPrice: decimal.NewFromFloat(r.CurrentPrice),
+		})
+	}
+
+	return stocks, nil
 }
 
 // DeleteByStockBrandIDs 銘柄IDと一致したものを削除する

--- a/mock/repositories/analyze_stock_brand_price_history.go
+++ b/mock/repositories/analyze_stock_brand_price_history.go
@@ -55,6 +55,21 @@ func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) DeleteByStock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByStockBrandIDs", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).DeleteByStockBrandIDs), ctx, ids)
 }
 
+// FindMultipleSignals mocks base method.
+func (m *MockAnalyzeStockBrandPriceHistoryRepository) FindMultipleSignals(ctx context.Context, filter *models.MultipleSignalStockFilter) ([]*models.MultipleSignalStock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindMultipleSignals", ctx, filter)
+	ret0, _ := ret[0].([]*models.MultipleSignalStock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindMultipleSignals indicates an expected call of FindMultipleSignals.
+func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) FindMultipleSignals(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindMultipleSignals", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).FindMultipleSignals), ctx, filter)
+}
+
 // FindWithFilter mocks base method.
 func (m *MockAnalyzeStockBrandPriceHistoryRepository) FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error) {
 	m.ctrl.T.Helper()

--- a/mock/usecase/stock_brands_interactor.go
+++ b/mock/usecase/stock_brands_interactor.go
@@ -57,6 +57,21 @@ func (mr *MockStockBrandInteractorMockRecorder) GetAnalyzeStockBrandPriceHistori
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAnalyzeStockBrandPriceHistories", reflect.TypeOf((*MockStockBrandInteractor)(nil).GetAnalyzeStockBrandPriceHistories), ctx, filter)
 }
 
+// GetMultipleSignalStocks mocks base method.
+func (m *MockStockBrandInteractor) GetMultipleSignalStocks(ctx context.Context, filter *models.MultipleSignalStockFilter) (*models.PaginatedMultipleSignalStocks, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMultipleSignalStocks", ctx, filter)
+	ret0, _ := ret[0].(*models.PaginatedMultipleSignalStocks)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMultipleSignalStocks indicates an expected call of GetMultipleSignalStocks.
+func (mr *MockStockBrandInteractorMockRecorder) GetMultipleSignalStocks(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMultipleSignalStocks", reflect.TypeOf((*MockStockBrandInteractor)(nil).GetMultipleSignalStocks), ctx, filter)
+}
+
 // GetStockBrands mocks base method.
 func (m *MockStockBrandInteractor) GetStockBrands(ctx context.Context, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error) {
 	m.ctrl.T.Helper()

--- a/models/analyze_stock_brand_price_history.go
+++ b/models/analyze_stock_brand_price_history.go
@@ -7,12 +7,16 @@ import (
 )
 
 const (
-	AnalyzeStockBrandPriceHistoryMethodSector25 string = "analyze_stock_brand_price_by_sector: 25日"
-	AnalyzeStockBrandPriceHistoryMethodSector75 string = "analyze_stock_brand_price_by_sector: 75日"
-	AnalyzeStockBrandPriceHistoryMethodNikkei25 string = "analyze_stock_brand_price_by_nikkei: 25日"
-	AnalyzeStockBrandPriceHistoryMethodNikkei75 string = "analyze_stock_brand_price_by_nikkei: 75日"
-	AnalyzeStockBrandPriceHistoryActionBuy      string = "Buy"
-	AnalyzeStockBrandPriceHistoryActionSell     string = "Sell"
+	AnalyzeStockBrandPriceHistoryMethodSector25          string = "analyze_stock_brand_price_by_sector: 25日"
+	AnalyzeStockBrandPriceHistoryMethodSector75          string = "analyze_stock_brand_price_by_sector: 75日"
+	AnalyzeStockBrandPriceHistoryMethodNikkei25          string = "analyze_stock_brand_price_by_nikkei: 25日"
+	AnalyzeStockBrandPriceHistoryMethodNikkei75          string = "analyze_stock_brand_price_by_nikkei: 75日"
+	AnalyzeStockBrandPriceHistoryMethodFindMACDBullishV1       string = "find_macd_bullish_stock_v1"
+	AnalyzeStockBrandPriceHistoryMethodFindTriangleV1          string = "find_triangle_formation_stock_v1"
+	AnalyzeStockBrandPriceHistoryMethodFindBollingerBreakoutV1 string = "find_bollinger_breakout_stock_v1"
+	AnalyzeStockBrandPriceHistoryMethodFindMLRankedV1          string = "find_ml_ranked_stocks_v1"
+	AnalyzeStockBrandPriceHistoryActionBuy                     string = "Buy"
+	AnalyzeStockBrandPriceHistoryActionSell                    string = "Sell"
 )
 
 type AnalyzeStockBrandPriceHistory struct {

--- a/models/multiple_signal_stock.go
+++ b/models/multiple_signal_stock.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type MultipleSignalStock struct {
+	StockBrandID string          `json:"stockBrandId"`
+	Name         string          `json:"name"`
+	TickerSymbol string          `json:"tickerSymbol"`
+	Date         time.Time       `json:"date"`
+	Methods      []string        `json:"methods"`
+	SignalCount   int             `json:"signalCount"`
+	CurrentPrice decimal.Decimal `json:"currentPrice"`
+}
+
+type MultipleSignalStockFilter struct {
+	Date   *time.Time
+	Cursor string
+	Limit  int
+}
+
+type PaginatedMultipleSignalStocks struct {
+	Stocks     []*MultipleSignalStock
+	NextCursor *string
+	Limit      int
+}

--- a/repositories/analyze_stock_brand_price_history.go
+++ b/repositories/analyze_stock_brand_price_history.go
@@ -10,6 +10,8 @@ import (
 type AnalyzeStockBrandPriceHistoryRepository interface {
 	// FindWithFilter 条件に一致する分析履歴を取得する
 	FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error)
+	// FindMultipleSignals 同一日に2つ以上のシグナルが出た銘柄を集計して取得する
+	FindMultipleSignals(ctx context.Context, filter *models.MultipleSignalStockFilter) ([]*models.MultipleSignalStock, error)
 	// DeleteByStockBrandIDs 銘柄IDで一致したものを削除する
 	DeleteByStockBrandIDs(ctx context.Context, ids []string) error
 }

--- a/sql/migrations/000006_alter_analyze_stock_brand_price_history_unique_with_date.down.sql
+++ b/sql/migrations/000006_alter_analyze_stock_brand_price_history_unique_with_date.down.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `analyze_stock_brand_price_history`
+  DROP INDEX `uq_analyze_stock_brand_price_history_stock_ticker_method_date`;
+
+ALTER TABLE `analyze_stock_brand_price_history`
+  ADD CONSTRAINT `uq_analyze_stock_brand_price_history_stock_ticker_method`
+    UNIQUE (`stock_brand_id`, `ticker_symbol`, `method`);
+
+ALTER TABLE `analyze_stock_brand_price_history`
+  DROP INDEX `idx_analyze_stock_brand_price_history_stock_brand_id`;

--- a/sql/migrations/000006_alter_analyze_stock_brand_price_history_unique_with_date.up.sql
+++ b/sql/migrations/000006_alter_analyze_stock_brand_price_history_unique_with_date.up.sql
@@ -1,0 +1,10 @@
+-- FKが既存ユニークキーのインデックスに依存しているため、先に補助インデックスを追加する
+ALTER TABLE `analyze_stock_brand_price_history`
+  ADD INDEX `idx_analyze_stock_brand_price_history_stock_brand_id` (`stock_brand_id`);
+
+ALTER TABLE `analyze_stock_brand_price_history`
+  DROP INDEX `uq_analyze_stock_brand_price_history_stock_ticker_method`;
+
+ALTER TABLE `analyze_stock_brand_price_history`
+  ADD CONSTRAINT `uq_analyze_stock_brand_price_history_stock_ticker_method_date`
+    UNIQUE (`stock_brand_id`, `ticker_symbol`, `method`, `created_at`);

--- a/test/e2e/api_get_daily_prices_test.go
+++ b/test/e2e/api_get_daily_prices_test.go
@@ -68,7 +68,7 @@ func TestE2E_GetDailyPrices(t *testing.T) {
 	httpServer := driver.NewHTTPServer()
 	stockPriceHandler := handler.NewStockPriceHandler(interactor, httpServer, zap.NewNop())
 	// StockBrandHandlerはこのテストでは使用しないためnilを渡す
-	mux := router.NewRouter(stockPriceHandler, nil, nil)
+	mux := router.NewRouter(stockPriceHandler, nil, nil, nil)
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 

--- a/test/e2e/api_get_stock_brands_test.go
+++ b/test/e2e/api_get_stock_brands_test.go
@@ -78,7 +78,7 @@ func TestE2E_GetStockBrands(t *testing.T) {
 	httpServer := driver.NewHTTPServer()
 	stockBrandHandler := handler.NewStockBrandHandler(stockBrandInteractor, httpServer, zap.NewNop())
 	stockPriceHandler := handler.NewStockPriceHandler(dailyPriceInteractor, httpServer, zap.NewNop())
-	mux := router.NewRouter(stockPriceHandler, stockBrandHandler, nil)
+	mux := router.NewRouter(stockPriceHandler, stockBrandHandler, nil, nil)
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 

--- a/usecase/get_multiple_signal_stocks.go
+++ b/usecase/get_multiple_signal_stocks.go
@@ -1,0 +1,42 @@
+package usecase
+
+import (
+	"context"
+
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/pkg/errors"
+)
+
+// GetMultipleSignalStocks 同一日に2つ以上のシグナルが出た銘柄一覧を取得する
+func (si *stockBrandInteractorImpl) GetMultipleSignalStocks(ctx context.Context, filter *models.MultipleSignalStockFilter) (*models.PaginatedMultipleSignalStocks, error) {
+	if filter == nil {
+		filter = &models.MultipleSignalStockFilter{}
+	}
+
+	limit := filter.Limit
+	fetchLimit := limit
+	if limit > 0 {
+		fetchLimit = limit + 1
+	}
+
+	repoFilter := *filter
+	repoFilter.Limit = fetchLimit
+
+	stocks, err := si.analyzeStockBrandPriceHistoryRepository.FindMultipleSignals(ctx, &repoFilter)
+	if err != nil {
+		return nil, errors.Wrap(err, "複数シグナル銘柄一覧の取得に失敗しました")
+	}
+
+	result := &models.PaginatedMultipleSignalStocks{
+		Stocks: stocks,
+		Limit:  limit,
+	}
+
+	if limit > 0 && len(stocks) > limit {
+		nextStock := stocks[limit]
+		result.NextCursor = &nextStock.TickerSymbol
+		result.Stocks = stocks[:limit]
+	}
+
+	return result, nil
+}

--- a/usecase/stock_brands_interactor.go
+++ b/usecase/stock_brands_interactor.go
@@ -26,6 +26,7 @@ type StockBrandInteractor interface {
 	UpdateStockBrands(ctx context.Context, t time.Time) error
 	GetStockBrands(ctx context.Context, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error)
 	GetAnalyzeStockBrandPriceHistories(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (*models.PaginatedAnalyzeStockBrandPriceHistories, error)
+	GetMultipleSignalStocks(ctx context.Context, filter *models.MultipleSignalStockFilter) (*models.PaginatedMultipleSignalStocks, error)
 }
 
 func NewStockBrandInteractor(


### PR DESCRIPTION
## Summary

- **migration 000006**: `analyze_stock_brand_price_history` のユニークキーに `created_at` を追加
  - `(stock_brand_id, ticker_symbol, method)` → `(stock_brand_id, ticker_symbol, method, created_at)`
  - 同一銘柄・method の日次 upsert が可能になる
  - FK サポート用インデックス `idx_..._stock_brand_id` を先に追加することで既存 FK を維持
- `models/analyze_stock_brand_price_history.go`: method 定数 4 種を追加
- `models/multiple_signal_stock.go`: `MultipleSignalStock` 型を新規追加
- `GET /multiple-signal-stocks` エンドポイントを新設
  - 同一日に 2 つ以上の method でシグナルが出た銘柄を `GROUP_CONCAT` で集計
  - クエリパラメータ: `date` (YYYY-MM-DD) / `cursor` / `limit` (デフォルト 100, 最大 500)
  - カーソルページネーション対応

## Test plan

- [ ] `make migrate-up` で 000006 適用 → `SHOW INDEX FROM analyze_stock_brand_price_history` で新キー確認
- [ ] `make test` 通過を確認
- [ ] `GET /multiple-signal-stocks` でデータが返ること
- [ ] `GET /multiple-signal-stocks?date=YYYY-MM-DD` で日付フィルタが効くこと
- [ ] `GET /analyze-stock-brand-price-histories?method=find_macd_bullish_stock_v1` で method フィルタが効くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)