### PR TITLE
feat: 全主要市場銘柄 財務情報一括sync CLIバッチ (sync_fin_statements_all_stocks)

### DIFF
--- a/di/wire.go
+++ b/di/wire.go
@@ -59,6 +59,7 @@ var cliSet = wire.NewSet(
 	commands.NewSyncFinAnnouncementsCommand,
 	commands.NewSyncFinStatementsCommand,
 	commands.NewBacktestAllStocksCommand,
+	commands.NewSyncFinStatementsAllStocksCommand,
 )
 
 var databaseSet = wire.NewSet(

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -68,7 +68,8 @@ func InitializeCli(ctx context.Context) (*cli.Runner, func(), error) {
 	syncFinStatementsCommand := commands.NewSyncFinStatementsCommand(stockBrandInteractor)
 	strategyRankingInteractor := usecase.NewStrategyRankingInteractor(stockBrandRepository, stockBrandsDailyPriceRepository, client)
 	backtestAllStocksCommand := commands.NewBacktestAllStocksCommand(strategyRankingInteractor)
-	runner := cli.NewRunner(healthCheckCommand, updateStockBrandsV1Command, createHistoricalDailyStockPricesV1Command, createDailyStockPriceV1Command, createNikkeiAndDjiHistoricalDataV1Command, adjustHistoricalDataForStockSplitCommand, adjustHistoricalDataForStockConsolidationCommand, exportYearlyDataCommand, exportMasterDataCommand, syncFinAnnouncementsCommand, syncFinStatementsCommand, backtestAllStocksCommand, indexInteractor, slackAPIClient)
+	syncFinStatementsAllStocksCommand := commands.NewSyncFinStatementsAllStocksCommand(stockBrandInteractor)
+	runner := cli.NewRunner(healthCheckCommand, updateStockBrandsV1Command, createHistoricalDailyStockPricesV1Command, createDailyStockPriceV1Command, createNikkeiAndDjiHistoricalDataV1Command, adjustHistoricalDataForStockSplitCommand, adjustHistoricalDataForStockConsolidationCommand, exportYearlyDataCommand, exportMasterDataCommand, syncFinAnnouncementsCommand, syncFinStatementsCommand, backtestAllStocksCommand, syncFinStatementsAllStocksCommand, indexInteractor, slackAPIClient)
 	return runner, func() {
 		cleanup()
 	}, nil
@@ -160,7 +161,7 @@ var usecaseSet = wire.NewSet(usecase.NewStockBrandInteractor, usecase.NewIndexIn
 
 var driverSet = wire.NewSet(driver.NewGorm, driver.NewDBConn, driver.NewHTTPRequest, driver.NewHTTPServer, driver.NewSlackAPIClient, driver.OpenRedis, driver.NewStockAPIClient, driver.NewMySQLDumpClient, driver.NewBoxAPIClient, driver.NewLogger)
 
-var cliSet = wire.NewSet(cli.NewRunner, commands.NewHealthCheckCommand, commands.NewUpdateStockBrandsV1Command, commands.NewCreateHistoricalDailyStockPricesV1Command, commands.NewCreateDailyStockPriceV1Command, commands.NewCreateNikkeiAndDjiHistoricalDataV1Command, commands.NewAdjustHistoricalDataForStockSplitCommand, commands.NewAdjustHistoricalDataForStockConsolidationCommand, commands.NewExportYearlyDataCommand, commands.NewExportMasterDataCommand, commands.NewSyncFinAnnouncementsCommand, commands.NewSyncFinStatementsCommand, commands.NewBacktestAllStocksCommand)
+var cliSet = wire.NewSet(cli.NewRunner, commands.NewHealthCheckCommand, commands.NewUpdateStockBrandsV1Command, commands.NewCreateHistoricalDailyStockPricesV1Command, commands.NewCreateDailyStockPriceV1Command, commands.NewCreateNikkeiAndDjiHistoricalDataV1Command, commands.NewAdjustHistoricalDataForStockSplitCommand, commands.NewAdjustHistoricalDataForStockConsolidationCommand, commands.NewExportYearlyDataCommand, commands.NewExportMasterDataCommand, commands.NewSyncFinAnnouncementsCommand, commands.NewSyncFinStatementsCommand, commands.NewBacktestAllStocksCommand, commands.NewSyncFinStatementsAllStocksCommand)
 
 var databaseSet = wire.NewSet(database.NewTransaction, database.NewStockBrandRepositoryImpl, database.NewNikkeiRepositoryImpl, database.NewDjiRepositoryImpl, database.NewStockBrandsDailyPriceRepositoryImpl, database.NewAnalyzeStockBrandPriceHistoryRepositoryImpl, database.NewStockBrandsDailyPriceForAnalyzeRepositoryImpl, database.NewHighVolumeStockBrandRepositoryImpl, database.NewAppliedStockSplitsHistoryRepositoryImpl, database.NewAppliedStockConsolidationsHistoryRepositoryImpl, database.NewFinAnnouncementRepositoryImpl, database.NewFinStatementRepositoryImpl, database.NewDaytradeExecutionRepositoryImpl)
 

--- a/infrastructure/cli/commands/sync_fin_statements_all_stocks.go
+++ b/infrastructure/cli/commands/sync_fin_statements_all_stocks.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"github.com/pkg/errors"
+	"github.com/urfave/cli/v2"
+
+	"github.com/Code0716/stock-price-repository/usecase"
+)
+
+type SyncFinStatementsAllStocksCommand struct {
+	interactor usecase.StockBrandInteractor
+}
+
+func NewSyncFinStatementsAllStocksCommand(interactor usecase.StockBrandInteractor) *SyncFinStatementsAllStocksCommand {
+	return &SyncFinStatementsAllStocksCommand{interactor: interactor}
+}
+
+func (c *SyncFinStatementsAllStocksCommand) Command() *Command {
+	return &Command{
+		Name:  "sync_fin_statements_all_stocks",
+		Usage: "全主要市場銘柄の財務情報をj-Quantsから逐次取得してDBに保存する。週次バッチ用。",
+		Flags: []cli.Flag{
+			&cli.IntFlag{
+				Name:  "interval-ms",
+				Value: 1100,
+				Usage: "各リクエスト前のウェイトms。J-Quantsレート制限1req/sec対策",
+			},
+			&cli.IntFlag{
+				Name:  "max",
+				Value: 0,
+				Usage: "処理する最大銘柄数（0=全件、テスト・検証用）",
+			},
+		},
+		Action: c.Action,
+	}
+}
+
+func (c *SyncFinStatementsAllStocksCommand) Action(ctx *cli.Context) error {
+	if err := c.interactor.SyncFinStatementsAllStocks(ctx.Context, ctx.Int("interval-ms"), ctx.Int("max")); err != nil {
+		return errors.Wrap(err, "SyncFinStatementsAllStocks error")
+	}
+	return nil
+}

--- a/infrastructure/cli/runner.go
+++ b/infrastructure/cli/runner.go
@@ -35,6 +35,7 @@ func NewRunner(
 	syncFinAnnouncementsCommand *commands.SyncFinAnnouncementsCommand,
 	syncFinStatementsCommand *commands.SyncFinStatementsCommand,
 	backtestAllStocksCommand *commands.BacktestAllStocksCommand,
+	syncFinStatementsAllStocksCommand *commands.SyncFinStatementsAllStocksCommand,
 	indexInteractor usecase.IndexInteractor,
 	slackAPIClient gateway.SlackAPIClient,
 ) *Runner {
@@ -52,6 +53,7 @@ func NewRunner(
 			syncFinAnnouncementsCommand.Command(),
 			syncFinStatementsCommand.Command(),
 			backtestAllStocksCommand.Command(),
+			syncFinStatementsAllStocksCommand.Command(),
 		},
 		indexInteractor: indexInteractor,
 		slackAPIClient:  slackAPIClient,

--- a/mock/usecase/stock_brands_interactor.go
+++ b/mock/usecase/stock_brands_interactor.go
@@ -160,6 +160,20 @@ func (mr *MockStockBrandInteractorMockRecorder) SyncFinStatements(ctx, tickerSym
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFinStatements", reflect.TypeOf((*MockStockBrandInteractor)(nil).SyncFinStatements), ctx, tickerSymbol)
 }
 
+// SyncFinStatementsAllStocks mocks base method.
+func (m *MockStockBrandInteractor) SyncFinStatementsAllStocks(ctx context.Context, intervalMs, max int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SyncFinStatementsAllStocks", ctx, intervalMs, max)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SyncFinStatementsAllStocks indicates an expected call of SyncFinStatementsAllStocks.
+func (mr *MockStockBrandInteractorMockRecorder) SyncFinStatementsAllStocks(ctx, intervalMs, max any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncFinStatementsAllStocks", reflect.TypeOf((*MockStockBrandInteractor)(nil).SyncFinStatementsAllStocks), ctx, intervalMs, max)
+}
+
 // UpdateStockBrands mocks base method.
 func (m *MockStockBrandInteractor) UpdateStockBrands(ctx context.Context, t time.Time) error {
 	m.ctrl.T.Helper()

--- a/test/helper/runner.go
+++ b/test/helper/runner.go
@@ -20,6 +20,7 @@ type TestRunnerOptions struct {
 	SyncFinAnnouncementsCommand                      *commands.SyncFinAnnouncementsCommand
 	SyncFinStatementsCommand                         *commands.SyncFinStatementsCommand
 	BacktestAllStocksCommand                         *commands.BacktestAllStocksCommand
+	SyncFinStatementsAllStocksCommand                *commands.SyncFinStatementsAllStocksCommand
 	IndexInteractor                                  usecase.IndexInteractor
 	SlackAPIClient                                   gateway.SlackAPIClient
 	MySQLDumpClient                                  gateway.MySQLDumpClient
@@ -63,6 +64,9 @@ func NewTestRunner(opts TestRunnerOptions) *cli.Runner {
 	if opts.BacktestAllStocksCommand == nil {
 		opts.BacktestAllStocksCommand = commands.NewBacktestAllStocksCommand(nil)
 	}
+	if opts.SyncFinStatementsAllStocksCommand == nil {
+		opts.SyncFinStatementsAllStocksCommand = commands.NewSyncFinStatementsAllStocksCommand(nil)
+	}
 
 	return cli.NewRunner(
 		opts.HealthCheckCommand,
@@ -77,6 +81,7 @@ func NewTestRunner(opts TestRunnerOptions) *cli.Runner {
 		opts.SyncFinAnnouncementsCommand,
 		opts.SyncFinStatementsCommand,
 		opts.BacktestAllStocksCommand,
+		opts.SyncFinStatementsAllStocksCommand,
 		opts.IndexInteractor,
 		opts.SlackAPIClient,
 	)

--- a/usecase/stock_brands_interactor.go
+++ b/usecase/stock_brands_interactor.go
@@ -34,6 +34,9 @@ type StockBrandInteractor interface {
 	GetNextFinAnnouncement(ctx context.Context, tickerSymbol string) (*models.FinAnnouncement, error)
 	SyncFinStatements(ctx context.Context, tickerSymbol string) error
 	GetFinStatements(ctx context.Context, filter *models.FinStatementFilter) ([]*models.FinStatement, error)
+	// SyncFinStatementsAllStocks 全主要市場銘柄の財務情報を逐次取得・保存する。
+	// intervalMs: 各APIリクエスト前のウェイト(ミリ秒, 0=ウェイトなし)。max: 処理上限(0=全件)。
+	SyncFinStatementsAllStocks(ctx context.Context, intervalMs, max int) error
 }
 
 func NewStockBrandInteractor(

--- a/usecase/sync_fin_statements_all_stocks.go
+++ b/usecase/sync_fin_statements_all_stocks.go
@@ -1,0 +1,80 @@
+package usecase
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	syncFinStatementsAllStocksCheckpointRedisKey = "sync_fin_statements_all_stocks_checkpoint"
+	// 週次運用で前回失敗のチェックポイントが翌週まで残らないよう短めTTL。
+	syncFinStatementsAllStocksCheckpointRedisTTL = 2 * 24 * time.Hour
+)
+
+func (si *stockBrandInteractorImpl) SyncFinStatementsAllStocks(ctx context.Context, intervalMs, max int) error {
+	brands, err := si.stockBrandRepository.FindAllMainMarkets(ctx)
+	if err != nil {
+		return errors.Wrap(err, "FindAllMainMarkets error")
+	}
+
+	checkpoint, err := si.readSyncFinStatementsAllStocksCheckpoint(ctx)
+	if err != nil {
+		return err
+	}
+
+	interval := time.Duration(intervalMs) * time.Millisecond
+	processed, errCount := 0, 0
+	for _, b := range brands {
+		if max > 0 && processed >= max {
+			break
+		}
+		if checkpoint != "" && b.TickerSymbol <= checkpoint {
+			continue
+		}
+
+		if interval > 0 {
+			select {
+			case <-time.After(interval):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+
+		if err := si.SyncFinStatements(ctx, b.TickerSymbol); err != nil {
+			log.Printf("SyncFinStatementsAllStocks: %s failed: %v", b.TickerSymbol, err)
+			errCount++
+		}
+
+		if e := si.redisClient.Set(
+			ctx,
+			syncFinStatementsAllStocksCheckpointRedisKey,
+			b.TickerSymbol,
+			syncFinStatementsAllStocksCheckpointRedisTTL,
+		).Err(); e != nil {
+			log.Printf("SyncFinStatementsAllStocks: checkpoint save error: %v", e)
+		}
+		processed++
+		if processed%50 == 0 {
+			log.Printf("sync_fin_statements_all_stocks: processed %d/%d (errors=%d)", processed, len(brands), errCount)
+		}
+	}
+
+	si.redisClient.Del(ctx, syncFinStatementsAllStocksCheckpointRedisKey)
+	log.Printf("sync_fin_statements_all_stocks: completed. processed=%d errors=%d", processed, errCount)
+	return nil
+}
+
+func (si *stockBrandInteractorImpl) readSyncFinStatementsAllStocksCheckpoint(ctx context.Context) (string, error) {
+	checkpoint, err := si.redisClient.Get(ctx, syncFinStatementsAllStocksCheckpointRedisKey).Result()
+	if err != nil && !errors.Is(err, redis.Nil) {
+		return "", errors.Wrap(err, "redisClient.Get error")
+	}
+	if errors.Is(err, redis.Nil) {
+		return "", nil
+	}
+	return checkpoint, nil
+}

--- a/usecase/sync_fin_statements_all_stocks_test.go
+++ b/usecase/sync_fin_statements_all_stocks_test.go
@@ -1,0 +1,218 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	mock_gateway "github.com/Code0716/stock-price-repository/mock/gateway"
+	mock_repositories "github.com/Code0716/stock-price-repository/mock/repositories"
+	"github.com/Code0716/stock-price-repository/infrastructure/gateway"
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestStockBrandInteractorImpl_SyncFinStatementsAllStocks(t *testing.T) {
+	type fields struct {
+		stockBrandRepo   func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandRepository
+		stockAPIClient   func(ctrl *gomock.Controller) *mock_gateway.MockStockAPIClient
+		finStatementRepo func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository
+		redisSetup       func(mr *miniredis.Miniredis)
+	}
+	type args struct {
+		intervalMs int
+		max        int
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+		check   func(t *testing.T, mr *miniredis.Miniredis)
+	}{
+		{
+			name: "(a) 正常: 全銘柄を処理してチェックポイントを削除する",
+			fields: fields{
+				stockBrandRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandRepository {
+					m := mock_repositories.NewMockStockBrandRepository(ctrl)
+					m.EXPECT().FindAllMainMarkets(gomock.Any()).Return([]*models.StockBrand{
+						{TickerSymbol: "1301"},
+						{TickerSymbol: "1302"},
+					}, nil)
+					return m
+				},
+				stockAPIClient: func(ctrl *gomock.Controller) *mock_gateway.MockStockAPIClient {
+					m := mock_gateway.NewMockStockAPIClient(ctrl)
+					m.EXPECT().GetFinancialStatementsBySymbol(gomock.Any(), gateway.StockAPISymbol("1301")).
+						Return([]*gateway.FinancialStatementsResponseInfo{}, nil)
+					m.EXPECT().GetFinancialStatementsBySymbol(gomock.Any(), gateway.StockAPISymbol("1302")).
+						Return([]*gateway.FinancialStatementsResponseInfo{}, nil)
+					return m
+				},
+				finStatementRepo: func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository {
+					m := mock_repositories.NewMockFinStatementRepository(ctrl)
+					m.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+					return m
+				},
+			},
+			args: args{intervalMs: 0, max: 0},
+			check: func(t *testing.T, mr *miniredis.Miniredis) {
+				t.Helper()
+				assert.False(t, mr.Exists(syncFinStatementsAllStocksCheckpointRedisKey), "完了後はチェックポイントキーが削除されているべき")
+			},
+		},
+		{
+			name: "(b) 1銘柄がAPIエラー → ログして継続、他銘柄は処理される",
+			fields: fields{
+				stockBrandRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandRepository {
+					m := mock_repositories.NewMockStockBrandRepository(ctrl)
+					m.EXPECT().FindAllMainMarkets(gomock.Any()).Return([]*models.StockBrand{
+						{TickerSymbol: "1301"},
+						{TickerSymbol: "1302"},
+						{TickerSymbol: "1303"},
+					}, nil)
+					return m
+				},
+				stockAPIClient: func(ctrl *gomock.Controller) *mock_gateway.MockStockAPIClient {
+					m := mock_gateway.NewMockStockAPIClient(ctrl)
+					m.EXPECT().GetFinancialStatementsBySymbol(gomock.Any(), gateway.StockAPISymbol("1301")).
+						Return(nil, errors.New("api error"))
+					m.EXPECT().GetFinancialStatementsBySymbol(gomock.Any(), gateway.StockAPISymbol("1302")).
+						Return([]*gateway.FinancialStatementsResponseInfo{}, nil)
+					m.EXPECT().GetFinancialStatementsBySymbol(gomock.Any(), gateway.StockAPISymbol("1303")).
+						Return([]*gateway.FinancialStatementsResponseInfo{}, nil)
+					return m
+				},
+				finStatementRepo: func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository {
+					m := mock_repositories.NewMockFinStatementRepository(ctrl)
+					m.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(2)
+					return m
+				},
+			},
+			args:    args{intervalMs: 0, max: 0},
+			wantErr: false,
+		},
+		{
+			name: "(c) max=1: 1銘柄だけ処理して打ち切り",
+			fields: fields{
+				stockBrandRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandRepository {
+					m := mock_repositories.NewMockStockBrandRepository(ctrl)
+					m.EXPECT().FindAllMainMarkets(gomock.Any()).Return([]*models.StockBrand{
+						{TickerSymbol: "1301"},
+						{TickerSymbol: "1302"},
+					}, nil)
+					return m
+				},
+				stockAPIClient: func(ctrl *gomock.Controller) *mock_gateway.MockStockAPIClient {
+					m := mock_gateway.NewMockStockAPIClient(ctrl)
+					m.EXPECT().GetFinancialStatementsBySymbol(gomock.Any(), gateway.StockAPISymbol("1301")).
+						Return([]*gateway.FinancialStatementsResponseInfo{}, nil).Times(1)
+					return m
+				},
+				finStatementRepo: func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository {
+					m := mock_repositories.NewMockFinStatementRepository(ctrl)
+					m.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+					return m
+				},
+			},
+			args: args{intervalMs: 0, max: 1},
+		},
+		{
+			name: "(d) 再開: チェックポイントが中間symbolにセット済み → 以前の銘柄はスキップ",
+			fields: fields{
+				stockBrandRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandRepository {
+					m := mock_repositories.NewMockStockBrandRepository(ctrl)
+					m.EXPECT().FindAllMainMarkets(gomock.Any()).Return([]*models.StockBrand{
+						{TickerSymbol: "1301"},
+						{TickerSymbol: "1302"},
+						{TickerSymbol: "1303"},
+					}, nil)
+					return m
+				},
+				stockAPIClient: func(ctrl *gomock.Controller) *mock_gateway.MockStockAPIClient {
+					m := mock_gateway.NewMockStockAPIClient(ctrl)
+					m.EXPECT().GetFinancialStatementsBySymbol(gomock.Any(), gateway.StockAPISymbol("1303")).
+						Return([]*gateway.FinancialStatementsResponseInfo{}, nil).Times(1)
+					return m
+				},
+				finStatementRepo: func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository {
+					m := mock_repositories.NewMockFinStatementRepository(ctrl)
+					m.EXPECT().Upsert(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+					return m
+				},
+				redisSetup: func(mr *miniredis.Miniredis) {
+					mr.Set(syncFinStatementsAllStocksCheckpointRedisKey, "1302")
+				},
+			},
+			args: args{intervalMs: 0, max: 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mr, redisClient := newTestRedis(t)
+			if tt.fields.redisSetup != nil {
+				tt.fields.redisSetup(mr)
+			}
+
+			si := &stockBrandInteractorImpl{
+				stockBrandRepository:   tt.fields.stockBrandRepo(ctrl),
+				stockAPIClient:         tt.fields.stockAPIClient(ctrl),
+				finStatementRepository: tt.fields.finStatementRepo(ctrl),
+				redisClient:            redisClient,
+			}
+
+			err := si.SyncFinStatementsAllStocks(context.Background(), tt.args.intervalMs, tt.args.max)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SyncFinStatementsAllStocks() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.check != nil {
+				tt.check(t, mr)
+			}
+		})
+	}
+}
+
+func TestReadSyncFinStatementsAllStocksCheckpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		redisSetup func(mr *miniredis.Miniredis)
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:    "キーなし → 空文字を返す",
+			want:    "",
+			wantErr: false,
+		},
+		{
+			name: "キーあり → checkpoint値を返す",
+			redisSetup: func(mr *miniredis.Miniredis) {
+				mr.Set(syncFinStatementsAllStocksCheckpointRedisKey, "7203")
+			},
+			want:    "7203",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mr, redisClient := newTestRedis(t)
+			if tt.redisSetup != nil {
+				tt.redisSetup(mr)
+			}
+
+			si := &stockBrandInteractorImpl{redisClient: redisClient}
+			got, err := si.readSyncFinStatementsAllStocksCheckpoint(context.Background())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readSyncFinStatementsAllStocksCheckpoint() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `sync_fin_statements_all_stocks` CLIコマンドを追加。全主要市場銘柄（約3,700）の財務情報をJ-Quantsから一括取得・DBに保存する
- J-Quantsレート制限1req/secに合わせた逐次実行（`--interval-ms` デフォルト1100ms）
- Redisチェックポイント（TTL 2日）で中断再開に対応。完了後はキーを削除して次回は最初から
- 1銘柄エラーはログして継続（全体を止めない）。`--max` フラグで最大件数制限（0=全件）

## 変更ファイル
- `usecase/sync_fin_statements_all_stocks.go` — 実装（既存 `SyncFinStatements` を再利用）
- `infrastructure/cli/commands/sync_fin_statements_all_stocks.go` — CLIコマンド
- `usecase/stock_brands_interactor.go` — インターフェースにメソッド追加
- `infrastructure/cli/runner.go`, `di/wire.go`, `test/helper/runner.go` — 登録
- `mock/`, `di/wire_gen.go` — 自動生成再生成

## Test plan
- [ ] `make test-unit` → usecase テスト4ケース(a)正常/(b)エラー継続/(c)max/(d)再開 全PASS
- [ ] `make build` → ビルド成功
- [ ] `make lint` → クリーン
- [ ] 実機確認: `make cli command="sync_fin_statements_all_stocks --max=5 --interval-ms=1100"` → fin_statement行数増加, `/valuation?symbol=<synced銘柄>` でPER表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)