### PR TITLE
fix: preserve main market filter in brand search

### DIFF
--- a/infrastructure/database/stock_brand.go
+++ b/infrastructure/database/stock_brand.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"gorm.io/gen/field"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 
@@ -112,8 +113,10 @@ func (si *StockBrandRepositoryImpl) FindWithFilter(ctx context.Context, filter *
 	// キーワード: 銘柄コード前方一致 OR 銘柄名部分一致
 	if filter.Keyword != "" {
 		esc := escapeLike(filter.Keyword)
-		q = q.Where(tx.StockBrand.TickerSymbol.Like(esc + "%")).
-			Or(tx.StockBrand.Name.Like("%" + esc + "%"))
+		q = q.Where(field.Or(
+			tx.StockBrand.TickerSymbol.Like(esc+"%"),
+			tx.StockBrand.Name.Like("%"+esc+"%"),
+		))
 	}
 
 	// ページネーション: シンボル開始位置 (inclusive)

--- a/infrastructure/database/stock_brand_with_filter_test.go
+++ b/infrastructure/database/stock_brand_with_filter_test.go
@@ -214,6 +214,14 @@ func TestStockBrandRepositoryImpl_FindWithFilter(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "主要市場と銘柄名検索の組み合わせ",
+			filter: models.NewStockBrandFilter().
+				WithOnlyMainMarkets().
+				WithKeyword("Other"),
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
 			name: "主要市場フラグとMarketCodes両方指定_主要市場フラグが優先される",
 			filter: models.NewStockBrandFilter().
 				WithOnlyMainMarkets().


### PR DESCRIPTION
## Summary
- group ticker/name keyword search conditions so market filters remain applied
- add regression coverage for main-market filtering with name search

## Tests
- ENVCODE=unit go test ./infrastructure/database -run TestStockBrandRepositoryImpl_FindWithFilter -count=1
- ENVCODE=unit go test ./infrastructure/database -count=1
- ENVCODE=unit go test ./... -count=1
- pnpm test src/features/stock-brands/hooks.test.tsx (front repo)