### PR TITLE
feat: add daytrade risk reward aggregates

### DIFF
--- a/infrastructure/database/daytrade_execution.go
+++ b/infrastructure/database/daytrade_execution.go
@@ -61,9 +61,13 @@ func (r *DaytradeExecutionRepositoryImpl) BulkInsertIgnore(ctx context.Context, 
 }
 
 type aggregateRow struct {
-	BucketDate sql.NullString `gorm:"column:bucket_date"`
-	ProfitLoss int64          `gorm:"column:profit_loss"`
-	TradeCount int            `gorm:"column:trade_count"`
+	BucketDate  sql.NullString `gorm:"column:bucket_date"`
+	ProfitLoss  int64          `gorm:"column:profit_loss"`
+	TradeCount  int            `gorm:"column:trade_count"`
+	GrossProfit int64          `gorm:"column:gross_profit"`
+	GrossLoss   int64          `gorm:"column:gross_loss"`
+	WinCount    int            `gorm:"column:win_count"`
+	LossCount   int            `gorm:"column:loss_count"`
 }
 
 func (r *DaytradeExecutionRepositoryImpl) Aggregate(ctx context.Context, from, to *time.Time, g models.DaytradeSummaryGranularity) ([]*models.DaytradeSummaryBucket, error) {
@@ -92,7 +96,16 @@ func (r *DaytradeExecutionRepositoryImpl) Aggregate(ctx context.Context, from, t
 
 	query := db.WithContext(ctx).
 		Table("daytrade_executions").
-		Select(fmt.Sprintf("%s, SUM(profit_loss) AS profit_loss, COUNT(*) AS trade_count", selectExpr))
+		Select(fmt.Sprintf(
+			"%s,"+
+				" SUM(profit_loss) AS profit_loss,"+
+				" COUNT(*) AS trade_count,"+
+				" COALESCE(SUM(CASE WHEN profit_loss > 0 THEN profit_loss ELSE 0 END), 0) AS gross_profit,"+
+				" COALESCE(SUM(CASE WHEN profit_loss < 0 THEN profit_loss ELSE 0 END), 0) AS gross_loss,"+
+				" COALESCE(SUM(CASE WHEN profit_loss > 0 THEN 1 ELSE 0 END), 0) AS win_count,"+
+				" COALESCE(SUM(CASE WHEN profit_loss < 0 THEN 1 ELSE 0 END), 0) AS loss_count",
+			selectExpr,
+		))
 
 	if from != nil {
 		query = query.Where("executed_on >= ?", from.Format("2006-01-02"))
@@ -113,8 +126,12 @@ func (r *DaytradeExecutionRepositoryImpl) Aggregate(ctx context.Context, from, t
 	buckets := make([]*models.DaytradeSummaryBucket, 0, len(rows))
 	for _, row := range rows {
 		bucket := &models.DaytradeSummaryBucket{
-			ProfitLoss: row.ProfitLoss,
-			TradeCount: row.TradeCount,
+			ProfitLoss:  row.ProfitLoss,
+			TradeCount:  row.TradeCount,
+			GrossProfit: row.GrossProfit,
+			GrossLoss:   row.GrossLoss,
+			WinCount:    row.WinCount,
+			LossCount:   row.LossCount,
 		}
 		if row.BucketDate.Valid {
 			s := row.BucketDate.String
@@ -130,6 +147,8 @@ type symbolSummaryRow struct {
 	BrandName    string `gorm:"column:brand_name"`
 	ProfitLoss   int64  `gorm:"column:profit_loss"`
 	TradeCount   int    `gorm:"column:trade_count"`
+	GrossProfit  int64  `gorm:"column:gross_profit"`
+	GrossLoss    int64  `gorm:"column:gross_loss"`
 	WinCount     int    `gorm:"column:win_count"`
 	LossCount    int    `gorm:"column:loss_count"`
 }
@@ -148,8 +167,10 @@ func (r *DaytradeExecutionRepositoryImpl) AggregateByTickerSymbol(ctx context.Co
 				" COALESCE(MAX(b.name), MAX(d.brand_name)) AS brand_name," +
 				" SUM(d.profit_loss) AS profit_loss," +
 				" COUNT(*) AS trade_count," +
-				" SUM(CASE WHEN d.profit_loss > 0 THEN 1 ELSE 0 END) AS win_count," +
-				" SUM(CASE WHEN d.profit_loss < 0 THEN 1 ELSE 0 END) AS loss_count",
+				" COALESCE(SUM(CASE WHEN d.profit_loss > 0 THEN d.profit_loss ELSE 0 END), 0) AS gross_profit," +
+				" COALESCE(SUM(CASE WHEN d.profit_loss < 0 THEN d.profit_loss ELSE 0 END), 0) AS gross_loss," +
+				" COALESCE(SUM(CASE WHEN d.profit_loss > 0 THEN 1 ELSE 0 END), 0) AS win_count," +
+				" COALESCE(SUM(CASE WHEN d.profit_loss < 0 THEN 1 ELSE 0 END), 0) AS loss_count",
 		).
 		Group("d.ticker_symbol").
 		Order("profit_loss DESC")
@@ -173,6 +194,8 @@ func (r *DaytradeExecutionRepositoryImpl) AggregateByTickerSymbol(ctx context.Co
 			BrandName:    row.BrandName,
 			ProfitLoss:   row.ProfitLoss,
 			TradeCount:   row.TradeCount,
+			GrossProfit:  row.GrossProfit,
+			GrossLoss:    row.GrossLoss,
 			WinCount:     row.WinCount,
 			LossCount:    row.LossCount,
 		})

--- a/models/daytrade_execution.go
+++ b/models/daytrade_execution.go
@@ -45,9 +45,13 @@ func (g DaytradeSummaryGranularity) Valid() bool {
 }
 
 type DaytradeSummaryBucket struct {
-	BucketDate *string `json:"date"`
-	ProfitLoss int64   `json:"profitLoss"`
-	TradeCount int     `json:"tradeCount"`
+	BucketDate  *string `json:"date"`
+	ProfitLoss  int64   `json:"profitLoss"`
+	TradeCount  int     `json:"tradeCount"`
+	GrossProfit int64   `json:"grossProfit"`
+	GrossLoss   int64   `json:"grossLoss"`
+	WinCount    int     `json:"winCount"`
+	LossCount   int     `json:"lossCount"`
 }
 
 type DaytradeImportResult struct {
@@ -63,6 +67,8 @@ type DaytradeSymbolSummary struct {
 	BrandName    string `json:"brandName"`
 	ProfitLoss   int64  `json:"profitLoss"`
 	TradeCount   int    `json:"tradeCount"`
+	GrossProfit  int64  `json:"grossProfit"`
+	GrossLoss    int64  `json:"grossLoss"`
 	WinCount     int    `json:"winCount"`
 	LossCount    int    `json:"lossCount"`
 }

--- a/test/e2e/api_daytrade_test.go
+++ b/test/e2e/api_daytrade_test.go
@@ -71,7 +71,7 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		var body struct {
-			Granularity string                         `json:"granularity"`
+			Granularity string                          `json:"granularity"`
 			Buckets     []*models.DaytradeSummaryBucket `json:"buckets"`
 		}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
@@ -92,6 +92,10 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Len(t, body.Buckets, 1)
 		assert.Nil(t, body.Buckets[0].BucketDate)
 		assert.Equal(t, 3, body.Buckets[0].TradeCount)
+		assert.Equal(t, int64(3500), body.Buckets[0].GrossProfit)
+		assert.Equal(t, int64(-800), body.Buckets[0].GrossLoss)
+		assert.Equal(t, 2, body.Buckets[0].WinCount)
+		assert.Equal(t, 1, body.Buckets[0].LossCount)
 	})
 
 	t.Run("指定日の明細取得", func(t *testing.T) {
@@ -153,8 +157,8 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		var body struct {
-			From  *string                        `json:"from"`
-			To    *string                        `json:"to"`
+			From  *string                         `json:"from"`
+			To    *string                         `json:"to"`
 			Items []*models.DaytradeSymbolSummary `json:"items"`
 		}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
@@ -166,11 +170,15 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Equal(t, "9984", body.Items[0].TickerSymbol)
 		assert.Equal(t, int64(3500), body.Items[0].ProfitLoss) // 1460 + 2040
 		assert.Equal(t, 2, body.Items[0].TradeCount)
+		assert.Equal(t, int64(3500), body.Items[0].GrossProfit)
+		assert.Equal(t, int64(0), body.Items[0].GrossLoss)
 		assert.Equal(t, 2, body.Items[0].WinCount)
 		assert.Equal(t, 0, body.Items[0].LossCount)
 
 		assert.Equal(t, "5803", body.Items[1].TickerSymbol)
 		assert.Equal(t, int64(-800), body.Items[1].ProfitLoss)
+		assert.Equal(t, int64(0), body.Items[1].GrossProfit)
+		assert.Equal(t, int64(-800), body.Items[1].GrossLoss)
 		assert.Equal(t, 1, body.Items[1].TradeCount)
 		assert.Equal(t, 0, body.Items[1].WinCount)
 		assert.Equal(t, 1, body.Items[1].LossCount)
@@ -184,8 +192,8 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 
 		var body struct {
-			From  *string                        `json:"from"`
-			To    *string                        `json:"to"`
+			From  *string                         `json:"from"`
+			To    *string                         `json:"to"`
 			Items []*models.DaytradeSymbolSummary `json:"items"`
 		}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
@@ -199,6 +207,8 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Equal(t, "9984", body.Items[0].TickerSymbol)
 		assert.Equal(t, int64(1460), body.Items[0].ProfitLoss)
 		assert.Equal(t, 1, body.Items[0].TradeCount)
+		assert.Equal(t, int64(1460), body.Items[0].GrossProfit)
+		assert.Equal(t, int64(0), body.Items[0].GrossLoss)
 	})
 
 	t.Run("銘柄別集計_from>toで400", func(t *testing.T) {
@@ -262,7 +272,7 @@ func TestE2E_Daytrade(t *testing.T) {
 		// 論理削除済みなので b.name は NULL → d.brand_name にフォールバック
 		assert.Equal(t, "9984", body.Items[0].TickerSymbol)
 		assert.NotEqual(t, "削除済み銘柄名", body.Items[0].BrandName) // 削除済み名は使わない
-		assert.NotEmpty(t, body.Items[0].BrandName)                  // CSV 由来の名前
+		assert.NotEmpty(t, body.Items[0].BrandName)            // CSV 由来の名前
 	})
 
 	// --- replace モード ---
@@ -283,8 +293,8 @@ func TestE2E_Daytrade(t *testing.T) {
 		require.NoError(t, json.NewDecoder(resp2.Body).Decode(&result))
 		resp2.Body.Close()
 
-		assert.Equal(t, 3, result.Deleted)   // 旧 3 件が削除された
-		assert.Equal(t, 3, result.Inserted)  // 新 3 件が挿入された
+		assert.Equal(t, 3, result.Deleted)  // 旧 3 件が削除された
+		assert.Equal(t, 3, result.Inserted) // 新 3 件が挿入された
 		assert.Equal(t, 0, result.Skipped)
 		assert.Equal(t, 3, result.TotalRow)
 	})


### PR DESCRIPTION
## Summary
- Add gross profit/loss and win/loss counts to daytrade summary responses
- Aggregate RR ratio inputs for both period buckets and symbol summaries
- Cover the new response fields in daytrade E2E tests

## Tests
- go test ./test/e2e -run TestE2E_Daytrade
- go test ./usecase ./models ./repositories ./infrastructure/database ./test/e2e -run Daytrade