### PR TITLE
build: docker イメージの Go を 1.26.4 に更新

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine
+FROM golang:1.26.4-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine
+FROM golang:1.26.4-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## 概要
直前の #76 で go.mod を `go 1.26.4` に更新（stdlib 脆弱性 GO-2026-5037/5039 解消）したが、`Dockerfile.api` / `Dockerfile.grpc` のベースが `golang:1.26.3-alpine` のままだった。`GOTOOLCHAIN=local` のコンテナでは air のビルドが `go.mod requires go >= 1.26.4` で失敗するため、両イメージを `golang:1.26.4-alpine` に更新する。

## 確認
- ローカルの api コンテナがこの不整合でビルド失敗→停止していたのを解消するための追従修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)