### PR TITLE
feat: 分析履歴API — offset ページネーション + ソート対応

### DIFF
--- a/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
+++ b/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -9,6 +10,36 @@ import (
 	"github.com/Code0716/stock-price-repository/usecase"
 	"go.uber.org/zap"
 )
+
+// validateAnalyzeHistoryAction は action パラメータを検証する。
+func validateAnalyzeHistoryAction(action string) error {
+	if action == "" ||
+		action == models.AnalyzeStockBrandPriceHistoryActionBuy ||
+		action == models.AnalyzeStockBrandPriceHistoryActionSell {
+		return nil
+	}
+	return &validationError{message: "actionはBuyまたはSellである必要があります"}
+}
+
+// parseBoundedInt はクエリパラメータを正の整数として読み取る。
+// max に 0 を渡すと上限チェックを省略する。値が空文字列の場合は defaultVal を返す。
+func parseBoundedInt(server driver.HTTPServer, r *http.Request, key string, defaultVal, max int) (int, error) {
+	str := server.GetQueryParam(r, key)
+	if str == "" {
+		return defaultVal, nil
+	}
+	v, err := strconv.Atoi(str)
+	if err != nil {
+		return 0, &validationError{message: fmt.Sprintf("%sは数値である必要があります", key)}
+	}
+	if v <= 0 {
+		return 0, &validationError{message: fmt.Sprintf("%sは正の整数である必要があります", key)}
+	}
+	if max > 0 && v > max {
+		return 0, &validationError{message: fmt.Sprintf("%sは%d以下である必要があります", key, max)}
+	}
+	return v, nil
+}
 
 const (
 	defaultAnalyzeStockBrandPriceHistoryLimit = 100
@@ -80,10 +111,8 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) validateGetAnalyzeStockBrandPrice
 	}
 
 	params.action = h.httpServer.GetQueryParam(r, "action")
-	if params.action != "" &&
-		params.action != models.AnalyzeStockBrandPriceHistoryActionBuy &&
-		params.action != models.AnalyzeStockBrandPriceHistoryActionSell {
-		return nil, &validationError{message: "actionはBuyまたはSellである必要があります"}
+	if err := validateAnalyzeHistoryAction(params.action); err != nil {
+		return nil, err
 	}
 
 	params.method = h.httpServer.GetQueryParam(r, "method")
@@ -113,59 +142,29 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) validateGetAnalyzeStockBrandPrice
 		}
 	}
 
-	pageStr := h.httpServer.GetQueryParam(r, "page")
-	if pageStr != "" {
-		page, err := strconv.Atoi(pageStr)
-		if err != nil {
-			return nil, &validationError{message: "pageは数値である必要があります"}
-		}
-		if page <= 0 {
-			return nil, &validationError{message: "pageは正の整数である必要があります"}
-		}
-		params.page = page
+	page, err := parseBoundedInt(h.httpServer, r, "page", 1, 0)
+	if err != nil {
+		return nil, err
 	}
+	params.page = page
 
-	limitStr := h.httpServer.GetQueryParam(r, "limit")
-	if limitStr != "" {
-		limit, err := strconv.Atoi(limitStr)
-		if err != nil {
-			return nil, &validationError{message: "limitは数値である必要があります"}
-		}
-		if limit <= 0 {
-			return nil, &validationError{message: "limitは正の整数である必要があります"}
-		}
-		if limit > maxAnalyzeStockBrandPriceHistoryLimit {
-			return nil, &validationError{message: "limitは1000以下である必要があります"}
-		}
-		params.limit = limit
+	limit, err := parseBoundedInt(h.httpServer, r, "limit", defaultAnalyzeStockBrandPriceHistoryLimit, maxAnalyzeStockBrandPriceHistoryLimit)
+	if err != nil {
+		return nil, err
 	}
+	params.limit = limit
 
-	datePageStr := h.httpServer.GetQueryParam(r, "date_page")
-	if datePageStr != "" {
-		datePage, err := strconv.Atoi(datePageStr)
-		if err != nil {
-			return nil, &validationError{message: "date_pageは数値である必要があります"}
-		}
-		if datePage <= 0 {
-			return nil, &validationError{message: "date_pageは正の整数である必要があります"}
-		}
-		params.datePage = datePage
+	datePage, err := parseBoundedInt(h.httpServer, r, "date_page", 0, 0)
+	if err != nil {
+		return nil, err
 	}
+	params.datePage = datePage
 
-	dateLimitStr := h.httpServer.GetQueryParam(r, "date_limit")
-	if dateLimitStr != "" {
-		dateLimit, err := strconv.Atoi(dateLimitStr)
-		if err != nil {
-			return nil, &validationError{message: "date_limitは数値である必要があります"}
-		}
-		if dateLimit <= 0 {
-			return nil, &validationError{message: "date_limitは正の整数である必要があります"}
-		}
-		if dateLimit > 50 {
-			return nil, &validationError{message: "date_limitは50以下である必要があります"}
-		}
-		params.dateLimit = dateLimit
+	dateLimit, err := parseBoundedInt(h.httpServer, r, "date_limit", 0, 50)
+	if err != nil {
+		return nil, err
 	}
+	params.dateLimit = dateLimit
 
 	return params, nil
 }

--- a/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
+++ b/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
@@ -22,19 +22,29 @@ type AnalyzeHistoryPaginationInfo struct {
 	TotalPages int   `json:"total_pages"`
 }
 
+type AnalyzeHistoryDatePaginationInfo struct {
+	DatePage       int   `json:"date_page"`
+	DateLimit      int   `json:"date_limit"`
+	TotalDates     int64 `json:"total_dates"`
+	TotalDatePages int   `json:"total_date_pages"`
+}
+
 type GetAnalyzeStockBrandPriceHistoriesResponse struct {
-	Histories  []*models.AnalyzeStockBrandPriceHistory `json:"histories"`
-	Pagination *AnalyzeHistoryPaginationInfo            `json:"pagination"`
+	Histories      []*models.AnalyzeStockBrandPriceHistory `json:"histories"`
+	Pagination     *AnalyzeHistoryPaginationInfo            `json:"pagination"`
+	DatePagination *AnalyzeHistoryDatePaginationInfo        `json:"date_pagination,omitempty"`
 }
 
 type getAnalyzeStockBrandPriceHistoriesParams struct {
-	symbol string
-	action string
-	method string
-	sortBy string
-	order  string
-	page   int
-	limit  int
+	symbol    string
+	action    string
+	method    string
+	sortBy    string
+	order     string
+	page      int
+	limit     int
+	datePage  int
+	dateLimit int
 }
 
 type AnalyzeStockBrandPriceHistoryHandler struct {
@@ -130,6 +140,33 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) validateGetAnalyzeStockBrandPrice
 		params.limit = limit
 	}
 
+	datePageStr := h.httpServer.GetQueryParam(r, "date_page")
+	if datePageStr != "" {
+		datePage, err := strconv.Atoi(datePageStr)
+		if err != nil {
+			return nil, &validationError{message: "date_pageは数値である必要があります"}
+		}
+		if datePage <= 0 {
+			return nil, &validationError{message: "date_pageは正の整数である必要があります"}
+		}
+		params.datePage = datePage
+	}
+
+	dateLimitStr := h.httpServer.GetQueryParam(r, "date_limit")
+	if dateLimitStr != "" {
+		dateLimit, err := strconv.Atoi(dateLimitStr)
+		if err != nil {
+			return nil, &validationError{message: "date_limitは数値である必要があります"}
+		}
+		if dateLimit <= 0 {
+			return nil, &validationError{message: "date_limitは正の整数である必要があります"}
+		}
+		if dateLimit > 50 {
+			return nil, &validationError{message: "date_limitは50以下である必要があります"}
+		}
+		params.dateLimit = dateLimit
+	}
+
 	return params, nil
 }
 
@@ -152,6 +189,8 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistorie
 		Order:        params.order,
 		Page:         params.page,
 		Limit:        params.limit,
+		DatePage:     params.datePage,
+		DateLimit:    params.dateLimit,
 	})
 	if err != nil {
 		h.logger.Error("failed to get analyze stock brand price histories", zap.Error(err))
@@ -159,7 +198,7 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistorie
 		return
 	}
 
-	respondJSON(w, h.logger, &GetAnalyzeStockBrandPriceHistoriesResponse{
+	resp := &GetAnalyzeStockBrandPriceHistoriesResponse{
 		Histories: result.Histories,
 		Pagination: &AnalyzeHistoryPaginationInfo{
 			Page:       result.Page,
@@ -167,5 +206,14 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistorie
 			Total:      result.Total,
 			TotalPages: result.TotalPages,
 		},
-	})
+	}
+	if params.datePage > 0 {
+		resp.DatePagination = &AnalyzeHistoryDatePaginationInfo{
+			DatePage:       result.DatePage,
+			DateLimit:      result.DateLimit,
+			TotalDates:     result.TotalDates,
+			TotalDatePages: result.TotalDatePages,
+		}
+	}
+	respondJSON(w, h.logger, resp)
 }

--- a/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
+++ b/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
@@ -15,16 +15,25 @@ const (
 	maxAnalyzeStockBrandPriceHistoryLimit     = 1000
 )
 
+type AnalyzeHistoryPaginationInfo struct {
+	Page       int   `json:"page"`
+	Limit      int   `json:"limit"`
+	Total      int64 `json:"total"`
+	TotalPages int   `json:"total_pages"`
+}
+
 type GetAnalyzeStockBrandPriceHistoriesResponse struct {
 	Histories  []*models.AnalyzeStockBrandPriceHistory `json:"histories"`
-	Pagination *PaginationInfo                         `json:"pagination,omitempty"`
+	Pagination *AnalyzeHistoryPaginationInfo            `json:"pagination"`
 }
 
 type getAnalyzeStockBrandPriceHistoriesParams struct {
 	symbol string
 	action string
 	method string
-	cursor string
+	sortBy string
+	order  string
+	page   int
 	limit  int
 }
 
@@ -44,7 +53,10 @@ func NewAnalyzeStockBrandPriceHistoryHandler(u usecase.StockBrandInteractor, h d
 
 func (h *AnalyzeStockBrandPriceHistoryHandler) validateGetAnalyzeStockBrandPriceHistoriesParams(r *http.Request) (*getAnalyzeStockBrandPriceHistoriesParams, error) {
 	params := &getAnalyzeStockBrandPriceHistoriesParams{
-		limit: defaultAnalyzeStockBrandPriceHistoryLimit,
+		limit:  defaultAnalyzeStockBrandPriceHistoryLimit,
+		page:   1,
+		sortBy: models.AnalyzeStockBrandPriceHistorySortByCreatedAt,
+		order:  models.AnalyzeStockBrandPriceHistoryOrderDesc,
 	}
 
 	params.symbol = h.httpServer.GetQueryParam(r, "symbol")
@@ -69,9 +81,38 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) validateGetAnalyzeStockBrandPrice
 		return nil, &validationError{message: "methodが長すぎます"}
 	}
 
-	params.cursor = h.httpServer.GetQueryParam(r, "cursor")
-	if len(params.cursor) > 36 {
-		return nil, &validationError{message: "cursorが長すぎます"}
+	sortBy := h.httpServer.GetQueryParam(r, "sort_by")
+	if sortBy != "" {
+		switch sortBy {
+		case models.AnalyzeStockBrandPriceHistorySortByCreatedAt,
+			models.AnalyzeStockBrandPriceHistorySortByProfit,
+			models.AnalyzeStockBrandPriceHistorySortByProfitRate:
+			params.sortBy = sortBy
+		default:
+			return nil, &validationError{message: "sort_byはcreated_at, profit, profit_rateのいずれかである必要があります"}
+		}
+	}
+
+	order := h.httpServer.GetQueryParam(r, "order")
+	if order != "" {
+		switch order {
+		case models.AnalyzeStockBrandPriceHistoryOrderAsc, models.AnalyzeStockBrandPriceHistoryOrderDesc:
+			params.order = order
+		default:
+			return nil, &validationError{message: "orderはascまたはdescである必要があります"}
+		}
+	}
+
+	pageStr := h.httpServer.GetQueryParam(r, "page")
+	if pageStr != "" {
+		page, err := strconv.Atoi(pageStr)
+		if err != nil {
+			return nil, &validationError{message: "pageは数値である必要があります"}
+		}
+		if page <= 0 {
+			return nil, &validationError{message: "pageは正の整数である必要があります"}
+		}
+		params.page = page
 	}
 
 	limitStr := h.httpServer.GetQueryParam(r, "limit")
@@ -107,7 +148,9 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistorie
 		TickerSymbol: params.symbol,
 		Action:       params.action,
 		Method:       params.method,
-		Cursor:       params.cursor,
+		SortBy:       params.sortBy,
+		Order:        params.order,
+		Page:         params.page,
 		Limit:        params.limit,
 	})
 	if err != nil {
@@ -118,9 +161,11 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistorie
 
 	respondJSON(w, h.logger, &GetAnalyzeStockBrandPriceHistoriesResponse{
 		Histories: result.Histories,
-		Pagination: &PaginationInfo{
-			NextCursor: result.NextCursor,
+		Pagination: &AnalyzeHistoryPaginationInfo{
+			Page:       result.Page,
 			Limit:      result.Limit,
+			Total:      result.Total,
+			TotalPages: result.TotalPages,
 		},
 	})
 }

--- a/entrypoint/api/handler/analyze_stock_brand_price_history_handler_test.go
+++ b/entrypoint/api/handler/analyze_stock_brand_price_history_handler_test.go
@@ -1,0 +1,194 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+
+	mock_driver "github.com/Code0716/stock-price-repository/mock/driver"
+	mock_usecase "github.com/Code0716/stock-price-repository/mock/usecase"
+	"github.com/Code0716/stock-price-repository/models"
+)
+
+func setupAnalyzeHistoryMockHTTPServer(ctrl *gomock.Controller, params map[string]string) *mock_driver.MockHTTPServer {
+	m := mock_driver.NewMockHTTPServer(ctrl)
+	keys := []string{"symbol", "action", "method", "sort_by", "order", "page", "limit"}
+	for _, k := range keys {
+		val := params[k]
+		m.EXPECT().GetQueryParam(gomock.Any(), k).Return(val).AnyTimes()
+	}
+	return m
+}
+
+func TestAnalyzeStockBrandPriceHistoryHandler_GetAnalyzeStockBrandPriceHistories(t *testing.T) {
+	now := time.Now()
+	sampleHistory := &models.AnalyzeStockBrandPriceHistory{
+		ID:           "id-1",
+		TickerSymbol: "1234",
+		TradePrice:   decimal.NewFromFloat(1000),
+		CurrentPrice: decimal.NewFromFloat(1200),
+		Action:       "Buy",
+		Method:       "find_macd_bullish_stock_v1",
+		CreatedAt:    now,
+	}
+
+	type fields struct {
+		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor
+		httpServer func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer
+	}
+
+	tests := []struct {
+		name           string
+		fields         fields
+		wantStatusCode int
+		wantPagination *AnalyzeHistoryPaginationInfo
+	}{
+		{
+			name: "正常系: デフォルトパラメータ",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
+					m.EXPECT().GetAnalyzeStockBrandPriceHistories(gomock.Any(), gomock.Eq(&models.AnalyzeStockBrandPriceHistoryFilter{
+						SortBy: models.AnalyzeStockBrandPriceHistorySortByCreatedAt,
+						Order:  models.AnalyzeStockBrandPriceHistoryOrderDesc,
+						Page:   1,
+						Limit:  100,
+					})).Return(&models.PaginatedAnalyzeStockBrandPriceHistories{
+						Histories:  []*models.AnalyzeStockBrandPriceHistory{sampleHistory},
+						Page:       1,
+						Limit:      100,
+						Total:      1,
+						TotalPages: 1,
+					}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return setupAnalyzeHistoryMockHTTPServer(ctrl, map[string]string{})
+				},
+			},
+			wantStatusCode: http.StatusOK,
+			wantPagination: &AnalyzeHistoryPaginationInfo{Page: 1, Limit: 100, Total: 1, TotalPages: 1},
+		},
+		{
+			name: "正常系: sort_by=profit&order=asc&page=2&limit=20",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
+					m.EXPECT().GetAnalyzeStockBrandPriceHistories(gomock.Any(), gomock.Eq(&models.AnalyzeStockBrandPriceHistoryFilter{
+						SortBy: models.AnalyzeStockBrandPriceHistorySortByProfit,
+						Order:  models.AnalyzeStockBrandPriceHistoryOrderAsc,
+						Page:   2,
+						Limit:  20,
+					})).Return(&models.PaginatedAnalyzeStockBrandPriceHistories{
+						Histories:  []*models.AnalyzeStockBrandPriceHistory{},
+						Page:       2,
+						Limit:      20,
+						Total:      25,
+						TotalPages: 2,
+					}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return setupAnalyzeHistoryMockHTTPServer(ctrl, map[string]string{
+						"sort_by": "profit",
+						"order":   "asc",
+						"page":    "2",
+						"limit":   "20",
+					})
+				},
+			},
+			wantStatusCode: http.StatusOK,
+			wantPagination: &AnalyzeHistoryPaginationInfo{Page: 2, Limit: 20, Total: 25, TotalPages: 2},
+		},
+		{
+			name: "異常系: 不正な sort_by",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					return mock_usecase.NewMockStockBrandInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return setupAnalyzeHistoryMockHTTPServer(ctrl, map[string]string{
+						"sort_by": "invalid_key",
+					})
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "異常系: 不正な order",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					return mock_usecase.NewMockStockBrandInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return setupAnalyzeHistoryMockHTTPServer(ctrl, map[string]string{
+						"order": "invalid_order",
+					})
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "異常系: page が 0",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					return mock_usecase.NewMockStockBrandInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return setupAnalyzeHistoryMockHTTPServer(ctrl, map[string]string{
+						"page": "0",
+					})
+				},
+			},
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "異常系: usecase エラー",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
+					m.EXPECT().GetAnalyzeStockBrandPriceHistories(gomock.Any(), gomock.Any()).Return(nil, errors.New("db error"))
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return setupAnalyzeHistoryMockHTTPServer(ctrl, map[string]string{})
+				},
+			},
+			wantStatusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			h := &AnalyzeStockBrandPriceHistoryHandler{
+				usecase:    tt.fields.usecase(ctrl),
+				httpServer: tt.fields.httpServer(ctrl),
+				logger:     zap.NewNop(),
+			}
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/analyze-stock-brand-price-histories", nil)
+			h.GetAnalyzeStockBrandPriceHistories(w, req)
+
+			assert.Equal(t, tt.wantStatusCode, w.Code)
+
+			if tt.wantPagination != nil {
+				var body GetAnalyzeStockBrandPriceHistoriesResponse
+				require := assert.New(t)
+				require.NoError(json.NewDecoder(w.Body).Decode(&body))
+				assert.Equal(t, tt.wantPagination, body.Pagination)
+			}
+		})
+	}
+}

--- a/entrypoint/api/handler/analyze_stock_brand_price_history_handler_test.go
+++ b/entrypoint/api/handler/analyze_stock_brand_price_history_handler_test.go
@@ -20,7 +20,7 @@ import (
 
 func setupAnalyzeHistoryMockHTTPServer(ctrl *gomock.Controller, params map[string]string) *mock_driver.MockHTTPServer {
 	m := mock_driver.NewMockHTTPServer(ctrl)
-	keys := []string{"symbol", "action", "method", "sort_by", "order", "page", "limit"}
+	keys := []string{"symbol", "action", "method", "sort_by", "order", "page", "limit", "date_page", "date_limit"}
 	for _, k := range keys {
 		val := params[k]
 		m.EXPECT().GetQueryParam(gomock.Any(), k).Return(val).AnyTimes()

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.7.0 h1:JxUKI6+CVBgCO2WToKy/nQk0sS+amI9z9EjVmdaocj4=

--- a/infrastructure/database/analyze_stock_brand_price_history.go
+++ b/infrastructure/database/analyze_stock_brand_price_history.go
@@ -41,6 +41,35 @@ type analyzeStockBrandPriceHistoryRow struct {
 	CreatedAt    time.Time
 }
 
+func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) buildWhereQuery(db *gorm.DB, filter *models.AnalyzeStockBrandPriceHistoryFilter) *gorm.DB {
+	if filter.TickerSymbol != "" {
+		db = db.Where("h.ticker_symbol = ?", filter.TickerSymbol)
+	}
+	if filter.Action != "" {
+		db = db.Where("h.action = ?", filter.Action)
+	}
+	if filter.Method != "" {
+		db = db.Where("h.method = ?", filter.Method)
+	}
+	return db
+}
+
+func orderClause(sortBy, order string) string {
+	dir := "DESC"
+	if order == models.AnalyzeStockBrandPriceHistoryOrderAsc {
+		dir = "ASC"
+	}
+
+	switch sortBy {
+	case models.AnalyzeStockBrandPriceHistorySortByProfit:
+		return fmt.Sprintf("(COALESCE(d.close_price, h.trade_price) - h.trade_price) %s, h.id %s", dir, dir)
+	case models.AnalyzeStockBrandPriceHistorySortByProfitRate:
+		return fmt.Sprintf("((COALESCE(d.close_price, h.trade_price) - h.trade_price) / h.trade_price) %s, h.id %s", dir, dir)
+	default:
+		return fmt.Sprintf("h.created_at %s, h.id %s", dir, dir)
+	}
+}
+
 // FindWithFilter 条件に一致する分析履歴を取得する
 // current_price は stock_brands_daily_price の最新 close_price を JOIN して都度算出する
 func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error) {
@@ -65,37 +94,19 @@ func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindWithFilter(ctx contex
 			ORDER BY date DESC LIMIT 1
 		)`)
 
-	if filter.TickerSymbol != "" {
-		db = db.Where("h.ticker_symbol = ?", filter.TickerSymbol)
-	}
-	if filter.Action != "" {
-		db = db.Where("h.action = ?", filter.Action)
-	}
-	if filter.Method != "" {
-		db = db.Where("h.method = ?", filter.Method)
-	}
-	if filter.Cursor != "" {
-		var cursorRow struct {
-			CreatedAt time.Time
-			ID        string
-		}
-		if err := ai.db.WithContext(ctx).
-			Table("analyze_stock_brand_price_history").
-			Select("created_at, id").
-			Where("id = ?", filter.Cursor).
-			Take(&cursorRow).Error; err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
-				return nil, nil
-			}
-			return nil, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.FindWithFilter cursor error")
-		}
-		db = db.Where("(h.created_at < ? OR (h.created_at = ? AND h.id < ?))", cursorRow.CreatedAt, cursorRow.CreatedAt, cursorRow.ID)
-	}
+	db = ai.buildWhereQuery(db, filter)
+	db = db.Order(orderClause(filter.SortBy, filter.Order))
 
-	db = db.Order("h.created_at DESC").Order("h.id DESC")
-	if filter.Limit > 0 {
-		db = db.Limit(filter.Limit)
+	limit := filter.Limit
+	if limit <= 0 {
+		limit = 100
 	}
+	page := filter.Page
+	if page <= 0 {
+		page = 1
+	}
+	offset := (page - 1) * limit
+	db = db.Limit(limit).Offset(offset)
 
 	var rows []*analyzeStockBrandPriceHistoryRow
 	if err := db.Find(&rows).Error; err != nil {
@@ -119,6 +130,21 @@ func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindWithFilter(ctx contex
 	}
 
 	return histories, nil
+}
+
+// CountWithFilter 条件に一致する分析履歴の総件数を返す
+func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) CountWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error) {
+	db := ai.db.WithContext(ctx).
+		Table("analyze_stock_brand_price_history AS h")
+
+	db = ai.buildWhereQuery(db, filter)
+
+	var count int64
+	if err := db.Count(&count).Error; err != nil {
+		return 0, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.CountWithFilter error")
+	}
+
+	return count, nil
 }
 
 // FindMultipleSignals 同一日に2つ以上のシグナルが出た銘柄を集計して返す

--- a/infrastructure/database/analyze_stock_brand_price_history.go
+++ b/infrastructure/database/analyze_stock_brand_price_history.go
@@ -147,6 +147,105 @@ func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) CountWithFilter(ctx conte
 	return count, nil
 }
 
+// FindDistinctDates フィルタ条件下でデータが存在する日付を DateLimit 件 (DatePage ページ目) 取得する
+func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindDistinctDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]string, error) {
+	dateLimit := filter.DateLimit
+	if dateLimit <= 0 {
+		dateLimit = 10
+	}
+	datePage := filter.DatePage
+	if datePage <= 0 {
+		datePage = 1
+	}
+	offset := (datePage - 1) * dateLimit
+
+	db := ai.db.WithContext(ctx).
+		Table("analyze_stock_brand_price_history AS h").
+		Select("DISTINCT h.created_at").
+		Order("h.created_at DESC").
+		Limit(dateLimit).
+		Offset(offset)
+
+	db = ai.buildWhereQuery(db, filter)
+
+	var dates []string
+	if err := db.Pluck("h.created_at", &dates).Error; err != nil {
+		return nil, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.FindDistinctDates error")
+	}
+
+	return dates, nil
+}
+
+// CountDistinctDates フィルタ条件下でデータが存在する日付の総数を返す
+func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) CountDistinctDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error) {
+	db := ai.db.WithContext(ctx).
+		Table("analyze_stock_brand_price_history AS h")
+
+	db = ai.buildWhereQuery(db, filter)
+
+	var count int64
+	if err := db.Distinct("h.created_at").Count(&count).Error; err != nil {
+		return 0, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.CountDistinctDates error")
+	}
+
+	return count, nil
+}
+
+// FindByDates 指定した日付リストに含まれる分析履歴を全件取得する
+func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindByDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter, dates []string) ([]*models.AnalyzeStockBrandPriceHistory, error) {
+	if len(dates) == 0 {
+		return []*models.AnalyzeStockBrandPriceHistory{}, nil
+	}
+
+	db := ai.db.WithContext(ctx).
+		Table("analyze_stock_brand_price_history AS h").
+		Select(`
+			h.id,
+			h.stock_brand_id,
+			COALESCE(s.name, '') AS name,
+			h.ticker_symbol,
+			h.trade_price,
+			COALESCE(d.close_price, h.trade_price) AS current_price,
+			h.action,
+			h.method,
+			h.memo,
+			h.created_at
+		`).
+		Joins("LEFT JOIN stock_brand AS s ON s.id = h.stock_brand_id AND s.deleted_at IS NULL").
+		Joins(`LEFT JOIN stock_brands_daily_price AS d ON d.id = (
+			SELECT id FROM stock_brands_daily_price
+			WHERE ticker_symbol = h.ticker_symbol AND deleted_at IS NULL
+			ORDER BY date DESC LIMIT 1
+		)`).
+		Where("h.created_at IN ?", dates)
+
+	db = ai.buildWhereQuery(db, filter)
+	db = db.Order(orderClause(filter.SortBy, filter.Order))
+
+	var rows []*analyzeStockBrandPriceHistoryRow
+	if err := db.Find(&rows).Error; err != nil {
+		return nil, errors.Wrap(err, "AnalyzeStockBrandPriceHistoryRepositoryImpl.FindByDates error")
+	}
+
+	histories := make([]*models.AnalyzeStockBrandPriceHistory, 0, len(rows))
+	for _, row := range rows {
+		histories = append(histories, models.NewAnalyzeStockBrandPriceHistory(
+			row.ID,
+			row.StockBrandID,
+			row.Name,
+			row.TickerSymbol,
+			decimal.NewFromFloat(row.TradePrice),
+			decimal.NewFromFloat(row.CurrentPrice),
+			row.Action,
+			row.Method,
+			row.Memo,
+			row.CreatedAt,
+		))
+	}
+
+	return histories, nil
+}
+
 // FindMultipleSignals 同一日に2つ以上のシグナルが出た銘柄を集計して返す
 func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindMultipleSignals(ctx context.Context, filter *models.MultipleSignalStockFilter) ([]*models.MultipleSignalStock, error) {
 	type multipleSignalRow struct {

--- a/infrastructure/database/analyze_stock_brand_price_history_test.go
+++ b/infrastructure/database/analyze_stock_brand_price_history_test.go
@@ -72,6 +72,174 @@ func TestAnalyzeStockBrandPriceHistoryRepositoryImpl_FindWithFilter(t *testing.T
 	})
 }
 
+func TestAnalyzeStockBrandPriceHistoryRepositoryImpl_FindWithFilter_Pagination(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewAnalyzeStockBrandPriceHistoryRepositoryImpl(db)
+	stockBrandRepo := NewStockBrandRepositoryImpl(db)
+	ctx := context.Background()
+	base := time.Now().Truncate(24 * time.Hour)
+
+	brand := &models.StockBrand{
+		ID:           "brand-page-1",
+		TickerSymbol: "9001",
+		Name:         "Page Test Brand",
+		MarketCode:   "111",
+		MarketName:   "Prime",
+		CreatedAt:    base,
+		UpdatedAt:    base,
+	}
+	require.NoError(t, stockBrandRepo.UpsertStockBrands(ctx, []*models.StockBrand{brand}))
+
+	// 5件挿入: created_at を1日ずつずらす
+	for i := 0; i < 5; i++ {
+		d := base.AddDate(0, 0, -i)
+		err := db.Exec(
+			"INSERT INTO analyze_stock_brand_price_history (id, stock_brand_id, ticker_symbol, trade_price, action, method, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			"page-uuid-"+string(rune('1'+i)), "brand-page-1", "9001", float64(1000+i*100), "Buy", "analyze_stock_brand_price_by_sector: 25日", d.Format("2006-01-02"),
+		).Error
+		require.NoError(t, err)
+	}
+
+	t.Run("page=1 limit=2 で最新2件取得", func(t *testing.T) {
+		results, err := repo.FindWithFilter(ctx, &models.AnalyzeStockBrandPriceHistoryFilter{
+			TickerSymbol: "9001",
+			Page:         1,
+			Limit:        2,
+		})
+		require.NoError(t, err)
+		assert.Len(t, results, 2)
+	})
+
+	t.Run("page=2 limit=2 で次の2件取得", func(t *testing.T) {
+		p1, err := repo.FindWithFilter(ctx, &models.AnalyzeStockBrandPriceHistoryFilter{
+			TickerSymbol: "9001",
+			Page:         1,
+			Limit:        2,
+		})
+		require.NoError(t, err)
+
+		p2, err := repo.FindWithFilter(ctx, &models.AnalyzeStockBrandPriceHistoryFilter{
+			TickerSymbol: "9001",
+			Page:         2,
+			Limit:        2,
+		})
+		require.NoError(t, err)
+		assert.Len(t, p2, 2)
+
+		// 重複なし
+		p1IDs := map[string]bool{p1[0].ID: true, p1[1].ID: true}
+		for _, h := range p2 {
+			assert.False(t, p1IDs[h.ID], "page1とpage2のIDが重複している: %s", h.ID)
+		}
+	})
+
+	t.Run("created_at ASC ソート", func(t *testing.T) {
+		results, err := repo.FindWithFilter(ctx, &models.AnalyzeStockBrandPriceHistoryFilter{
+			TickerSymbol: "9001",
+			SortBy:       models.AnalyzeStockBrandPriceHistorySortByCreatedAt,
+			Order:        models.AnalyzeStockBrandPriceHistoryOrderAsc,
+			Page:         1,
+			Limit:        5,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 5)
+		for i := 1; i < len(results); i++ {
+			assert.True(t, !results[i].CreatedAt.Before(results[i-1].CreatedAt), "ASCソートが崩れている")
+		}
+	})
+
+	t.Run("created_at DESC ソート (デフォルト)", func(t *testing.T) {
+		results, err := repo.FindWithFilter(ctx, &models.AnalyzeStockBrandPriceHistoryFilter{
+			TickerSymbol: "9001",
+			SortBy:       models.AnalyzeStockBrandPriceHistorySortByCreatedAt,
+			Order:        models.AnalyzeStockBrandPriceHistoryOrderDesc,
+			Page:         1,
+			Limit:        5,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 5)
+		for i := 1; i < len(results); i++ {
+			assert.True(t, !results[i].CreatedAt.After(results[i-1].CreatedAt), "DESCソートが崩れている")
+		}
+	})
+}
+
+func TestAnalyzeStockBrandPriceHistoryRepositoryImpl_CountWithFilter(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewAnalyzeStockBrandPriceHistoryRepositoryImpl(db)
+	stockBrandRepo := NewStockBrandRepositoryImpl(db)
+	ctx := context.Background()
+	now := time.Now().Truncate(24 * time.Hour)
+
+	brands := []*models.StockBrand{
+		{ID: "brand-cnt-1", TickerSymbol: "8001", Name: "Count Brand 1", MarketCode: "111", MarketName: "Prime", CreatedAt: now, UpdatedAt: now},
+		{ID: "brand-cnt-2", TickerSymbol: "8002", Name: "Count Brand 2", MarketCode: "111", MarketName: "Prime", CreatedAt: now, UpdatedAt: now},
+	}
+	require.NoError(t, stockBrandRepo.UpsertStockBrands(ctx, brands))
+
+	inserts := []struct {
+		id     string
+		brand  string
+		ticker string
+		action string
+		method string
+	}{
+		{"cnt-1", "brand-cnt-1", "8001", "Buy", "analyze_stock_brand_price_by_sector: 25日"},
+		{"cnt-2", "brand-cnt-1", "8001", "Sell", "analyze_stock_brand_price_by_sector: 75日"},
+		{"cnt-3", "brand-cnt-2", "8002", "Buy", "analyze_stock_brand_price_by_sector: 25日"},
+	}
+	for _, ins := range inserts {
+		require.NoError(t, db.Exec(
+			"INSERT INTO analyze_stock_brand_price_history (id, stock_brand_id, ticker_symbol, trade_price, action, method, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			ins.id, ins.brand, ins.ticker, 1000.0, ins.action, ins.method, now.Format("2006-01-02"),
+		).Error)
+	}
+
+	tests := []struct {
+		name   string
+		filter *models.AnalyzeStockBrandPriceHistoryFilter
+		want   int64
+	}{
+		{
+			name:   "フィルタなし: 全件",
+			filter: &models.AnalyzeStockBrandPriceHistoryFilter{},
+			want:   3,
+		},
+		{
+			name:   "ticker=8001 でフィルタ",
+			filter: &models.AnalyzeStockBrandPriceHistoryFilter{TickerSymbol: "8001"},
+			want:   2,
+		},
+		{
+			name:   "action=Buy でフィルタ",
+			filter: &models.AnalyzeStockBrandPriceHistoryFilter{Action: "Buy"},
+			want:   2,
+		},
+		{
+			name:   "ticker=8001 + action=Sell",
+			filter: &models.AnalyzeStockBrandPriceHistoryFilter{TickerSymbol: "8001", Action: "Sell"},
+			want:   1,
+		},
+		{
+			name:   "存在しないticker",
+			filter: &models.AnalyzeStockBrandPriceHistoryFilter{TickerSymbol: "9999"},
+			want:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			count, err := repo.CountWithFilter(ctx, tt.filter)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, count)
+		})
+	}
+}
+
 func TestAnalyzeStockBrandPriceHistoryRepositoryImpl_DeleteByStockBrandIDs(t *testing.T) {
 	db, cleanup := setupTestDB(t)
 	defer cleanup()
@@ -138,4 +306,58 @@ func TestAnalyzeStockBrandPriceHistoryRepositoryImpl_DeleteByStockBrandIDs(t *te
 			}
 		})
 	}
+}
+
+func TestAnalyzeStockBrandPriceHistoryRepositoryImpl_FindWithFilter_SortByProfit(t *testing.T) {
+	db, cleanup := setupTestDB(t)
+	defer cleanup()
+
+	repo := NewAnalyzeStockBrandPriceHistoryRepositoryImpl(db)
+	stockBrandRepo := NewStockBrandRepositoryImpl(db)
+	ctx := context.Background()
+	now := time.Now().Truncate(24 * time.Hour)
+
+	brand := &models.StockBrand{
+		ID:           "brand-profit-1",
+		TickerSymbol: "7001",
+		Name:         "Profit Brand",
+		MarketCode:   "111",
+		MarketName:   "Prime",
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	require.NoError(t, stockBrandRepo.UpsertStockBrands(ctx, []*models.StockBrand{brand}))
+
+	// 3件: trade_price が異なる（daily_price なし → current_price = trade_price → profit = 0）
+	// profit を確認するには daily_price が必要だが、sort自体は実行できることを確認する
+	for i, price := range []float64{1000.0, 2000.0, 500.0} {
+		require.NoError(t, db.Exec(
+			"INSERT INTO analyze_stock_brand_price_history (id, stock_brand_id, ticker_symbol, trade_price, action, method, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+			"profit-uuid-"+string(rune('1'+i)), "brand-profit-1", "7001", price, "Buy", "find_macd_bullish_stock_v1", now.AddDate(0, 0, -i).Format("2006-01-02"),
+		).Error)
+	}
+
+	t.Run("sort_by=profit DESC でエラーなく取得できる", func(t *testing.T) {
+		results, err := repo.FindWithFilter(ctx, &models.AnalyzeStockBrandPriceHistoryFilter{
+			TickerSymbol: "7001",
+			SortBy:       models.AnalyzeStockBrandPriceHistorySortByProfit,
+			Order:        models.AnalyzeStockBrandPriceHistoryOrderDesc,
+			Page:         1,
+			Limit:        10,
+		})
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
+
+	t.Run("sort_by=profit_rate ASC でエラーなく取得できる", func(t *testing.T) {
+		results, err := repo.FindWithFilter(ctx, &models.AnalyzeStockBrandPriceHistoryFilter{
+			TickerSymbol: "7001",
+			SortBy:       models.AnalyzeStockBrandPriceHistorySortByProfitRate,
+			Order:        models.AnalyzeStockBrandPriceHistoryOrderAsc,
+			Page:         1,
+			Limit:        10,
+		})
+		require.NoError(t, err)
+		assert.Len(t, results, 3)
+	})
 }

--- a/mock/repositories/analyze_stock_brand_price_history.go
+++ b/mock/repositories/analyze_stock_brand_price_history.go
@@ -41,6 +41,21 @@ func (m *MockAnalyzeStockBrandPriceHistoryRepository) EXPECT() *MockAnalyzeStock
 	return m.recorder
 }
 
+// CountWithFilter mocks base method.
+func (m *MockAnalyzeStockBrandPriceHistoryRepository) CountWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountWithFilter", ctx, filter)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountWithFilter indicates an expected call of CountWithFilter.
+func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) CountWithFilter(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountWithFilter", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).CountWithFilter), ctx, filter)
+}
+
 // DeleteByStockBrandIDs mocks base method.
 func (m *MockAnalyzeStockBrandPriceHistoryRepository) DeleteByStockBrandIDs(ctx context.Context, ids []string) error {
 	m.ctrl.T.Helper()

--- a/mock/repositories/analyze_stock_brand_price_history.go
+++ b/mock/repositories/analyze_stock_brand_price_history.go
@@ -41,6 +41,21 @@ func (m *MockAnalyzeStockBrandPriceHistoryRepository) EXPECT() *MockAnalyzeStock
 	return m.recorder
 }
 
+// CountDistinctDates mocks base method.
+func (m *MockAnalyzeStockBrandPriceHistoryRepository) CountDistinctDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CountDistinctDates", ctx, filter)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CountDistinctDates indicates an expected call of CountDistinctDates.
+func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) CountDistinctDates(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountDistinctDates", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).CountDistinctDates), ctx, filter)
+}
+
 // CountWithFilter mocks base method.
 func (m *MockAnalyzeStockBrandPriceHistoryRepository) CountWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error) {
 	m.ctrl.T.Helper()
@@ -68,6 +83,36 @@ func (m *MockAnalyzeStockBrandPriceHistoryRepository) DeleteByStockBrandIDs(ctx 
 func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) DeleteByStockBrandIDs(ctx, ids any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByStockBrandIDs", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).DeleteByStockBrandIDs), ctx, ids)
+}
+
+// FindByDates mocks base method.
+func (m *MockAnalyzeStockBrandPriceHistoryRepository) FindByDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter, dates []string) ([]*models.AnalyzeStockBrandPriceHistory, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByDates", ctx, filter, dates)
+	ret0, _ := ret[0].([]*models.AnalyzeStockBrandPriceHistory)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByDates indicates an expected call of FindByDates.
+func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) FindByDates(ctx, filter, dates any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByDates", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).FindByDates), ctx, filter, dates)
+}
+
+// FindDistinctDates mocks base method.
+func (m *MockAnalyzeStockBrandPriceHistoryRepository) FindDistinctDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindDistinctDates", ctx, filter)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindDistinctDates indicates an expected call of FindDistinctDates.
+func (mr *MockAnalyzeStockBrandPriceHistoryRepositoryMockRecorder) FindDistinctDates(ctx, filter any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindDistinctDates", reflect.TypeOf((*MockAnalyzeStockBrandPriceHistoryRepository)(nil).FindDistinctDates), ctx, filter)
 }
 
 // FindMultipleSignals mocks base method.

--- a/models/analyze_stock_brand_price_history.go
+++ b/models/analyze_stock_brand_price_history.go
@@ -17,6 +17,12 @@ const (
 	AnalyzeStockBrandPriceHistoryMethodFindMLRankedV1          string = "find_ml_ranked_stocks_v1"
 	AnalyzeStockBrandPriceHistoryActionBuy                     string = "Buy"
 	AnalyzeStockBrandPriceHistoryActionSell                    string = "Sell"
+
+	AnalyzeStockBrandPriceHistorySortByCreatedAt  string = "created_at"
+	AnalyzeStockBrandPriceHistorySortByProfit     string = "profit"
+	AnalyzeStockBrandPriceHistorySortByProfitRate string = "profit_rate"
+	AnalyzeStockBrandPriceHistoryOrderAsc         string = "asc"
+	AnalyzeStockBrandPriceHistoryOrderDesc        string = "desc"
 )
 
 type AnalyzeStockBrandPriceHistory struct {
@@ -37,14 +43,18 @@ type AnalyzeStockBrandPriceHistoryFilter struct {
 	TickerSymbol string
 	Action       string
 	Method       string
-	Cursor       string
+	SortBy       string
+	Order        string
+	Page         int
 	Limit        int
 }
 
 type PaginatedAnalyzeStockBrandPriceHistories struct {
 	Histories  []*AnalyzeStockBrandPriceHistory
-	NextCursor *string
+	Page       int
 	Limit      int
+	Total      int64
+	TotalPages int
 }
 
 func NewAnalyzeStockBrandPriceHistory(

--- a/models/analyze_stock_brand_price_history.go
+++ b/models/analyze_stock_brand_price_history.go
@@ -47,14 +47,20 @@ type AnalyzeStockBrandPriceHistoryFilter struct {
 	Order        string
 	Page         int
 	Limit        int
+	DatePage     int // 1-indexed; 0 means normal (non-date-grouped) mode
+	DateLimit    int // number of distinct dates per page; 0 means use default
 }
 
 type PaginatedAnalyzeStockBrandPriceHistories struct {
-	Histories  []*AnalyzeStockBrandPriceHistory
-	Page       int
-	Limit      int
-	Total      int64
-	TotalPages int
+	Histories      []*AnalyzeStockBrandPriceHistory
+	Page           int
+	Limit          int
+	Total          int64
+	TotalPages     int
+	DatePage       int
+	DateLimit      int
+	TotalDates     int64
+	TotalDatePages int
 }
 
 func NewAnalyzeStockBrandPriceHistory(

--- a/repositories/analyze_stock_brand_price_history.go
+++ b/repositories/analyze_stock_brand_price_history.go
@@ -12,6 +12,12 @@ type AnalyzeStockBrandPriceHistoryRepository interface {
 	FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error)
 	// CountWithFilter 条件に一致する分析履歴の総件数を取得する
 	CountWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error)
+	// FindDistinctDates フィルタ条件下でデータが存在する日付の一覧を取得する（日付グループモード用）
+	FindDistinctDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]string, error)
+	// CountDistinctDates フィルタ条件下でデータが存在する日付の総数を返す
+	CountDistinctDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error)
+	// FindByDates 指定した日付リストに含まれる分析履歴を全件取得する
+	FindByDates(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter, dates []string) ([]*models.AnalyzeStockBrandPriceHistory, error)
 	// FindMultipleSignals 同一日に2つ以上のシグナルが出た銘柄を集計して取得する
 	FindMultipleSignals(ctx context.Context, filter *models.MultipleSignalStockFilter) ([]*models.MultipleSignalStock, error)
 	// DeleteByStockBrandIDs 銘柄IDで一致したものを削除する

--- a/repositories/analyze_stock_brand_price_history.go
+++ b/repositories/analyze_stock_brand_price_history.go
@@ -10,6 +10,8 @@ import (
 type AnalyzeStockBrandPriceHistoryRepository interface {
 	// FindWithFilter 条件に一致する分析履歴を取得する
 	FindWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) ([]*models.AnalyzeStockBrandPriceHistory, error)
+	// CountWithFilter 条件に一致する分析履歴の総件数を取得する
+	CountWithFilter(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (int64, error)
 	// FindMultipleSignals 同一日に2つ以上のシグナルが出た銘柄を集計して取得する
 	FindMultipleSignals(ctx context.Context, filter *models.MultipleSignalStockFilter) ([]*models.MultipleSignalStock, error)
 	// DeleteByStockBrandIDs 銘柄IDで一致したものを削除する

--- a/usecase/get_analyze_stock_brand_price_histories.go
+++ b/usecase/get_analyze_stock_brand_price_histories.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"math"
 
 	"github.com/Code0716/stock-price-repository/models"
 	"github.com/pkg/errors"
@@ -13,30 +14,33 @@ func (si *stockBrandInteractorImpl) GetAnalyzeStockBrandPriceHistories(ctx conte
 		filter = &models.AnalyzeStockBrandPriceHistoryFilter{}
 	}
 
-	limit := filter.Limit
-	fetchLimit := limit
-	if limit > 0 {
-		fetchLimit = limit + 1
+	if filter.Limit <= 0 {
+		filter.Limit = 100
+	}
+	if filter.Page <= 0 {
+		filter.Page = 1
 	}
 
-	repoFilter := *filter
-	repoFilter.Limit = fetchLimit
+	total, err := si.analyzeStockBrandPriceHistoryRepository.CountWithFilter(ctx, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "分析履歴件数の取得に失敗しました")
+	}
 
-	histories, err := si.analyzeStockBrandPriceHistoryRepository.FindWithFilter(ctx, &repoFilter)
+	histories, err := si.analyzeStockBrandPriceHistoryRepository.FindWithFilter(ctx, filter)
 	if err != nil {
 		return nil, errors.Wrap(err, "分析履歴一覧の取得に失敗しました")
 	}
 
-	result := &models.PaginatedAnalyzeStockBrandPriceHistories{
-		Histories: histories,
-		Limit:     limit,
+	totalPages := int(math.Ceil(float64(total) / float64(filter.Limit)))
+	if totalPages < 1 {
+		totalPages = 1
 	}
 
-	if limit > 0 && len(histories) > limit {
-		nextHistory := histories[limit]
-		result.NextCursor = &nextHistory.ID
-		result.Histories = histories[:limit]
-	}
-
-	return result, nil
+	return &models.PaginatedAnalyzeStockBrandPriceHistories{
+		Histories:  histories,
+		Page:       filter.Page,
+		Limit:      filter.Limit,
+		Total:      total,
+		TotalPages: totalPages,
+	}, nil
 }

--- a/usecase/get_analyze_stock_brand_price_histories.go
+++ b/usecase/get_analyze_stock_brand_price_histories.go
@@ -14,6 +14,10 @@ func (si *stockBrandInteractorImpl) GetAnalyzeStockBrandPriceHistories(ctx conte
 		filter = &models.AnalyzeStockBrandPriceHistoryFilter{}
 	}
 
+	if filter.DatePage > 0 {
+		return si.getAnalyzeStockBrandPriceHistoriesByDate(ctx, filter)
+	}
+
 	if filter.Limit <= 0 {
 		filter.Limit = 100
 	}
@@ -42,5 +46,53 @@ func (si *stockBrandInteractorImpl) GetAnalyzeStockBrandPriceHistories(ctx conte
 		Limit:      filter.Limit,
 		Total:      total,
 		TotalPages: totalPages,
+	}, nil
+}
+
+func (si *stockBrandInteractorImpl) getAnalyzeStockBrandPriceHistoriesByDate(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (*models.PaginatedAnalyzeStockBrandPriceHistories, error) {
+	if filter.DateLimit <= 0 {
+		filter.DateLimit = 10
+	}
+
+	totalDates, err := si.analyzeStockBrandPriceHistoryRepository.CountDistinctDates(ctx, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "日付総数の取得に失敗しました")
+	}
+
+	dates, err := si.analyzeStockBrandPriceHistoryRepository.FindDistinctDates(ctx, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "日付一覧の取得に失敗しました")
+	}
+
+	if len(dates) == 0 {
+		totalDatePages := int(math.Ceil(float64(totalDates) / float64(filter.DateLimit)))
+		if totalDatePages < 1 {
+			totalDatePages = 1
+		}
+		return &models.PaginatedAnalyzeStockBrandPriceHistories{
+			Histories:      []*models.AnalyzeStockBrandPriceHistory{},
+			DatePage:       filter.DatePage,
+			DateLimit:      filter.DateLimit,
+			TotalDates:     totalDates,
+			TotalDatePages: totalDatePages,
+		}, nil
+	}
+
+	histories, err := si.analyzeStockBrandPriceHistoryRepository.FindByDates(ctx, filter, dates)
+	if err != nil {
+		return nil, errors.Wrap(err, "分析履歴一覧（日付指定）の取得に失敗しました")
+	}
+
+	totalDatePages := int(math.Ceil(float64(totalDates) / float64(filter.DateLimit)))
+	if totalDatePages < 1 {
+		totalDatePages = 1
+	}
+
+	return &models.PaginatedAnalyzeStockBrandPriceHistories{
+		Histories:      histories,
+		DatePage:       filter.DatePage,
+		DateLimit:      filter.DateLimit,
+		TotalDates:     totalDates,
+		TotalDatePages: totalDatePages,
 	}, nil
 }

--- a/usecase/get_analyze_stock_brand_price_histories_test.go
+++ b/usecase/get_analyze_stock_brand_price_histories_test.go
@@ -1,0 +1,187 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	mock_repositories "github.com/Code0716/stock-price-repository/mock/repositories"
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/Code0716/stock-price-repository/repositories"
+)
+
+func TestStockBrandInteractorImpl_GetAnalyzeStockBrandPriceHistories(t *testing.T) {
+	now := time.Now()
+	sampleHistory := &models.AnalyzeStockBrandPriceHistory{
+		ID:           "id-1",
+		StockBrandID: "brand-1",
+		TickerSymbol: "1234",
+		TradePrice:   decimal.NewFromFloat(1000),
+		CurrentPrice: decimal.NewFromFloat(1200),
+		Action:       models.AnalyzeStockBrandPriceHistoryActionBuy,
+		Method:       models.AnalyzeStockBrandPriceHistoryMethodSector25,
+		CreatedAt:    now,
+	}
+
+	type fields struct {
+		analyzeRepo func(ctrl *gomock.Controller) repositories.AnalyzeStockBrandPriceHistoryRepository
+	}
+	type args struct {
+		filter *models.AnalyzeStockBrandPriceHistoryFilter
+	}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *models.PaginatedAnalyzeStockBrandPriceHistories
+		wantErr bool
+	}{
+		{
+			name: "正常系: page=1, limit=10, total=1",
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) repositories.AnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					expectedFilter := &models.AnalyzeStockBrandPriceHistoryFilter{
+						Page:  1,
+						Limit: 10,
+					}
+					m.EXPECT().CountWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return(int64(1), nil)
+					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return([]*models.AnalyzeStockBrandPriceHistory{sampleHistory}, nil)
+					return m
+				},
+			},
+			args: args{
+				filter: &models.AnalyzeStockBrandPriceHistoryFilter{
+					Page:  1,
+					Limit: 10,
+				},
+			},
+			want: &models.PaginatedAnalyzeStockBrandPriceHistories{
+				Histories:  []*models.AnalyzeStockBrandPriceHistory{sampleHistory},
+				Page:       1,
+				Limit:      10,
+				Total:      1,
+				TotalPages: 1,
+			},
+		},
+		{
+			name: "正常系: total_pages の端数切り上げ",
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) repositories.AnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					expectedFilter := &models.AnalyzeStockBrandPriceHistoryFilter{
+						Page:  2,
+						Limit: 10,
+					}
+					m.EXPECT().CountWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return(int64(25), nil)
+					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return([]*models.AnalyzeStockBrandPriceHistory{sampleHistory}, nil)
+					return m
+				},
+			},
+			args: args{
+				filter: &models.AnalyzeStockBrandPriceHistoryFilter{
+					Page:  2,
+					Limit: 10,
+				},
+			},
+			want: &models.PaginatedAnalyzeStockBrandPriceHistories{
+				Histories:  []*models.AnalyzeStockBrandPriceHistory{sampleHistory},
+				Page:       2,
+				Limit:      10,
+				Total:      25,
+				TotalPages: 3,
+			},
+		},
+		{
+			name: "正常系: nilフィルタはデフォルト値を使う",
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) repositories.AnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					expectedFilter := &models.AnalyzeStockBrandPriceHistoryFilter{
+						Page:  1,
+						Limit: 100,
+					}
+					m.EXPECT().CountWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return(int64(0), nil)
+					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return([]*models.AnalyzeStockBrandPriceHistory{}, nil)
+					return m
+				},
+			},
+			args: args{filter: nil},
+			want: &models.PaginatedAnalyzeStockBrandPriceHistories{
+				Histories:  []*models.AnalyzeStockBrandPriceHistory{},
+				Page:       1,
+				Limit:      100,
+				Total:      0,
+				TotalPages: 1,
+			},
+		},
+		{
+			name: "異常系: CountWithFilter エラー",
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) repositories.AnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					expectedFilter := &models.AnalyzeStockBrandPriceHistoryFilter{
+						Page:  1,
+						Limit: 10,
+					}
+					m.EXPECT().CountWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return(int64(0), assert.AnError)
+					return m
+				},
+			},
+			args: args{
+				filter: &models.AnalyzeStockBrandPriceHistoryFilter{
+					Page:  1,
+					Limit: 10,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "異常系: FindWithFilter エラー",
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) repositories.AnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					expectedFilter := &models.AnalyzeStockBrandPriceHistoryFilter{
+						Page:  1,
+						Limit: 10,
+					}
+					m.EXPECT().CountWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return(int64(5), nil)
+					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(expectedFilter)).Return(nil, assert.AnError)
+					return m
+				},
+			},
+			args: args{
+				filter: &models.AnalyzeStockBrandPriceHistoryFilter{
+					Page:  1,
+					Limit: 10,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			si := &stockBrandInteractorImpl{}
+			if tt.fields.analyzeRepo != nil {
+				si.analyzeStockBrandPriceHistoryRepository = tt.fields.analyzeRepo(ctrl)
+			}
+
+			got, err := si.GetAnalyzeStockBrandPriceHistories(context.Background(), tt.args.filter)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- カーソルベースのページネーションを offset+total 方式（`page`/`limit`）に置き換え
- `sort_by=created_at|profit|profit_rate` と `order=asc|desc` クエリパラメータを追加
- `CountWithFilter` をリポジトリに新設し `total`/`total_pages` をレスポンスに返す
- 既存の `cursor` パラメータを削除（呼び出し元はフロントのみ）

**レスポンス変更**:
```json
{
  "histories": [...],
  "pagination": { "page": 1, "limit": 100, "total": 1234, "total_pages": 13 }
}
```

## Test plan

- [x] `make test-unit` 全通過
- [x] 新規ハンドラテスト (sort_by/order/page のバリデーション含む)
- [x] 新規 usecase テスト (total_pages 端数切り上げ含む)
- [x] 新規 repository テスト (ページング/ソート/CountWithFilter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)