### PR TITLE
feat: デイトレ期間統計に最大ランアップ (MaxRunup) を追加

### DIFF
--- a/models/daytrade_execution.go
+++ b/models/daytrade_execution.go
@@ -96,5 +96,6 @@ type DaytradePeriodStats struct {
 	MaxProfit     int64 `json:"maxProfit"`
 	MaxLoss       int64 `json:"maxLoss"`
 	MaxDrawdown   int64 `json:"maxDrawdown"`
+	MaxRunup      int64 `json:"maxRunup"`
 	MaxLossStreak int   `json:"maxLossStreak"`
 }

--- a/test/e2e/api_daytrade_test.go
+++ b/test/e2e/api_daytrade_test.go
@@ -163,6 +163,7 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Equal(t, int64(2040), body.MaxProfit)
 		assert.Equal(t, int64(-800), body.MaxLoss)
 		assert.GreaterOrEqual(t, body.MaxDrawdown, int64(0))
+		assert.GreaterOrEqual(t, body.MaxRunup, int64(0))
 		assert.GreaterOrEqual(t, body.MaxLossStreak, 0)
 	})
 

--- a/usecase/daytrade/equity_stats.go
+++ b/usecase/daytrade/equity_stats.go
@@ -3,12 +3,14 @@ package daytrade
 import "github.com/Code0716/stock-price-repository/models"
 
 // ComputeEquityStats は日次バケット（executed_on 昇順）から
-// 最大ドローダウン（ピーク初期値 0・正の金額）と最大連敗日数を計算する。
+// 最大ドローダウン（ピーク初期値 0）・最大ランアップ（谷初期値 0）・
+// 最大連敗日数を計算する。いずれも正の金額。
 //
 // 約定日が日付精度のみのため、連敗はトレード単位ではなく「負け日の連続」として定義する。
-func ComputeEquityStats(daily []*models.DaytradeSummaryBucket) (maxDrawdown int64, maxLossStreak int) {
+func ComputeEquityStats(daily []*models.DaytradeSummaryBucket) (maxDrawdown, maxRunup int64, maxLossStreak int) {
 	var cumulative int64
-	var peak int64 // ピーク初期値 0（全損失なら初日からドローダウンとして計上）
+	var peak int64   // ピーク初期値 0（全損失なら初日からドローダウンとして計上）
+	var trough int64 // 谷初期値 0（全利益なら初日からランアップとして計上）
 	var streak int
 
 	for _, b := range daily {
@@ -21,6 +23,13 @@ func ComputeEquityStats(daily []*models.DaytradeSummaryBucket) (maxDrawdown int6
 			maxDrawdown = dd
 		}
 
+		if cumulative < trough {
+			trough = cumulative
+		}
+		if ru := cumulative - trough; ru > maxRunup {
+			maxRunup = ru
+		}
+
 		if b.ProfitLoss < 0 {
 			streak++
 			if streak > maxLossStreak {
@@ -30,5 +39,5 @@ func ComputeEquityStats(daily []*models.DaytradeSummaryBucket) (maxDrawdown int6
 			streak = 0
 		}
 	}
-	return maxDrawdown, maxLossStreak
+	return maxDrawdown, maxRunup, maxLossStreak
 }

--- a/usecase/daytrade/equity_stats_test.go
+++ b/usecase/daytrade/equity_stats_test.go
@@ -21,30 +21,35 @@ func TestComputeEquityStats(t *testing.T) {
 		name            string
 		daily           []*models.DaytradeSummaryBucket
 		wantMaxDrawdown int64
+		wantMaxRunup    int64
 		wantMaxStreak   int
 	}{
 		{
 			name:            "空スライス",
 			daily:           buckets(),
 			wantMaxDrawdown: 0,
+			wantMaxRunup:    0,
 			wantMaxStreak:   0,
 		},
 		{
 			name:            "全勝（ドローダウンなし・連敗なし）",
 			daily:           buckets(100, 200, 300),
 			wantMaxDrawdown: 0,
+			wantMaxRunup:    600, // cumulative: 100, 300, 600 / trough=0 → max RU=600
 			wantMaxStreak:   0,
 		},
 		{
 			name:            "全敗（ピーク0から即ドローダウン）",
 			daily:           buckets(-100, -200, -300),
 			wantMaxDrawdown: 600, // cumulative: -100, -300, -600 / peak=0 → max DD=600
+			wantMaxRunup:    0,
 			wantMaxStreak:   3,
 		},
 		{
 			name:            "最初が利益でその後下落",
 			daily:           buckets(1000, -400, -200),
 			wantMaxDrawdown: 600, // peak=1000, cumulative=400→最小 / DD=600
+			wantMaxRunup:    1000, // trough=0 → cum=1000 / RU=1000
 			wantMaxStreak:   2,
 		},
 		{
@@ -52,25 +57,36 @@ func TestComputeEquityStats(t *testing.T) {
 			daily:           buckets(-100, 50, -200, -300, 100, -50),
 			wantMaxStreak:   2,   // -200,-300 の 2 連敗が最大
 			wantMaxDrawdown: 550, // peak=0, 最低 cumulative=-550 → DD=550
+			wantMaxRunup:    100, // trough=-550, cumulative=-450 → RU=100
 		},
 		{
 			name:            "ドローダウンが複数の谷を持つ場合",
 			daily:           buckets(1000, -800, 500, -1200),
 			wantMaxDrawdown: 1500, // peak=1000 → cum=-500(day4) → DD=1500
+			wantMaxRunup:    1000, // trough=0 → cum=1000(day1) → RU=1000
 			wantMaxStreak:   1,
 		},
 		{
 			name:            "ブレイクイーブン（profitLoss==0）は連敗をリセット",
 			daily:           buckets(-100, 0, -200),
 			wantMaxDrawdown: 300, // cumulative: -100, -100, -300 / peak=0 → DD=300
-			wantMaxStreak:   1,   // 0 が連敗をリセットする
+			wantMaxRunup:    0,
+			wantMaxStreak:   1, // 0 が連敗をリセットする
+		},
+		{
+			name:            "ランアップが複数の山を持つ場合",
+			daily:           buckets(-1000, 800, -500, 1200),
+			wantMaxDrawdown: 1000, // cum: -1000,-200,-700,500 / peak=0 → DD=1000(day1)
+			wantMaxRunup:    1500, // trough=-1000, cum=500(day4) → RU=1500
+			wantMaxStreak:   1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotDD, gotStreak := ComputeEquityStats(tt.daily)
+			gotDD, gotRunup, gotStreak := ComputeEquityStats(tt.daily)
 			assert.Equal(t, tt.wantMaxDrawdown, gotDD, "maxDrawdown")
+			assert.Equal(t, tt.wantMaxRunup, gotRunup, "maxRunup")
 			assert.Equal(t, tt.wantMaxStreak, gotStreak, "maxLossStreak")
 		})
 	}

--- a/usecase/daytrade_interactor.go
+++ b/usecase/daytrade_interactor.go
@@ -103,7 +103,7 @@ func (u *daytradeInteractorImpl) GetPeriodStats(ctx context.Context, from, to *t
 	if err != nil {
 		return nil, errors.Wrap(err, "Aggregate daily error")
 	}
-	maxDD, maxStreak := daytrade.ComputeEquityStats(daily)
+	maxDD, maxRunup, maxStreak := daytrade.ComputeEquityStats(daily)
 	return &models.DaytradePeriodStats{
 		ProfitLoss:    agg.ProfitLoss,
 		TradeCount:    agg.TradeCount,
@@ -114,6 +114,7 @@ func (u *daytradeInteractorImpl) GetPeriodStats(ctx context.Context, from, to *t
 		MaxProfit:     agg.MaxProfit,
 		MaxLoss:       agg.MaxLoss,
 		MaxDrawdown:   maxDD,
+		MaxRunup:      maxRunup,
 		MaxLossStreak: maxStreak,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- `ComputeEquityStats` に trough 追跡を追加し、最大ランアップ（累積損益の谷から次の山までの最大上昇額）を最大DD と同一1パスで算出
- `DaytradePeriodStats` に `MaxRunup int64 \`json:"maxRunup"\`` フィールドを追加
- `/daytrade/stats` レスポンスに `maxRunup` を含めて返すよう interactor を更新

## Test plan

- [x] `TestComputeEquityStats` — 既存7ケース全てに `wantMaxRunup` を追加、ランアップ対称の新ケース1つ追加、全8テスト通過
- [x] `test/e2e/api_daytrade_test.go` — `/daytrade/stats` に `MaxRunup >= 0` アサーションを追加
- [x] `make test-unit` 全通過
- [x] `make lint` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)