### PR TITLE
refactor(daytrade): チェックボックス廃止・日付範囲で置き換えの差分更新

### DIFF
--- a/entrypoint/api/handler/daytrade_handler.go
+++ b/entrypoint/api/handler/daytrade_handler.go
@@ -36,10 +36,7 @@ func (h *DaytradeHandler) ImportSBICsv(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	opts := usecase.ImportOptions{
-		Replace: r.FormValue("replace") == "true",
-	}
-	result, err := h.usecase.ImportSBICsv(r.Context(), file, opts)
+	result, err := h.usecase.ImportSBICsv(r.Context(), file)
 	if err != nil {
 		if errors.Is(err, daytrade.ErrParse) {
 			http.Error(w, err.Error(), http.StatusUnprocessableEntity)

--- a/infrastructure/database/daytrade_execution.go
+++ b/infrastructure/database/daytrade_execution.go
@@ -29,17 +29,20 @@ func NewDaytradeExecutionRepositoryImpl(db *gorm.DB) repositories.DaytradeExecut
 	}
 }
 
-func (r *DaytradeExecutionRepositoryImpl) DeleteBySource(ctx context.Context, source string) (int64, error) {
+func (r *DaytradeExecutionRepositoryImpl) DeleteBySourceAndDates(ctx context.Context, source string, dates []time.Time) (int64, error) {
+	if len(dates) == 0 {
+		return 0, nil
+	}
 	db, ok := GetTxDB(ctx)
 	if !ok {
 		db = r.db
 	}
 
 	result := db.WithContext(ctx).
-		Where("source = ?", source).
+		Where("source = ? AND executed_on IN ?", source, dates).
 		Delete(&genModel.DaytradeExecution{})
 	if result.Error != nil {
-		return 0, errors.Wrap(result.Error, "DaytradeExecutionRepositoryImpl.DeleteBySource error")
+		return 0, errors.Wrap(result.Error, "DaytradeExecutionRepositoryImpl.DeleteBySourceAndDates error")
 	}
 	return result.RowsAffected, nil
 }

--- a/mock/repositories/daytrade_execution.go
+++ b/mock/repositories/daytrade_execution.go
@@ -102,19 +102,19 @@ func (mr *MockDaytradeExecutionRepositoryMockRecorder) BulkInsertIgnore(ctx, exe
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BulkInsertIgnore", reflect.TypeOf((*MockDaytradeExecutionRepository)(nil).BulkInsertIgnore), ctx, executions)
 }
 
-// DeleteBySource mocks base method.
-func (m *MockDaytradeExecutionRepository) DeleteBySource(ctx context.Context, source string) (int64, error) {
+// DeleteBySourceAndDates mocks base method.
+func (m *MockDaytradeExecutionRepository) DeleteBySourceAndDates(ctx context.Context, source string, dates []time.Time) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBySource", ctx, source)
+	ret := m.ctrl.Call(m, "DeleteBySourceAndDates", ctx, source, dates)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DeleteBySource indicates an expected call of DeleteBySource.
-func (mr *MockDaytradeExecutionRepositoryMockRecorder) DeleteBySource(ctx, source any) *gomock.Call {
+// DeleteBySourceAndDates indicates an expected call of DeleteBySourceAndDates.
+func (mr *MockDaytradeExecutionRepositoryMockRecorder) DeleteBySourceAndDates(ctx, source, dates any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBySource", reflect.TypeOf((*MockDaytradeExecutionRepository)(nil).DeleteBySource), ctx, source)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBySourceAndDates", reflect.TypeOf((*MockDaytradeExecutionRepository)(nil).DeleteBySourceAndDates), ctx, source, dates)
 }
 
 // FindByDate mocks base method.

--- a/mock/usecase/daytrade_interactor.go
+++ b/mock/usecase/daytrade_interactor.go
@@ -16,7 +16,6 @@ import (
 	time "time"
 
 	models "github.com/Code0716/stock-price-repository/models"
-	usecase "github.com/Code0716/stock-price-repository/usecase"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -121,16 +120,16 @@ func (mr *MockDaytradeInteractorMockRecorder) GetSummaryByTickerSymbol(ctx, from
 }
 
 // ImportSBICsv mocks base method.
-func (m *MockDaytradeInteractor) ImportSBICsv(ctx context.Context, r io.Reader, opts usecase.ImportOptions) (*models.DaytradeImportResult, error) {
+func (m *MockDaytradeInteractor) ImportSBICsv(ctx context.Context, r io.Reader) (*models.DaytradeImportResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ImportSBICsv", ctx, r, opts)
+	ret := m.ctrl.Call(m, "ImportSBICsv", ctx, r)
 	ret0, _ := ret[0].(*models.DaytradeImportResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ImportSBICsv indicates an expected call of ImportSBICsv.
-func (mr *MockDaytradeInteractorMockRecorder) ImportSBICsv(ctx, r, opts any) *gomock.Call {
+func (mr *MockDaytradeInteractorMockRecorder) ImportSBICsv(ctx, r any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportSBICsv", reflect.TypeOf((*MockDaytradeInteractor)(nil).ImportSBICsv), ctx, r, opts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImportSBICsv", reflect.TypeOf((*MockDaytradeInteractor)(nil).ImportSBICsv), ctx, r)
 }

--- a/repositories/daytrade_execution.go
+++ b/repositories/daytrade_execution.go
@@ -12,8 +12,8 @@ import (
 type DaytradeExecutionRepository interface {
 	// 重複は UNIQUE 制約で弾く。返す inserted は実挿入件数。
 	BulkInsertIgnore(ctx context.Context, executions []*models.DaytradeExecution) (inserted int, err error)
-	// DeleteBySource は指定 source のレコードを全削除し、削除件数を返す。
-	DeleteBySource(ctx context.Context, source string) (int64, error)
+	// DeleteBySourceAndDates は指定 source かつ executed_on が dates のいずれかに合致するレコードを削除し、削除件数を返す。dates が空の場合は削除せず 0 を返す。
+	DeleteBySourceAndDates(ctx context.Context, source string, dates []time.Time) (int64, error)
 	// from / to は nil 可。両方 nil なら全期間。
 	Aggregate(ctx context.Context, from, to *time.Time, g models.DaytradeSummaryGranularity) ([]*models.DaytradeSummaryBucket, error)
 	// AggregateByTickerSymbol 銘柄毎の損益を集計。from / to は nil 可。両方 nil なら全期間。

--- a/test/e2e/api_daytrade_test.go
+++ b/test/e2e/api_daytrade_test.go
@@ -39,7 +39,7 @@ func TestE2E_Daytrade(t *testing.T) {
 	t.Run("初回インポートで3件挿入される", func(t *testing.T) {
 		helper.TruncateAllTables(t, db)
 
-		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_sjis.csv", false)
+		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_sjis.csv")
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		var result models.DaytradeImportResult
@@ -49,10 +49,12 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.Equal(t, 3, result.TotalRow)
 		assert.Equal(t, 3, result.Inserted)
 		assert.Equal(t, 0, result.Skipped)
+		assert.Equal(t, 0, result.Deleted)
 	})
 
-	t.Run("同じCSVを再インポートすると重複スキップ", func(t *testing.T) {
-		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_sjis.csv", false)
+	t.Run("同じCSVを再インポートするとその日が置き換わる", func(t *testing.T) {
+		// 前のテストで 3 件挿入済み（TruncateAllTables なし）
+		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_sjis.csv")
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		var result models.DaytradeImportResult
@@ -60,8 +62,9 @@ func TestE2E_Daytrade(t *testing.T) {
 		resp.Body.Close()
 
 		assert.Equal(t, 3, result.TotalRow)
-		assert.Equal(t, 0, result.Inserted)
-		assert.Equal(t, 3, result.Skipped)
+		assert.Equal(t, 3, result.Inserted)
+		assert.Equal(t, 0, result.Skipped)
+		assert.Equal(t, 3, result.Deleted) // 同じ日付のレコードを削除してから再挿入
 	})
 
 	t.Run("日次サマリーが正しく返る", func(t *testing.T) {
@@ -322,34 +325,92 @@ func TestE2E_Daytrade(t *testing.T) {
 		assert.NotEmpty(t, body.Items[0].BrandName)            // CSV 由来の名前
 	})
 
-	// --- replace モード ---
+	// --- 日付範囲で置き換えのテスト ---
 
-	t.Run("replaceモード_旧データ全削除して新フォーマットで再挿入", func(t *testing.T) {
+	t.Run("日付範囲で置き換え_同じ日のCSVを別フォーマットで再取り込みすると新内容に置き換わる", func(t *testing.T) {
 		helper.TruncateAllTables(t, db)
 
-		// まず旧フォーマット CSV を 3 件挿入
-		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_sjis.csv", false)
+		// 旧フォーマット CSV を 3 件挿入（trade_kind="売建" あり）
+		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_sjis.csv")
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		resp.Body.Close()
 
-		// replace=true で新フォーマット CSV (同 3 件) を投入
-		resp2 := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_new_sjis.csv", true)
+		// 新フォーマット CSV（同じ日付・同数）で再取り込み
+		resp2 := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_new_sjis.csv")
 		require.Equal(t, http.StatusOK, resp2.StatusCode)
 
 		var result models.DaytradeImportResult
 		require.NoError(t, json.NewDecoder(resp2.Body).Decode(&result))
 		resp2.Body.Close()
 
-		assert.Equal(t, 3, result.Deleted)  // 旧 3 件が削除された
-		assert.Equal(t, 3, result.Inserted) // 新 3 件が挿入された
+		assert.Equal(t, 3, result.Deleted)  // 旧フォーマット 3 件が日付範囲で削除された
+		assert.Equal(t, 3, result.Inserted) // 新フォーマット 3 件が挿入された
 		assert.Equal(t, 0, result.Skipped)
 		assert.Equal(t, 3, result.TotalRow)
+
+		// DB の内容が新フォーマットになっていること（trade_kind が空文字）
+		resp3, err := http.Get(ts.URL + "/daytrade/executions?date=2026-05-21")
+		require.NoError(t, err)
+		defer resp3.Body.Close()
+
+		var body struct {
+			Executions []*models.DaytradeExecution `json:"executions"`
+		}
+		require.NoError(t, json.NewDecoder(resp3.Body).Decode(&body))
+		require.NotEmpty(t, body.Executions)
+		for _, ex := range body.Executions {
+			assert.Equal(t, "", ex.TradeKind, "新フォーマットはtradeKind空文字")
+		}
+	})
+
+	t.Run("日付範囲で置き換え_別日のCSVを取り込んでも既存日付は消えない", func(t *testing.T) {
+		helper.TruncateAllTables(t, db)
+
+		// 2026-05-19 と 2026-05-21 の 3 件を挿入
+		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_sjis.csv")
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+
+		// 別の日（2026-05-14）だけを含む inline CSV を取り込む
+		header := `"約定日","取引","銘柄","信用","数量","約定代金","単価","平均取得単価","売買損益(税引前・円)"` + "\n"
+		row := `"2026/5/14","売建","ソフトバンクグループ 9984","返済売","100","596,940","5,969.4","5,960","+840"` + "\n"
+		csvContent := []byte(header + row)
+
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+		fw, err := mw.CreateFormFile("file", "new_day.csv")
+		require.NoError(t, err)
+		_, err = fw.Write(csvContent)
+		require.NoError(t, err)
+		require.NoError(t, mw.Close())
+
+		resp2, err := http.Post(ts.URL+"/daytrade/executions/import", mw.FormDataContentType(), &buf)
+		require.NoError(t, err)
+		defer resp2.Body.Close()
+		require.Equal(t, http.StatusOK, resp2.StatusCode)
+
+		var result models.DaytradeImportResult
+		require.NoError(t, json.NewDecoder(resp2.Body).Decode(&result))
+
+		assert.Equal(t, 1, result.TotalRow)
+		assert.Equal(t, 1, result.Inserted)
+		assert.Equal(t, 0, result.Deleted) // 2026-05-14 には既存レコードなし
+
+		// 元の 3 件（2026-05-19, 2026-05-21）が残っていること
+		var allStats struct {
+			Buckets []*models.DaytradeSummaryBucket `json:"buckets"`
+		}
+		resp3, err := http.Get(ts.URL + "/daytrade/summary?granularity=all")
+		require.NoError(t, err)
+		defer resp3.Body.Close()
+		require.NoError(t, json.NewDecoder(resp3.Body).Decode(&allStats))
+		assert.Equal(t, 4, allStats.Buckets[0].TradeCount) // 元 3 件 + 新規 1 件
 	})
 
 	t.Run("新フォーマットCSV_tradeKindが空文字でmarginKindが正しい", func(t *testing.T) {
 		helper.TruncateAllTables(t, db)
 
-		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_new_sjis.csv", false)
+		resp := postCSV(t, ts.URL, "../../usecase/daytrade/testdata/sbi_sample_new_sjis.csv")
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		resp.Body.Close()
 
@@ -400,7 +461,7 @@ func TestE2E_Daytrade(t *testing.T) {
 	})
 }
 
-func postCSV(t *testing.T, baseURL string, csvPath string, replace bool) *http.Response {
+func postCSV(t *testing.T, baseURL string, csvPath string) *http.Response {
 	t.Helper()
 	var buf bytes.Buffer
 	mw := multipart.NewWriter(&buf)
@@ -411,9 +472,6 @@ func postCSV(t *testing.T, baseURL string, csvPath string, replace bool) *http.R
 	require.NoError(t, err)
 	_, err = fw.Write(csvBytes)
 	require.NoError(t, err)
-	if replace {
-		require.NoError(t, mw.WriteField("replace", "true"))
-	}
 	require.NoError(t, mw.Close())
 
 	resp, err := http.Post(baseURL+"/daytrade/executions/import", mw.FormDataContentType(), &buf)

--- a/usecase/daytrade_interactor.go
+++ b/usecase/daytrade_interactor.go
@@ -14,14 +14,8 @@ import (
 	"github.com/Code0716/stock-price-repository/usecase/daytrade"
 )
 
-// ImportOptions ImportSBICsv の動作オプション
-type ImportOptions struct {
-	// Replace が true のとき、source="sbi" の既存データを全削除してから挿入する。
-	Replace bool
-}
-
 type DaytradeInteractor interface {
-	ImportSBICsv(ctx context.Context, r io.Reader, opts ImportOptions) (*models.DaytradeImportResult, error)
+	ImportSBICsv(ctx context.Context, r io.Reader) (*models.DaytradeImportResult, error)
 	GetSummary(ctx context.Context, from, to *time.Time, g models.DaytradeSummaryGranularity) ([]*models.DaytradeSummaryBucket, error)
 	GetSummaryByTickerSymbol(ctx context.Context, from, to *time.Time) ([]*models.DaytradeSymbolSummary, error)
 	GetExecutionsByDate(ctx context.Context, date time.Time) ([]*models.DaytradeExecution, error)
@@ -40,7 +34,7 @@ func NewDaytradeInteractor(tx repositories.Transaction, repo repositories.Daytra
 	return &daytradeInteractorImpl{tx: tx, repo: repo, now: time.Now}
 }
 
-func (u *daytradeInteractorImpl) ImportSBICsv(ctx context.Context, r io.Reader, opts ImportOptions) (*models.DaytradeImportResult, error) {
+func (u *daytradeInteractorImpl) ImportSBICsv(ctx context.Context, r io.Reader) (*models.DaytradeImportResult, error) {
 	rows, err := daytrade.ParseSBIDaytradeCSV(r, u.now())
 	if err != nil {
 		return nil, err
@@ -52,19 +46,27 @@ func (u *daytradeInteractorImpl) ImportSBICsv(ctx context.Context, r io.Reader, 
 	total := len(rows)
 	var inserted int
 	var deleted int64
+
+	dateSet := make(map[time.Time]struct{})
+	for _, row := range rows {
+		dateSet[row.ExecutedOn] = struct{}{}
+	}
+	dates := make([]time.Time, 0, len(dateSet))
+	for d := range dateSet {
+		dates = append(dates, d)
+	}
+
 	if err := u.tx.DoInTx(ctx, func(ctx context.Context) error {
-		if opts.Replace {
-			n, err := u.repo.DeleteBySource(ctx, "sbi")
-			if err != nil {
-				return errors.Wrap(err, "DeleteBySource error")
-			}
-			deleted = n
+		n, err := u.repo.DeleteBySourceAndDates(ctx, "sbi", dates)
+		if err != nil {
+			return errors.Wrap(err, "DeleteBySourceAndDates error")
 		}
-		n, err := u.repo.BulkInsertIgnore(ctx, rows)
+		deleted = n
+		n2, err := u.repo.BulkInsertIgnore(ctx, rows)
 		if err != nil {
 			return errors.Wrap(err, "BulkInsertIgnore error")
 		}
-		inserted = n
+		inserted = n2
 		return nil
 	}); err != nil {
 		return nil, errors.Wrap(err, "DoInTx error")


### PR DESCRIPTION
## Summary

- `replace` フラグ（「既存データを置き換える」チェックボックス）を廃止
- CSVインポートは常に「CSVに含まれる約定日のみ DELETE→INSERT する日付範囲置き換え方式」に統一
- 今日分だけ入れたら今日だけ更新、1年分入れたら1年分が更新、昨日だけなら昨日だけ更新

## Changes

- `repositories/daytrade_execution.go`: `DeleteBySource` → `DeleteBySourceAndDates(dates []time.Time)`
- `infrastructure/database/daytrade_execution.go`: 日付 IN 句による部分削除に変更
- `usecase/daytrade_interactor.go`: `ImportOptions` 廃止、行から約定日集合を抽出して日付範囲削除→再挿入
- `entrypoint/api/handler/daytrade_handler.go`: `replace` フォームパラメータ削除
- `mock/`: `make mock` で自動再生成
- `test/e2e/api_daytrade_test.go`: replaceモードテストを日付範囲テストに書き換え・新規2ケース追加

## Test plan

- [ ] `make test-unit` 通過確認
- [ ] `make test-e2e` 通過確認（Docker MySQL 必要）
- [ ] `make lint` 0 issues 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)