### PR TITLE
fix: symbol_from を inclusive に統一し symbol_prefix 前方一致検索を追加

### DIFF
--- a/entrypoint/api/handler/stock_brand_handler.go
+++ b/entrypoint/api/handler/stock_brand_handler.go
@@ -33,6 +33,7 @@ type PaginationInfo struct {
 
 // getStockBrandsParams GetStockBrandsのリクエストパラメータ
 type getStockBrandsParams struct {
+	symbolPrefix    string
 	symbolFrom      string
 	limit           int
 	onlyMainMarkets bool
@@ -55,6 +56,17 @@ func NewStockBrandHandler(u usecase.StockBrandInteractor, h driver.HTTPServer, l
 // validateGetStockBrandsParams GetStockBrandsのリクエストパラメータをバリデーションする
 func (h *StockBrandHandler) validateGetStockBrandsParams(r *http.Request) (*getStockBrandsParams, error) {
 	params := &getStockBrandsParams{}
+
+	// symbol_prefix パラメータの取得とバリデーション
+	params.symbolPrefix = h.httpServer.GetQueryParam(r, "symbol_prefix")
+	if params.symbolPrefix != "" {
+		if len(params.symbolPrefix) > 10 {
+			return nil, &validationError{message: "symbol_prefixが長すぎます"}
+		}
+		if !alphanumericOptionalRegex.MatchString(params.symbolPrefix) {
+			return nil, &validationError{message: "symbol_prefixは英数字である必要があります"}
+		}
+	}
 
 	// symbolFrom パラメータの取得とバリデーション
 	params.symbolFrom = h.httpServer.GetQueryParam(r, "symbol_from")
@@ -126,7 +138,7 @@ func (h *StockBrandHandler) GetStockBrands(w http.ResponseWriter, r *http.Reques
 	}
 
 	// ユースケース呼び出し
-	result, err := h.usecase.GetStockBrands(r.Context(), params.symbolFrom, params.limit, params.onlyMainMarkets)
+	result, err := h.usecase.GetStockBrands(r.Context(), params.symbolPrefix, params.symbolFrom, params.limit, params.onlyMainMarkets)
 	if err != nil {
 		h.logger.Error("failed to get stock brands", zap.Error(err))
 		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)

--- a/entrypoint/api/handler/stock_brand_handler_test.go
+++ b/entrypoint/api/handler/stock_brand_handler_test.go
@@ -39,7 +39,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
 					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
 					m.EXPECT().
-						GetStockBrands(gomock.Any(), "", 0, false).
+						GetStockBrands(gomock.Any(), "", "", 0, false).
 						Return(&models.PaginatedStockBrands{
 							Brands: []*models.StockBrand{
 								{
@@ -56,6 +56,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("")
@@ -85,7 +86,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 					nextCursor := "5678"
 					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
 					m.EXPECT().
-						GetStockBrands(gomock.Any(), "1000", 10, false).
+						GetStockBrands(gomock.Any(), "", "1000", 10, false).
 						Return(&models.PaginatedStockBrands{
 							Brands: []*models.StockBrand{
 								{
@@ -102,6 +103,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("1000")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("10")
 					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("")
@@ -131,12 +133,58 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 			}(),
 		},
 		{
+			name: "正常系: symbol_prefix前方一致検索",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
+					m.EXPECT().
+						GetStockBrands(gomock.Any(), "7203", "", 0, false).
+						Return(&models.PaginatedStockBrands{
+							Brands: []*models.StockBrand{
+								{
+									ID:           "1",
+									TickerSymbol: "7203",
+									Name:         "トヨタ自動車",
+									MarketCode:   "111",
+								},
+							},
+							NextCursor: nil,
+							Limit:      0,
+						}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("7203")
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("")
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/stock-brands?symbol_prefix=7203", nil),
+			},
+			wantStatusCode: http.StatusOK,
+			wantBody: &GetStockBrandsResponse{
+				StockBrands: []*models.StockBrand{
+					{
+						ID:           "1",
+						TickerSymbol: "7203",
+						Name:         "トヨタ自動車",
+						MarketCode:   "111",
+					},
+				},
+				Pagination: nil,
+			},
+		},
+		{
 			name: "正常系: 主要市場のみフィルタリング",
 			fields: fields{
 				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
 					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
 					m.EXPECT().
-						GetStockBrands(gomock.Any(), "", 0, true).
+						GetStockBrands(gomock.Any(), "", "", 0, true).
 						Return(&models.PaginatedStockBrands{
 							Brands: []*models.StockBrand{
 								{
@@ -153,6 +201,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("true")
@@ -176,6 +225,42 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 			},
 		},
 		{
+			name: "異常系: symbol_prefixが長すぎる",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					return mock_usecase.NewMockStockBrandInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("12345678901")
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/stock-brands?symbol_prefix=12345678901", nil),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "symbol_prefixが長すぎます\n",
+		},
+		{
+			name: "異常系: symbol_prefixに不正な文字が含まれる",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
+					return mock_usecase.NewMockStockBrandInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("7203%")
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/stock-brands?symbol_prefix=7203%25", nil),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "symbol_prefixは英数字である必要があります\n",
+		},
+		{
 			name: "異常系: symbol_fromが長すぎる",
 			fields: fields{
 				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
@@ -183,6 +268,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("12345678901")
 					return m
 				},
@@ -201,6 +287,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("1234@")
 					return m
 				},
@@ -219,6 +306,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("abc")
 					return m
@@ -238,6 +326,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("0")
 					return m
@@ -257,6 +346,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("10001")
 					return m
@@ -276,6 +366,7 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("invalid")
@@ -294,12 +385,13 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
 					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
 					m.EXPECT().
-						GetStockBrands(gomock.Any(), "", 0, false).
+						GetStockBrands(gomock.Any(), "", "", 0, false).
 						Return(nil, errors.New("db error"))
 					return m
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("")
@@ -318,12 +410,13 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
 					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
 					m.EXPECT().
-						GetStockBrands(gomock.Any(), "", 0, true).
+						GetStockBrands(gomock.Any(), "", "", 0, true).
 						Return(nil, errors.New("db error"))
 					return m
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("true")
@@ -342,12 +435,13 @@ func TestStockBrandHandler_GetStockBrands(t *testing.T) {
 				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandInteractor {
 					m := mock_usecase.NewMockStockBrandInteractor(ctrl)
 					m.EXPECT().
-						GetStockBrands(gomock.Any(), "1301", 0, true).
+						GetStockBrands(gomock.Any(), "", "1301", 0, true).
 						Return(nil, errors.New("db error"))
 					return m
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_prefix").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol_from").Return("1301")
 					m.EXPECT().GetQueryParam(gomock.Any(), "limit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "only_main_markets").Return("true")

--- a/infrastructure/database/analyze_stock_brand_price_history.go
+++ b/infrastructure/database/analyze_stock_brand_price_history.go
@@ -270,7 +270,7 @@ func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindMultipleSignals(ctx c
 
 	whereClause := dateCondition
 	if filter.Cursor != "" {
-		whereClause += " AND h.ticker_symbol > ?"
+		whereClause += " AND h.ticker_symbol >= ?"
 		args = append(args, filter.Cursor)
 	}
 

--- a/infrastructure/database/high_volume_stock_brand.go
+++ b/infrastructure/database/high_volume_stock_brand.go
@@ -61,7 +61,7 @@ func (r *HighVolumeStockBrandRepositoryImpl) FindWithPagination(
 
 	// Apply cursor condition
 	if symbolFrom != "" {
-		query = query.Where(hvb.TickerSymbol.Gt(symbolFrom))
+		query = query.Where(hvb.TickerSymbol.Gte(symbolFrom))
 	}
 
 	// Apply limit

--- a/infrastructure/database/high_volume_stock_brand_pagination_test.go
+++ b/infrastructure/database/high_volume_stock_brand_pagination_test.go
@@ -212,7 +212,7 @@ func TestHighVolumeStockBrandRepositoryImpl_FindWithPagination(t *testing.T) {
 				err = query.HighVolumeStockBrand.Create(hvStockBrand1, hvStockBrand2, hvStockBrand3)
 				require.NoError(t, err)
 			},
-			symbolFrom: "3001",
+			symbolFrom: "3002",
 			limit:      2,
 			wantCount:  2,
 			wantFirst:  "3002",

--- a/infrastructure/database/stock_brand.go
+++ b/infrastructure/database/stock_brand.go
@@ -109,9 +109,14 @@ func (si *StockBrandRepositoryImpl) FindWithFilter(ctx context.Context, filter *
 		q = q.Where(tx.StockBrand.MarketCode.In(filter.MarketCodes...))
 	}
 
-	// ページネーション: シンボル開始位置
+	// 前方一致フィルタ
+	if filter.SymbolPrefix != "" {
+		q = q.Where(tx.StockBrand.TickerSymbol.Like(filter.SymbolPrefix + "%"))
+	}
+
+	// ページネーション: シンボル開始位置 (inclusive)
 	if filter.SymbolFrom != "" {
-		q = q.Where(tx.StockBrand.TickerSymbol.Gt(filter.SymbolFrom))
+		q = q.Where(tx.StockBrand.TickerSymbol.Gte(filter.SymbolFrom))
 	}
 
 	// ソート: シンボル昇順

--- a/infrastructure/database/stock_brand_with_filter_test.go
+++ b/infrastructure/database/stock_brand_with_filter_test.go
@@ -143,12 +143,12 @@ func TestStockBrandRepositoryImpl_FindWithFilter(t *testing.T) {
 			},
 		},
 		{
-			name:    "ページネーション_symbolFrom指定",
+			name:    "ページネーション_symbolFrom指定 (inclusive)",
 			filter:  models.NewStockBrandFilter().WithPagination("1002", 0),
-			wantLen: 3,
+			wantLen: 4,
 			wantErr: false,
 			checkFirst: func(t *testing.T, brands []*models.StockBrand) {
-				assert.Equal(t, "1003", brands[0].TickerSymbol)
+				assert.Equal(t, "1002", brands[0].TickerSymbol)
 			},
 		},
 		{
@@ -162,8 +162,8 @@ func TestStockBrandRepositoryImpl_FindWithFilter(t *testing.T) {
 			},
 		},
 		{
-			name:    "ページネーション_symbolFromとlimit両方指定",
-			filter:  models.NewStockBrandFilter().WithPagination("1001", 2),
+			name:    "ページネーション_symbolFromとlimit両方指定 (inclusive)",
+			filter:  models.NewStockBrandFilter().WithPagination("1002", 2),
 			wantLen: 2,
 			wantErr: false,
 			checkFirst: func(t *testing.T, brands []*models.StockBrand) {
@@ -172,10 +172,10 @@ func TestStockBrandRepositoryImpl_FindWithFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "主要市場とページネーション組み合わせ",
+			name: "主要市場とページネーション組み合わせ (inclusive)",
 			filter: models.NewStockBrandFilter().
 				WithOnlyMainMarkets().
-				WithPagination("1002", 2),
+				WithPagination("1003", 2),
 			wantLen: 2,
 			wantErr: false,
 			checkFirst: func(t *testing.T, brands []*models.StockBrand) {
@@ -186,6 +186,32 @@ func TestStockBrandRepositoryImpl_FindWithFilter(t *testing.T) {
 					assert.Contains(t, []string{"111", "112", "113"}, b.MarketCode)
 				}
 			},
+		},
+		{
+			name:    "前方一致_symbolPrefix指定",
+			filter:  models.NewStockBrandFilter().WithSymbolPrefix("100"),
+			wantLen: 5,
+			wantErr: false,
+			checkFirst: func(t *testing.T, brands []*models.StockBrand) {
+				for _, b := range brands {
+					assert.True(t, len(b.TickerSymbol) >= 3 && b.TickerSymbol[:3] == "100")
+				}
+			},
+		},
+		{
+			name:    "前方一致_symbolPrefixで絞り込み",
+			filter:  models.NewStockBrandFilter().WithSymbolPrefix("1003"),
+			wantLen: 1,
+			wantErr: false,
+			checkFirst: func(t *testing.T, brands []*models.StockBrand) {
+				assert.Equal(t, "1003", brands[0].TickerSymbol)
+			},
+		},
+		{
+			name:    "前方一致_symbolPrefixに一致なし",
+			filter:  models.NewStockBrandFilter().WithSymbolPrefix("9999"),
+			wantLen: 0,
+			wantErr: false,
 		},
 		{
 			name: "主要市場フラグとMarketCodes両方指定_主要市場フラグが優先される",

--- a/mock/usecase/stock_brands_interactor.go
+++ b/mock/usecase/stock_brands_interactor.go
@@ -118,18 +118,18 @@ func (mr *MockStockBrandInteractorMockRecorder) GetNextFinAnnouncement(ctx, tick
 }
 
 // GetStockBrands mocks base method.
-func (m *MockStockBrandInteractor) GetStockBrands(ctx context.Context, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error) {
+func (m *MockStockBrandInteractor) GetStockBrands(ctx context.Context, symbolPrefix, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStockBrands", ctx, symbolFrom, limit, onlyMainMarkets)
+	ret := m.ctrl.Call(m, "GetStockBrands", ctx, symbolPrefix, symbolFrom, limit, onlyMainMarkets)
 	ret0, _ := ret[0].(*models.PaginatedStockBrands)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetStockBrands indicates an expected call of GetStockBrands.
-func (mr *MockStockBrandInteractorMockRecorder) GetStockBrands(ctx, symbolFrom, limit, onlyMainMarkets any) *gomock.Call {
+func (mr *MockStockBrandInteractorMockRecorder) GetStockBrands(ctx, symbolPrefix, symbolFrom, limit, onlyMainMarkets any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStockBrands", reflect.TypeOf((*MockStockBrandInteractor)(nil).GetStockBrands), ctx, symbolFrom, limit, onlyMainMarkets)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStockBrands", reflect.TypeOf((*MockStockBrandInteractor)(nil).GetStockBrands), ctx, symbolPrefix, symbolFrom, limit, onlyMainMarkets)
 }
 
 // SyncFinAnnouncements mocks base method.

--- a/models/stock_brand.go
+++ b/models/stock_brand.go
@@ -39,7 +39,9 @@ type StockBrandFilter struct {
 	// MarketCodes 指定された市場コードでフィルタ（nilの場合は全市場）
 	// OnlyMainMarketsがtrueの場合、このフィールドは無視される
 	MarketCodes []string
-	// SymbolFrom ページネーション用の開始シンボル（空文字列の場合は最初から）
+	// SymbolPrefix 銘柄コードの前方一致フィルタ（空文字列の場合はフィルタなし）
+	SymbolPrefix string
+	// SymbolFrom ページネーション用の開始シンボル（空文字列の場合は最初から、inclusive）
 	SymbolFrom string
 	// Limit 取得件数上限（0の場合は全件取得）
 	Limit int
@@ -50,6 +52,7 @@ func NewStockBrandFilter() *StockBrandFilter {
 	return &StockBrandFilter{
 		OnlyMainMarkets: false,
 		MarketCodes:     nil,
+		SymbolPrefix:    "",
 		SymbolFrom:      "",
 		Limit:           0,
 	}
@@ -64,6 +67,12 @@ func (f *StockBrandFilter) WithOnlyMainMarkets() *StockBrandFilter {
 // WithMarketCodes 指定市場コードに絞り込む
 func (f *StockBrandFilter) WithMarketCodes(codes ...string) *StockBrandFilter {
 	f.MarketCodes = codes
+	return f
+}
+
+// WithSymbolPrefix 銘柄コードの前方一致フィルタを設定
+func (f *StockBrandFilter) WithSymbolPrefix(prefix string) *StockBrandFilter {
+	f.SymbolPrefix = prefix
 	return f
 }
 

--- a/test/e2e/api_get_stock_brands_test.go
+++ b/test/e2e/api_get_stock_brands_test.go
@@ -188,7 +188,7 @@ func TestE2E_GetStockBrands(t *testing.T) {
 				err := stockBrandRepo.UpsertStockBrands(context.Background(), brands)
 				require.NoError(t, err)
 			},
-			query:      "?symbol_from=1301&limit=2",
+			query:      "?symbol_from=1332&limit=2",
 			wantStatus: http.StatusOK,
 			check: func(t *testing.T, body []byte) {
 				var res handler.GetStockBrandsResponse
@@ -298,7 +298,7 @@ func TestE2E_GetStockBrands(t *testing.T) {
 				err := stockBrandRepo.UpsertStockBrands(context.Background(), brands)
 				require.NoError(t, err)
 			},
-			query:      "?symbol_from=1301&limit=10&only_main_markets=true",
+			query:      "?symbol_from=1332&limit=10&only_main_markets=true",
 			wantStatus: http.StatusOK,
 			check: func(t *testing.T, body []byte) {
 				var res handler.GetStockBrandsResponse

--- a/test/e2e/grpc_get_high_volume_stock_brands_test.go
+++ b/test/e2e/grpc_get_high_volume_stock_brands_test.go
@@ -172,8 +172,8 @@ func TestE2E_GetHighVolumeStockBrands(t *testing.T) {
 				
 				require.NotNil(t, resp.Pagination)
 				assert.Equal(t, int32(2), resp.Pagination.Limit)
-				// 次のカーソルは2件目のTickerSymbol
-				assert.Equal(t, "2002", resp.Pagination.NextCursor)
+				// 次のカーソルは次ページ先頭のTickerSymbol (inclusive)
+				assert.Equal(t, "2003", resp.Pagination.NextCursor)
 			},
 		},
 		{
@@ -201,13 +201,13 @@ func TestE2E_GetHighVolumeStockBrands(t *testing.T) {
 				}
 			},
 			req: &pb.GetHighVolumeStockBrandsRequest{
-				SymbolFrom: "3001",
+				SymbolFrom: "3002",
 				Limit:      2,
 			},
 			check: func(t *testing.T, resp *pb.GetHighVolumeStockBrandsResponse, err error) {
 				require.NoError(t, err)
 				require.Len(t, resp.Brands, 2)
-				// 3001より大きいものから取得開始 -> 3002, 3003
+				// 3002以降 (inclusive) から取得開始 -> 3002, 3003
 				assert.Equal(t, "3002", resp.Brands[0].TickerSymbol)
 				assert.Equal(t, "3003", resp.Brands[1].TickerSymbol)
 

--- a/usecase/get_high_volume_stock_brands.go
+++ b/usecase/get_high_volume_stock_brands.go
@@ -65,10 +65,9 @@ func (u *getHighVolumeStockBrandsInteractor) ExecuteWithPagination(
 
 	// Set next cursor if there are more results
 	if limit > 0 && len(brands) > limit {
-		// NextCursorは現在のページの最後の要素のTickerSymbol
-		lastBrand := brands[limit-1]
-		result.NextCursor = &lastBrand.TickerSymbol
-		result.Brands = brands[:limit] // Trim to requested limit
+		nextBrand := brands[limit]
+		result.NextCursor = &nextBrand.TickerSymbol
+		result.Brands = brands[:limit]
 	}
 
 	return result, nil

--- a/usecase/get_high_volume_stock_brands_test.go
+++ b/usecase/get_high_volume_stock_brands_test.go
@@ -182,7 +182,7 @@ func TestGetHighVolumeStockBrandsInteractor_ExecuteWithPagination(t *testing.T) 
 				limit:      2,
 			},
 			want: func() *models.PaginatedHighVolumeStockBrands {
-				nextCursor := "1002"
+				nextCursor := "1003"
 				return &models.PaginatedHighVolumeStockBrands{
 					Brands: []*models.HighVolumeStockBrand{
 						models.NewHighVolumeStockBrand("uuid-1", "1001", "Test Brand 1", 1000000, now),
@@ -195,12 +195,12 @@ func TestGetHighVolumeStockBrandsInteractor_ExecuteWithPagination(t *testing.T) 
 			wantErr: false,
 		},
 		{
-			name: "正常系: symbolFromを指定して次ページを取得",
+			name: "正常系: symbolFromを指定して次ページを取得 (inclusive)",
 			fields: fields{
 				highVolumeStockBrandRepo: func(ctrl *gomock.Controller) *mock_repositories.MockHighVolumeStockBrandRepository {
 					mock := mock_repositories.NewMockHighVolumeStockBrandRepository(ctrl)
 					mock.EXPECT().
-						FindWithPagination(gomock.Any(), gomock.Eq("1002"), gomock.Eq(3)).
+						FindWithPagination(gomock.Any(), gomock.Eq("1003"), gomock.Eq(3)).
 						Return([]*models.HighVolumeStockBrand{
 							models.NewHighVolumeStockBrand("uuid-3", "1003", "Test Brand 3", 3000000, now),
 							models.NewHighVolumeStockBrand("uuid-4", "1004", "Test Brand 4", 4000000, now),
@@ -211,11 +211,11 @@ func TestGetHighVolumeStockBrandsInteractor_ExecuteWithPagination(t *testing.T) 
 			},
 			args: args{
 				ctx:        context.Background(),
-				symbolFrom: "1002",
+				symbolFrom: "1003",
 				limit:      2,
 			},
 			want: func() *models.PaginatedHighVolumeStockBrands {
-				nextCursor := "1004"
+				nextCursor := "1005"
 				return &models.PaginatedHighVolumeStockBrands{
 					Brands: []*models.HighVolumeStockBrand{
 						models.NewHighVolumeStockBrand("uuid-3", "1003", "Test Brand 3", 3000000, now),

--- a/usecase/get_stock_brands.go
+++ b/usecase/get_stock_brands.go
@@ -9,10 +9,11 @@ import (
 )
 
 // GetStockBrands 銘柄一覧を取得する
-// symbolFrom: 取得開始シンボル（ページネーション用）
+// symbolPrefix: 銘柄コードの前方一致フィルタ（空文字列の場合はフィルタなし）
+// symbolFrom: ページネーション用の開始シンボル（inclusive、空文字列の場合は最初から）
 // limit: 取得件数上限
 // onlyMainMarkets: true の場合、マーケットコード 111, 112, 113 のみを取得
-func (si *stockBrandInteractorImpl) GetStockBrands(ctx context.Context, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error) {
+func (si *stockBrandInteractorImpl) GetStockBrands(ctx context.Context, symbolPrefix string, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error) {
 	// limitが指定されている場合、次ページの有無を判定するため+1件取得
 	fetchLimit := limit
 	if limit > 0 {
@@ -20,6 +21,9 @@ func (si *stockBrandInteractorImpl) GetStockBrands(ctx context.Context, symbolFr
 	}
 
 	filter := models.NewStockBrandFilter().WithPagination(symbolFrom, fetchLimit)
+	if symbolPrefix != "" {
+		filter = filter.WithSymbolPrefix(symbolPrefix)
+	}
 	if onlyMainMarkets {
 		filter = filter.WithOnlyMainMarkets()
 	}

--- a/usecase/get_stock_brands_test.go
+++ b/usecase/get_stock_brands_test.go
@@ -19,6 +19,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 	}
 	type args struct {
 		ctx             context.Context
+		symbolPrefix    string
 		symbolFrom      string
 		limit           int
 		onlyMainMarkets bool
@@ -39,6 +40,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: false,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "",
 						Limit:           0,
 					})).Return([]*models.StockBrand{
@@ -60,6 +62,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "",
 				limit:           0,
 				onlyMainMarkets: false,
@@ -93,6 +96,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: false,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "1000",
 						Limit:           11,
 					})).Return([]*models.StockBrand{
@@ -168,6 +172,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "1000",
 				limit:           10,
 				onlyMainMarkets: false,
@@ -251,6 +256,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: true,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "",
 						Limit:           0,
 					})).Return([]*models.StockBrand{
@@ -272,6 +278,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "",
 				limit:           0,
 				onlyMainMarkets: true,
@@ -305,6 +312,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: true,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "1000",
 						Limit:           11,
 					})).Return([]*models.StockBrand{
@@ -380,6 +388,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "1000",
 				limit:           10,
 				onlyMainMarkets: true,
@@ -463,6 +472,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: false,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "",
 						Limit:           0,
 					})).Return(nil, errors.New("db error"))
@@ -471,6 +481,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "",
 				limit:           0,
 				onlyMainMarkets: false,
@@ -487,6 +498,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: false,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "1000",
 						Limit:           11,
 					})).Return(nil, errors.New("db error"))
@@ -495,6 +507,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "1000",
 				limit:           10,
 				onlyMainMarkets: false,
@@ -510,6 +523,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: true,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "",
 						Limit:           0,
 					})).Return(nil, errors.New("db error"))
@@ -518,6 +532,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "",
 				limit:           0,
 				onlyMainMarkets: true,
@@ -534,6 +549,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
 						OnlyMainMarkets: true,
 						MarketCodes:     nil,
+						SymbolPrefix:    "",
 						SymbolFrom:      "1000",
 						Limit:           11,
 					})).Return(nil, errors.New("db error"))
@@ -542,12 +558,56 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			},
 			args: args{
 				ctx:             context.Background(),
+				symbolPrefix:    "",
 				symbolFrom:      "1000",
 				limit:           10,
 				onlyMainMarkets: true,
 			},
 			want:    nil,
 			wantErr: true,
+		},
+		{
+			name: "正常系: symbol_prefix前方一致検索",
+			fields: fields{
+				stockBrandRepository: func(ctrl *gomock.Controller) repositories.StockBrandRepository {
+					m := mock_repositories.NewMockStockBrandRepository(ctrl)
+					m.EXPECT().FindWithFilter(gomock.Any(), gomock.Eq(&models.StockBrandFilter{
+						OnlyMainMarkets: false,
+						MarketCodes:     nil,
+						SymbolPrefix:    "7203",
+						SymbolFrom:      "",
+						Limit:           0,
+					})).Return([]*models.StockBrand{
+						{
+							ID:           "1",
+							TickerSymbol: "7203",
+							Name:         "トヨタ自動車",
+							MarketCode:   "111",
+						},
+					}, nil)
+					return m
+				},
+			},
+			args: args{
+				ctx:             context.Background(),
+				symbolPrefix:    "7203",
+				symbolFrom:      "",
+				limit:           0,
+				onlyMainMarkets: false,
+			},
+			want: &models.PaginatedStockBrands{
+				Brands: []*models.StockBrand{
+					{
+						ID:           "1",
+						TickerSymbol: "7203",
+						Name:         "トヨタ自動車",
+						MarketCode:   "111",
+					},
+				},
+				NextCursor: nil,
+				Limit:      0,
+			},
+			wantErr: false,
 		},
 	}
 
@@ -559,7 +619,7 @@ func TestStockBrandInteractorImpl_GetStockBrands(t *testing.T) {
 			r := tt.fields.stockBrandRepository(ctrl)
 			si := NewStockBrandInteractor(nil, r, nil, nil, nil, nil, nil, nil, nil)
 
-			got, err := si.GetStockBrands(tt.args.ctx, tt.args.symbolFrom, tt.args.limit, tt.args.onlyMainMarkets)
+			got, err := si.GetStockBrands(tt.args.ctx, tt.args.symbolPrefix, tt.args.symbolFrom, tt.args.limit, tt.args.onlyMainMarkets)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("StockBrandInteractorImpl.GetStockBrands() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/usecase/stock_brands_interactor.go
+++ b/usecase/stock_brands_interactor.go
@@ -26,7 +26,7 @@ type stockBrandInteractorImpl struct {
 
 type StockBrandInteractor interface {
 	UpdateStockBrands(ctx context.Context, t time.Time) error
-	GetStockBrands(ctx context.Context, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error)
+	GetStockBrands(ctx context.Context, symbolPrefix string, symbolFrom string, limit int, onlyMainMarkets bool) (*models.PaginatedStockBrands, error)
 	GetAnalyzeStockBrandPriceHistories(ctx context.Context, filter *models.AnalyzeStockBrandPriceHistoryFilter) (*models.PaginatedAnalyzeStockBrandPriceHistories, error)
 	GetMultipleSignalStocks(ctx context.Context, filter *models.MultipleSignalStockFilter) (*models.PaginatedMultipleSignalStocks, error)
 	SyncFinAnnouncements(ctx context.Context) error


### PR DESCRIPTION
## Summary

- `symbol_from` のセマンティクスを全エンドポイントで **exclusive (Gt) → inclusive (Gte / `>=`)** に統一
  - DB クエリ3箇所 (stock_brand, high_volume_stock_brand, analyze_stock_brand_price_history) を修正
  - `get_high_volume_stock_brands` の `next_cursor` 取得を `brands[limit-1]` → `brands[limit]` に修正し、他 usecase との一貫性を回復
- `/stock-brands` に **`symbol_prefix` クエリパラメータを新設** (`LIKE 'xxx%'` 前方一致)
  - `StockBrandFilter.SymbolPrefix` フィールド追加
  - `GetStockBrands` usecase インターフェースに `symbolPrefix` 引数追加
  - ハンドラに `symbol_prefix` のパース・バリデーション追加 (長さ ≤ 10, 英数字のみ)
- unit / E2E テストを inclusive 仕様に合わせて更新

## Background

フロント側で検索文字列を `symbol_from` (カーソル用) に流用していたバグの修正と合わせ、バックエンド側の根本原因 (exclusive cursor のページ抜けバグ) も同時修正。

## Test plan

- [x] `ENVCODE=unit go test ./...` 全通過
- [x] E2E テスト (test/e2e) 全通過
- [x] `make lint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)