### PR TITLE
fix: api 起動時の DB 接続レースを解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ proto-definitions/
 /*.pb.go
 shell_scripts/
 grpc
+
+# Claude Code の作業用 git worktree（一時的なもの）
+.claude/worktrees/

--- a/compose.yml
+++ b/compose.yml
@@ -17,7 +17,7 @@ services:
       MYSQL_COLLATION: utf8mb4_general_ci
       TZ: $STOCK_PRICE_REPOSITORY_MYSQL_TIMEZONE
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h 127.0.0.1 -uroot -p$${MYSQL_ROOT_PASSWORD} --silent"]
+      test: ["CMD-SHELL", "mysql -h 127.0.0.1 -uroot -p$${MYSQL_ROOT_PASSWORD} -e 'SELECT 1' --silent"]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/driver/db.go
+++ b/driver/db.go
@@ -2,13 +2,25 @@
 package driver
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/pkg/errors"
 
 	"github.com/Code0716/stock-price-repository/config"
+)
+
+const (
+	// docker compose の depends_on(service_healthy) だけでは MySQL 初回起動の
+	// 一時サーバや起動直後のクラッシュリカバリ中の谷間を吸収しきれず、
+	// gorm.Open() の初回 Ping が失敗してプロセスが即死する。DB 側にだけ
+	// リトライが無かったため、アプリ側で接続確立まで待つ。
+	dbConnMaxPingRetries = 30              // 最大試行回数
+	dbConnPingInterval   = 2 * time.Second // 試行間隔（30回 = 最大約60秒待ち。MySQL のリカバリ/init を吸収できる長さ）
+	dbConnPingTimeout    = 3 * time.Second // 1回の Ping のタイムアウト（ハング防止）
 )
 
 // NewDBConn initializes DB connection.
@@ -29,7 +41,29 @@ func NewDBConn() (conn *sql.DB, cleanup func(), err error) {
 		}
 	}
 
+	// sql.Open は遅延接続のため、実接続が確立できるまで Ping をリトライする。
+	// これにより後続の NewGorm()(gorm.Open) 時点で接続が生きていることを保証する。
+	if err := pingWithRetry(sqlDB); err != nil {
+		_ = sqlDB.Close()
+		return nil, nil, errors.Wrap(err, "NewDBConn.pingWithRetry retry exhausted")
+	}
+
 	return sqlDB, cleanup, nil
+}
+
+// pingWithRetry pings the DB until it succeeds or retries are exhausted.
+func pingWithRetry(sqlDB *sql.DB) error {
+	var err error
+	for range dbConnMaxPingRetries {
+		ctx, cancel := context.WithTimeout(context.Background(), dbConnPingTimeout)
+		err = sqlDB.PingContext(ctx)
+		cancel()
+		if err == nil {
+			return nil
+		}
+		time.Sleep(dbConnPingInterval)
+	}
+	return err
 }
 
 // BuildMySQLConnectionString builds mysql connection string.


### PR DESCRIPTION
## 背景

\`docker compose up -d\` 時に api コンテナが高確率でコケる問題への対応。原因は「DB が立ち上がり切る前に api が起動し、接続に失敗して即死する」レース。

調査で判明したメカニズム:
- \`driver/db.go: NewDBConn()\` の \`sql.Open\` は遅延接続で、実接続は \`driver/gorm.go: NewGorm()\` の \`gorm.Open()\`（version 取得 Ping）で確立される
- DB がまだ接続を受け付けない一瞬に当たると \`gorm.Open()\` が失敗 → \`entrypoint/api/main.go\` の \`logger.Fatal\` でプロセス即死
- compose の \`condition: service_healthy\` はあるが healthcheck が \`mysqladmin ping\` で起動レースに弱い
- DB 側にだけ接続リトライが無かった（Redis 側は \`MaxRetries\` 等を持つ）

## 変更

- **driver/db.go**: \`NewDBConn\` に \`pingWithRetry\`（\`PingContext\` を 2秒間隔×最大30回 ≒最大60秒、各回3秒タイムアウト）を追加。接続確立後に \`*sql.DB\` を返すため、後続の \`gorm.Open\` 時点で接続が生きていることを保証。失敗時は \`Close()\` してから \`pkg/errors\` でラップ。grpc-server も同じ \`NewDBConn\` 共用のため自動的に堅牢化。
- **compose.yml**: db healthcheck を \`mysqladmin ping\` → \`mysql -e 'SELECT 1'\` に変更し「クエリ受付可能」をより確実に判定。

## 検証

- \`go build ./driver/ ./entrypoint/...\` → OK
- \`ENVCODE=unit go test ./driver/\` → ok
- \`golangci-lint run ./driver/\` → 0 issues
- \`docker compose config\` → 構文 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)