### PR TITLE
perf: backtest_all_stocks_v1 を並列化して高速化 (9m44s→2m5s)

### DIFF
--- a/domain_service/backtest.go
+++ b/domain_service/backtest.go
@@ -13,10 +13,62 @@ type ExitParams struct {
 	MaxHoldDays int             // 最大保有営業日数
 }
 
+// tradeStats 約定確定時にインクリメンタルに加算する集計アキュムレータ。
+// TradeList を後から走査せずに WinRate/PF/平均損益を算出するために使う。
+type tradeStats struct {
+	trades      int
+	wins        int
+	losses      int
+	grossProfit decimal.Decimal
+	grossLoss   decimal.Decimal
+	sumWin      decimal.Decimal
+	sumLoss     decimal.Decimal
+	holdDaysSum int
+}
+
+// record 1約定の損益率と保有日数を集計に加える。
+func (ts *tradeStats) record(ret decimal.Decimal, holdDays int) {
+	ts.trades++
+	ts.holdDaysSum += holdDays
+	if ret.GreaterThan(decimal.Zero) {
+		ts.wins++
+		ts.grossProfit = ts.grossProfit.Add(ret)
+		ts.sumWin = ts.sumWin.Add(ret)
+	} else if ret.LessThan(decimal.Zero) {
+		ts.losses++
+		ts.grossLoss = ts.grossLoss.Add(ret.Abs())
+		ts.sumLoss = ts.sumLoss.Add(ret)
+	}
+}
+
 // RunBacktest entrySignals が true の日の終値で1単位買い、共通ルール
 // （利確/損切り/最大保有/データ末尾）で終値手仕舞いするバックテストを実行する。
 // 同時に保有できるポジションは1つ。エクイティは初期資金 1.0 起点の倍率。
+// Equity / TradeList も構築する（フロント表示・ドリルダウン用）。
 func RunBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, params ExitParams) models.BacktestResult {
+	return runBacktest(prices, entrySignals, params, true)
+}
+
+// RunBacktestMetrics RunBacktest と同じ成績指標を返すが、Equity / TradeList は構築しない
+// （日次の Date.Format とスライス確保を省く）。全銘柄横断バッチなど、集計のみ必要な用途向け。
+func RunBacktestMetrics(prices []*models.StockBrandDailyPrice, entrySignals []bool, params ExitParams) models.BacktestResult {
+	return runBacktest(prices, entrySignals, params, false)
+}
+
+// exitReason 当日のリターンと保有日数から手仕舞い理由を返す。手仕舞い不要なら ""。
+func exitReason(ret decimal.Decimal, holdDays int, params ExitParams) string {
+	switch {
+	case ret.GreaterThanOrEqual(params.TakeProfit):
+		return "take_profit"
+	case ret.LessThanOrEqual(params.StopLoss.Neg()):
+		return "stop_loss"
+	case holdDays >= params.MaxHoldDays:
+		return "max_hold"
+	}
+	return ""
+}
+
+func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, params ExitParams, collectSeries bool) models.BacktestResult {
 	n := len(prices)
 	result := models.BacktestResult{
 		TotalReturn:  decimal.Zero,
@@ -40,20 +92,27 @@ func RunBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 	var entryPrice, entryEquity decimal.Decimal
 
 	equitySeries := make([]decimal.Decimal, 0, n)
+	var stats tradeStats
 
 	closeTrade := func(i int, reason string) {
 		exitPrice := prices[i].Close
 		ret := exitPrice.Div(entryPrice).Sub(one)
 		realizedEquity = entryEquity.Mul(exitPrice.Div(entryPrice))
-		result.TradeList = append(result.TradeList, models.BacktestTrade{
-			EntryDate:  prices[entryIdx].Date.Format(util.DateLayout),
-			ExitDate:   prices[i].Date.Format(util.DateLayout),
-			EntryPrice: entryPrice,
-			ExitPrice:  exitPrice,
-			Return:     ret,
-			HoldDays:   i - entryIdx,
-			Reason:     reason,
-		})
+
+		// 約定をインクリメンタルに集計（TradeList 非依存）
+		stats.record(ret, i-entryIdx)
+
+		if collectSeries {
+			result.TradeList = append(result.TradeList, models.BacktestTrade{
+				EntryDate:  prices[entryIdx].Date.Format(util.DateLayout),
+				ExitDate:   prices[i].Date.Format(util.DateLayout),
+				EntryPrice: entryPrice,
+				ExitPrice:  exitPrice,
+				Return:     ret,
+				HoldDays:   i - entryIdx,
+				Reason:     reason,
+			})
+		}
 		inPosition = false
 	}
 
@@ -61,13 +120,8 @@ func RunBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 		// Step A: イグジット判定（エントリー当日は判定しない）
 		if inPosition && i > entryIdx {
 			ret := prices[i].Close.Div(entryPrice).Sub(one)
-			switch {
-			case ret.GreaterThanOrEqual(params.TakeProfit):
-				closeTrade(i, "take_profit")
-			case ret.LessThanOrEqual(params.StopLoss.Neg()):
-				closeTrade(i, "stop_loss")
-			case i-entryIdx >= params.MaxHoldDays:
-				closeTrade(i, "max_hold")
+			if reason := exitReason(ret, i-entryIdx, params); reason != "" {
+				closeTrade(i, reason)
 			}
 		}
 
@@ -87,10 +141,12 @@ func RunBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 			eq = realizedEquity
 		}
 		equitySeries = append(equitySeries, eq)
-		result.Equity = append(result.Equity, models.BacktestEquityPoint{
-			Date:   prices[i].Date.Format(util.DateLayout),
-			Equity: eq,
-		})
+		if collectSeries {
+			result.Equity = append(result.Equity, models.BacktestEquityPoint{
+				Date:   prices[i].Date.Format(util.DateLayout),
+				Equity: eq,
+			})
+		}
 	}
 
 	// データ末尾で保有が残っていれば強制クローズ（最終日の終値）。
@@ -99,58 +155,33 @@ func RunBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 		closeTrade(n-1, "end_of_data")
 	}
 
-	result.Trades = len(result.TradeList)
+	result.Trades = stats.trades
 	result.TotalReturn = realizedEquity.Sub(one)
 	result.MaxDrawdown = MaxDrawdown(equitySeries)
-	result.AvgHoldDays = avgHoldDays(result.TradeList)
-	fillTradeStats(&result)
+	if stats.trades > 0 {
+		result.AvgHoldDays = float64(stats.holdDaysSum) / float64(stats.trades)
+	}
+	fillTradeStats(&result, &stats)
 	return result
 }
 
-// fillTradeStats 勝率・PF・平均損益・ペイオフを集計する。
-func fillTradeStats(result *models.BacktestResult) {
-	if len(result.TradeList) == 0 {
+// fillTradeStats 集計済み tradeStats から勝率・PF・平均損益・ペイオフを算出する。
+func fillTradeStats(result *models.BacktestResult, stats *tradeStats) {
+	if stats.trades == 0 {
 		return
 	}
-	wins, losses := 0, 0
-	grossProfit, grossLoss := decimal.Zero, decimal.Zero
-	sumWin, sumLoss := decimal.Zero, decimal.Zero
-	for _, t := range result.TradeList {
-		if t.Return.GreaterThan(decimal.Zero) {
-			wins++
-			grossProfit = grossProfit.Add(t.Return)
-			sumWin = sumWin.Add(t.Return)
-		} else if t.Return.LessThan(decimal.Zero) {
-			losses++
-			grossLoss = grossLoss.Add(t.Return.Abs())
-			sumLoss = sumLoss.Add(t.Return)
-		}
-	}
+	result.WinRate = decimal.NewFromInt(int64(stats.wins)).Div(decimal.NewFromInt(int64(stats.trades)))
 
-	total := decimal.NewFromInt(int64(len(result.TradeList)))
-	result.WinRate = decimal.NewFromInt(int64(wins)).Div(total)
-
-	if !grossLoss.IsZero() {
-		result.ProfitFactor = grossProfit.Div(grossLoss)
+	if !stats.grossLoss.IsZero() {
+		result.ProfitFactor = stats.grossProfit.Div(stats.grossLoss)
 	}
-	if wins > 0 {
-		result.AvgWin = sumWin.Div(decimal.NewFromInt(int64(wins)))
+	if stats.wins > 0 {
+		result.AvgWin = stats.sumWin.Div(decimal.NewFromInt(int64(stats.wins)))
 	}
-	if losses > 0 {
-		result.AvgLoss = sumLoss.Div(decimal.NewFromInt(int64(losses)))
+	if stats.losses > 0 {
+		result.AvgLoss = stats.sumLoss.Div(decimal.NewFromInt(int64(stats.losses)))
 	}
-	if losses > 0 && !result.AvgLoss.IsZero() {
+	if stats.losses > 0 && !result.AvgLoss.IsZero() {
 		result.PayoffRatio = result.AvgWin.Div(result.AvgLoss.Abs())
 	}
-}
-
-func avgHoldDays(trades []models.BacktestTrade) float64 {
-	if len(trades) == 0 {
-		return 0
-	}
-	sum := 0
-	for _, t := range trades {
-		sum += t.HoldDays
-	}
-	return float64(sum) / float64(len(trades))
 }

--- a/domain_service/backtest_test.go
+++ b/domain_service/backtest_test.go
@@ -96,6 +96,39 @@ func TestRunBacktest(t *testing.T) {
 	})
 }
 
+func TestRunBacktestMetrics(t *testing.T) {
+	params := ExitParams{
+		TakeProfit:  decimal.NewFromFloat(0.10),
+		StopLoss:    decimal.NewFromFloat(0.05),
+		MaxHoldDays: 10,
+	}
+	// 複数の約定が出るシナリオ（利確→再エントリー→損切り）
+	prices := pricesFromCloses(100, 100, 110, 110, 110, 104)
+	signals := boolsAt(6, 1, 3)
+
+	full := RunBacktest(prices, signals, params)
+	metrics := RunBacktestMetrics(prices, signals, params)
+
+	// メトリクスは完全一致
+	assert.Equal(t, full.Trades, metrics.Trades)
+	assert.True(t, full.TotalReturn.Equal(metrics.TotalReturn), "TotalReturn")
+	assert.True(t, full.WinRate.Equal(metrics.WinRate), "WinRate")
+	assert.True(t, full.ProfitFactor.Equal(metrics.ProfitFactor), "ProfitFactor")
+	assert.True(t, full.MaxDrawdown.Equal(metrics.MaxDrawdown), "MaxDrawdown")
+	assert.True(t, full.AvgWin.Equal(metrics.AvgWin), "AvgWin")
+	assert.True(t, full.AvgLoss.Equal(metrics.AvgLoss), "AvgLoss")
+	assert.True(t, full.PayoffRatio.Equal(metrics.PayoffRatio), "PayoffRatio")
+	assert.InDelta(t, full.AvgHoldDays, metrics.AvgHoldDays, 1e-9)
+
+	// Metrics 版は Equity / TradeList を構築しない
+	assert.Empty(t, metrics.Equity)
+	assert.Empty(t, metrics.TradeList)
+	// Full 版は構築する
+	assert.NotEmpty(t, full.Equity)
+	assert.NotEmpty(t, full.TradeList)
+	assert.GreaterOrEqual(t, full.Trades, 2)
+}
+
 func f64FromDec(d decimal.Decimal) float64 {
 	v, _ := d.Float64()
 	return v

--- a/driver/db.go
+++ b/driver/db.go
@@ -21,6 +21,13 @@ const (
 	dbConnMaxPingRetries = 30              // 最大試行回数
 	dbConnPingInterval   = 2 * time.Second // 試行間隔（30回 = 最大約60秒待ち。MySQL のリカバリ/init を吸収できる長さ）
 	dbConnPingTimeout    = 3 * time.Second // 1回の Ping のタイムアウト（ハング防止）
+
+	// コネクションプール設定。全銘柄バッチなどの並列読み（ワーカー数〜18）でも
+	// コネクション枯渇/churn を起こさないよう、MySQL の max_connections(既定151) の
+	// 範囲で十分なプールを確保する。
+	dbMaxOpenConns    = 30
+	dbMaxIdleConns    = 30
+	dbConnMaxLifetime = 5 * time.Minute
 )
 
 // NewDBConn initializes DB connection.
@@ -34,6 +41,10 @@ func NewDBConn() (conn *sql.DB, cleanup func(), err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
+	sqlDB.SetMaxOpenConns(dbMaxOpenConns)
+	sqlDB.SetMaxIdleConns(dbMaxIdleConns)
+	sqlDB.SetConnMaxLifetime(dbConnMaxLifetime)
 
 	cleanup = func() {
 		if err := sqlDB.Close(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.7
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/text v0.37.0
 	google.golang.org/grpc v1.81.1
 	google.golang.org/protobuf v1.36.11
@@ -50,7 +51,6 @@ require (
 	golang.org/x/exp v0.0.0-20240112132812-db7319d0e0e3 // indirect
 	golang.org/x/mod v0.36.0 // indirect
 	golang.org/x/net v0.54.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect

--- a/infrastructure/cli/commands/backtest_all_stocks.go
+++ b/infrastructure/cli/commands/backtest_all_stocks.go
@@ -43,6 +43,11 @@ func (c *BacktestAllStocksCommand) Command() *Command {
 				Value: 5,
 				Usage: "バックテスト対象の直近N年",
 			},
+			&cli.IntFlag{
+				Name:  "concurrency",
+				Value: 0,
+				Usage: "ワーカー数（0 で CPU コア数）",
+			},
 		},
 		Action: c.Action,
 	}
@@ -55,7 +60,8 @@ func (c *BacktestAllStocksCommand) Action(ctx *cli.Context) error {
 		MaxHoldDays: ctx.Int("max-hold-days"),
 	}
 	years := ctx.Int("years")
-	n, err := c.interactor.ComputeAndSaveStrategyRanking(ctx.Context, params, years)
+	concurrency := ctx.Int("concurrency")
+	n, err := c.interactor.ComputeAndSaveStrategyRanking(ctx.Context, params, years, concurrency)
 	if err != nil {
 		return errors.Wrap(err, "ComputeAndSaveStrategyRanking error")
 	}

--- a/mock/usecase/strategy_ranking_interactor.go
+++ b/mock/usecase/strategy_ranking_interactor.go
@@ -42,18 +42,18 @@ func (m *MockStrategyRankingInteractor) EXPECT() *MockStrategyRankingInteractorM
 }
 
 // ComputeAndSaveStrategyRanking mocks base method.
-func (m *MockStrategyRankingInteractor) ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years int) (int, error) {
+func (m *MockStrategyRankingInteractor) ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years, concurrency int) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ComputeAndSaveStrategyRanking", ctx, params, years)
+	ret := m.ctrl.Call(m, "ComputeAndSaveStrategyRanking", ctx, params, years, concurrency)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ComputeAndSaveStrategyRanking indicates an expected call of ComputeAndSaveStrategyRanking.
-func (mr *MockStrategyRankingInteractorMockRecorder) ComputeAndSaveStrategyRanking(ctx, params, years any) *gomock.Call {
+func (mr *MockStrategyRankingInteractorMockRecorder) ComputeAndSaveStrategyRanking(ctx, params, years, concurrency any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeAndSaveStrategyRanking", reflect.TypeOf((*MockStrategyRankingInteractor)(nil).ComputeAndSaveStrategyRanking), ctx, params, years)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeAndSaveStrategyRanking", reflect.TypeOf((*MockStrategyRankingInteractor)(nil).ComputeAndSaveStrategyRanking), ctx, params, years, concurrency)
 }
 
 // GetStrategyRanking mocks base method.

--- a/usecase/strategy_ranking_interactor.go
+++ b/usecase/strategy_ranking_interactor.go
@@ -4,14 +4,16 @@ package usecase
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"log"
+	"runtime"
 	"sort"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/redis/go-redis/v9"
 	"github.com/shopspring/decimal"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/Code0716/stock-price-repository/domain_service"
 	"github.com/Code0716/stock-price-repository/models"
@@ -37,12 +39,37 @@ type strategyAcc struct {
 	bestCount      int
 }
 
+// newAccs 戦略ごとの集計アキュムレータを初期化して返す。
+func newAccs() map[string]*strategyAcc {
+	accs := make(map[string]*strategyAcc, len(domain_service.StrategyOrder))
+	for _, s := range domain_service.StrategyOrder {
+		accs[s] = &strategyAcc{}
+	}
+	return accs
+}
+
+// mergeAccs src の集計を dst に加算する（ワーカーローカル集計のマージ用）。
+func mergeAccs(dst, src map[string]*strategyAcc) {
+	for _, s := range domain_service.StrategyOrder {
+		d, sa := dst[s], src[s]
+		d.stockCount += sa.stockCount
+		d.tradedStocks += sa.tradedStocks
+		d.positiveCount += sa.positiveCount
+		d.sumTotalReturn = d.sumTotalReturn.Add(sa.sumTotalReturn)
+		d.sumWinRate = d.sumWinRate.Add(sa.sumWinRate)
+		d.sumPF = d.sumPF.Add(sa.sumPF)
+		d.totalTrades += sa.totalTrades
+		d.bestCount += sa.bestCount
+	}
+}
+
 // accumulateResults 日足と exitParams から各戦略の結果を accs に集計する。
+// 集計用途のため Equity/TradeList を構築しない RunBacktestMetrics を使う。
 func accumulateResults(prices []*models.StockBrandDailyPrice, exitParams domain_service.ExitParams, accs map[string]*strategyAcc) {
 	results := make(map[string]models.BacktestResult, len(domain_service.StrategyOrder))
 	for _, s := range domain_service.StrategyOrder {
 		signals := domain_service.EntrySignalsByStrategy(s, prices)
-		results[s] = domain_service.RunBacktest(prices, signals, exitParams)
+		results[s] = domain_service.RunBacktestMetrics(prices, signals, exitParams)
 	}
 	for _, s := range domain_service.StrategyOrder {
 		res := results[s]
@@ -82,8 +109,8 @@ type strategyRankingInteractorImpl struct {
 // StrategyRankingInteractor 全銘柄横断バックテスト集計インターフェース。
 type StrategyRankingInteractor interface {
 	// ComputeAndSaveStrategyRanking 全主要市場銘柄を全戦略でバックテストし、集計を Redis に保存する。
-	// years: 直近N年を対象期間とする。処理した銘柄数を返す。
-	ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years int) (int, error)
+	// years: 直近N年を対象期間とする。concurrency: ワーカー数（<=0 で NumCPU）。処理した銘柄数を返す。
+	ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years, concurrency int) (int, error)
 	// GetStrategyRanking Redis から集計を返す。未計算なら Computed=false の空の StrategyRanking を返す。
 	GetStrategyRanking(ctx context.Context) (*models.StrategyRanking, error)
 }
@@ -115,7 +142,7 @@ func (r *strategyRankingInteractorImpl) GetStrategyRanking(ctx context.Context) 
 	return &ranking, nil
 }
 
-func (r *strategyRankingInteractorImpl) ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years int) (int, error) {
+func (r *strategyRankingInteractorImpl) ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years, concurrency int) (int, error) {
 	brands, err := r.stockBrandRepository.FindAllMainMarkets(ctx)
 	if err != nil {
 		return 0, errors.Wrap(err, "FindAllMainMarkets error")
@@ -123,38 +150,15 @@ func (r *strategyRankingInteractorImpl) ComputeAndSaveStrategyRanking(ctx contex
 
 	now := time.Now()
 	from := now.AddDate(-years, 0, 0)
-	asc := models.SortOrderAsc
 	exitParams := domain_service.ExitParams{
 		TakeProfit:  params.TakeProfit,
 		StopLoss:    params.StopLoss,
 		MaxHoldDays: params.MaxHoldDays,
 	}
 
-	// 戦略ごとのアキュムレータを初期化
-	accs := make(map[string]*strategyAcc, len(domain_service.StrategyOrder))
-	for _, s := range domain_service.StrategyOrder {
-		accs[s] = &strategyAcc{}
-	}
-
-	processed := 0
-	for i, brand := range brands {
-		prices, err := r.stockBrandsDailyStockPriceRepository.ListDailyPricesBySymbol(ctx, models.ListDailyPricesBySymbolFilter{
-			TickerSymbol: brand.TickerSymbol,
-			DateFrom:     &from,
-			DateTo:       &now,
-			DateOrder:    &asc,
-		})
-		if err != nil {
-			return processed, errors.Wrap(err, fmt.Sprintf("ListDailyPricesBySymbol error for %s", brand.TickerSymbol))
-		}
-		if len(prices) < strategyRankingMinDays {
-			continue
-		}
-		accumulateResults(prices, exitParams, accs)
-		processed++
-		if (i+1)%100 == 0 {
-			log.Printf("strategy ranking: processed %d/%d brands", i+1, len(brands))
-		}
+	accs, processed, err := r.runWorkers(ctx, brands, from, now, exitParams, concurrency)
+	if err != nil {
+		return processed, err
 	}
 
 	// StrategyRankingItem を組み立て
@@ -204,4 +208,80 @@ func (r *strategyRankingInteractorImpl) ComputeAndSaveStrategyRanking(ctx contex
 
 	log.Printf("strategy ranking: completed. processed=%d/%d brands", processed, len(brands))
 	return processed, nil
+}
+
+// runWorkers 固定 concurrency 個のワーカーで全銘柄を並列にバックテストし、
+// ワーカーローカルに集計してからマージした accs と処理銘柄数を返す。
+// 各ワーカーは自分専用の accs にのみ書き込むためロック不要。decimal の総和は
+// 順序非依存で厳密なので、結果は逐次版と完全一致する。
+func (r *strategyRankingInteractorImpl) runWorkers(
+	ctx context.Context,
+	brands []*models.StockBrand,
+	from, to time.Time,
+	exitParams domain_service.ExitParams,
+	concurrency int,
+) (map[string]*strategyAcc, int, error) {
+	if concurrency <= 0 {
+		concurrency = runtime.NumCPU()
+	}
+	asc := models.SortOrderAsc
+
+	workerAccs := make([]map[string]*strategyAcc, concurrency)
+	for w := range workerAccs {
+		workerAccs[w] = newAccs()
+	}
+
+	jobs := make(chan *models.StockBrand)
+	var processed atomic.Int64
+	g, gctx := errgroup.WithContext(ctx)
+
+	for w := 0; w < concurrency; w++ {
+		w := w
+		g.Go(func() error {
+			local := workerAccs[w]
+			for brand := range jobs {
+				prices, err := r.stockBrandsDailyStockPriceRepository.ListDailyPricesBySymbol(gctx, models.ListDailyPricesBySymbolFilter{
+					TickerSymbol: brand.TickerSymbol,
+					DateFrom:     &from,
+					DateTo:       &to,
+					DateOrder:    &asc,
+				})
+				if err != nil {
+					return errors.Wrap(err, "ListDailyPricesBySymbol error for "+brand.TickerSymbol)
+				}
+				if len(prices) < strategyRankingMinDays {
+					continue
+				}
+				accumulateResults(prices, exitParams, local)
+				if n := processed.Add(1); n%200 == 0 {
+					log.Printf("strategy ranking: processed %d/%d brands", n, len(brands))
+				}
+			}
+			return nil
+		})
+	}
+
+	// フィーダ：ctx キャンセルを尊重して銘柄を投入する
+	g.Go(func() error {
+		defer close(jobs)
+		for _, b := range brands {
+			select {
+			case jobs <- b:
+			case <-gctx.Done():
+				return gctx.Err()
+			}
+		}
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
+		return nil, int(processed.Load()), err
+	}
+
+	// ワーカーローカルの集計をマージ
+	accs := newAccs()
+	for _, wa := range workerAccs {
+		mergeAccs(accs, wa)
+	}
+	return accs, int(processed.Load()), nil
 }

--- a/usecase/strategy_ranking_interactor_test.go
+++ b/usecase/strategy_ranking_interactor_test.go
@@ -126,7 +126,7 @@ func TestStrategyRankingInteractor_ComputeAndSaveStrategyRanking_Normal(t *testi
 	}
 
 	interactor := NewStrategyRankingInteractor(brandRepo, priceRepo, client)
-	n, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5)
+	n, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5, 2)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, n)
 
@@ -160,7 +160,7 @@ func TestStrategyRankingInteractor_ComputeAndSaveStrategyRanking_SkipShortData(t
 
 	params := models.BacktestParams{TakeProfit: decimal.NewFromFloat(0.1), StopLoss: decimal.NewFromFloat(0.05), MaxHoldDays: 20}
 	interactor := NewStrategyRankingInteractor(brandRepo, priceRepo, client)
-	n, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5)
+	n, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5, 2)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, n) // スキップされたので処理0件
 
@@ -186,6 +186,6 @@ func TestStrategyRankingInteractor_ComputeAndSaveStrategyRanking_PriceError(t *t
 
 	params := models.BacktestParams{TakeProfit: decimal.NewFromFloat(0.1), StopLoss: decimal.NewFromFloat(0.05), MaxHoldDays: 20}
 	interactor := NewStrategyRankingInteractor(brandRepo, priceRepo, client)
-	_, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5)
+	_, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5, 2)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
## 概要
全銘柄横断バックテストバッチ `backtest_all_stocks_v1` が遅い（3,739銘柄で約9分44秒）問題を、ワーカープール並列化＋不要割当の削減で高速化する。**結果（ランキング数値）は逐次版と完全一致**。

## 変更点
- `usecase/strategy_ranking_interactor.go`: 固定Nワーカー＋ワーカーローカル集計→マージのロックフリー並列化（`errgroup`）。`ComputeAndSaveStrategyRanking` に `concurrency` 引数、CLIに `--concurrency` フラグ（既定=NumCPU）を追加
- `domain_service/backtest.go`: `RunBacktestMetrics` を追加。集計用途で Equity/TradeList と日次 `Date.Format`（約2,200万回）を省く。`RunBacktest` の出力は不変（②a に影響なし）
- `driver/db.go`: コネクションプール設定（MaxOpen/MaxIdle=30, MaxLifetime=5m）

## 計測（ローカル, 3,739銘柄）
- 高速化前: **9分44秒** → 高速化後: **2分5秒（約4.6倍）**
- ランキング数値は完全一致（移動平均+3.2%/最優秀1082、総取引131218 等まで一致）

## テスト
`go build`/`go vet`/`golangci-lint`(0 issues)/ ユニットテスト（`-race` 含む）パス。`RunBacktestMetrics` が `RunBacktest` とメトリクス一致＋Equity/TradeList 空であることを検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)