### PR TITLE
fix: FindMultipleSignals の ONLY_FULL_GROUP_BY エラーを修正

### DIFF
--- a/infrastructure/database/analyze_stock_brand_price_history.go
+++ b/infrastructure/database/analyze_stock_brand_price_history.go
@@ -158,12 +158,12 @@ func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindMultipleSignals(ctx c
 	query := fmt.Sprintf(`
 		SELECT
 			h.stock_brand_id,
-			COALESCE(s.name, '') AS name,
+			ANY_VALUE(COALESCE(s.name, '')) AS name,
 			h.ticker_symbol,
 			DATE(h.created_at) AS date,
 			GROUP_CONCAT(DISTINCT h.method ORDER BY h.method ASC SEPARATOR ',') AS methods,
 			COUNT(DISTINCT h.method) AS signal_count,
-			COALESCE(d.close_price, 0) AS current_price
+			ANY_VALUE(COALESCE(d.close_price, 0)) AS current_price
 		FROM analyze_stock_brand_price_history h
 		LEFT JOIN stock_brand AS s ON s.id = h.stock_brand_id AND s.deleted_at IS NULL
 		LEFT JOIN stock_brands_daily_price AS d ON d.id = (


### PR DESCRIPTION
## Summary

`GET /multiple-signal-stocks` が 500 エラーになる問題を修正。

**原因**: `FindMultipleSignals` のクエリで `d.close_price`（`stock_brands_daily_price` から JOIN）と `s.name`（`stock_brand` から JOIN）が `GROUP BY` 句に含まれていないため、MySQL の `sql_mode=only_full_group_by` に違反していた。

**修正**: JOIN で一意に決まる値であるため `ANY_VALUE()` でラップ。

```sql
-- 修正前
COALESCE(s.name, '') AS name,
COALESCE(d.close_price, 0) AS current_price

-- 修正後
ANY_VALUE(COALESCE(s.name, '')) AS name,
ANY_VALUE(COALESCE(d.close_price, 0)) AS current_price
```

## Test plan

- [ ] CI 通過確認
- [ ] `GET /multiple-signal-stocks` が 200 を返すことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)