### PR TITLE
feat: テクニカル指標フェーズ2（一目均衡表 + サポート/レジスタンス自動抽出）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,3 +290,26 @@ func TestE2E_CommandName(t *testing.T) {
 - `gorm.DB` を直接クエリに使用（gen_query 層を経由すること）
 - `local`/`dev` 以外の環境で gRPC リフレクションを有効化
 - Raspberry Pi 向けクロスコンパイル済みバイナリ `entrypoint/cli/spr-cli` をコミット
+
+---
+
+## PR・CI・main 最新化フロー
+
+```bash
+# 1. PR 作成
+gh pr create --title "<タイトル>" --body "<説明>"
+
+# 2. CI 通過を確認（全チェックがグリーンになるまで待機）
+gh pr checks <PR番号> --watch
+
+# 3. マージ（CI 通過・レビュー承認後）
+gh pr merge <PR番号> --squash --delete-branch
+
+# 4. ローカル main を最新化
+git checkout main
+git pull origin main
+```
+
+- CI がすべてグリーンになるまでマージしない
+- マージ後は必ず `git pull origin main` でローカル main を最新化する
+- feature ブランチはマージ後に削除する（`--delete-branch` オプション）

--- a/domain_service/technical_indicators.go
+++ b/domain_service/technical_indicators.go
@@ -406,6 +406,152 @@ func CalculateOBV(prices []*models.StockBrandDailyPrice) []decimal.Decimal {
 	return obv
 }
 
+// highLowMid 直近 period 日（end を含む）の (高値max + 安値min) / 2 を返す。
+func highLowMid(prices []*models.StockBrandDailyPrice, end, period int) decimal.Decimal {
+	hh := prices[end].High
+	ll := prices[end].Low
+	for j := end - period + 1; j <= end; j++ {
+		if prices[j].High.GreaterThan(hh) {
+			hh = prices[j].High
+		}
+		if prices[j].Low.LessThan(ll) {
+			ll = prices[j].Low
+		}
+	}
+	return hh.Add(ll).Div(decimal.NewFromInt(2))
+}
+
+// IchimokuResult 一目均衡表の計算結果（生値・未シフト）。
+type IchimokuResult struct {
+	Tenkan  decimal.Decimal // 転換線: (conv日高値 + conv日安値) / 2
+	Kijun   decimal.Decimal // 基準線: (base日高値 + base日安値) / 2
+	SenkouA decimal.Decimal // 先行スパンA生値: (Tenkan + Kijun) / 2
+	SenkouB decimal.Decimal // 先行スパンB生値: (spanB日高値 + spanB日安値) / 2
+}
+
+// CalculateIchimoku 一目均衡表を計算する（既定 conv=9, base=26, spanB=52）。
+// 配列長は len(prices)。データ不足（len < spanB）は nil。
+// ウォームアップ未確定インデックスは Zero。Chikou（遅行スパン）は終値そのものなので usecase 側で扱う。
+func CalculateIchimoku(prices []*models.StockBrandDailyPrice, conv, base, spanB int) []IchimokuResult {
+	n := len(prices)
+	if conv <= 0 || base <= 0 || spanB <= 0 || n < spanB {
+		return nil
+	}
+
+	two := decimal.NewFromInt(2)
+	results := make([]IchimokuResult, n)
+	for i := 0; i < n; i++ {
+		if i >= conv-1 {
+			results[i].Tenkan = highLowMid(prices, i, conv)
+		}
+		if i >= base-1 {
+			results[i].Kijun = highLowMid(prices, i, base)
+		}
+		if i >= spanB-1 {
+			results[i].SenkouB = highLowMid(prices, i, spanB)
+		}
+		if i >= base-1 && i >= conv-1 {
+			results[i].SenkouA = results[i].Tenkan.Add(results[i].Kijun).Div(two)
+		}
+	}
+	return results
+}
+
+// SwingLevel スイング高値/安値を集約したサポート/レジスタンスレベル。
+type SwingLevel struct {
+	Price   decimal.Decimal
+	Touches int // クラスタに統合されたスイング点数
+	LastIdx int // 最後にタッチしたインデックス（usecase 側で日付化）
+}
+
+// swingRawPoint スイング検出の中間値。
+type swingRawPoint struct {
+	price decimal.Decimal
+	idx   int
+}
+
+// detectSwingPoints lookback 幅でスイング高値/安値を検出して返す（価格昇順ソート済み）。
+func detectSwingPoints(prices []*models.StockBrandDailyPrice, lookback int) []swingRawPoint {
+	n := len(prices)
+	var points []swingRawPoint
+	for i := lookback; i < n-lookback; i++ {
+		high := prices[i].High
+		low := prices[i].Low
+		isHigh, isLow := true, true
+		for j := i - lookback; j <= i+lookback; j++ {
+			if j == i {
+				continue
+			}
+			if prices[j].High.GreaterThanOrEqual(high) {
+				isHigh = false
+			}
+			if prices[j].Low.LessThanOrEqual(low) {
+				isLow = false
+			}
+		}
+		if isHigh {
+			points = append(points, swingRawPoint{high, i})
+		}
+		if isLow {
+			points = append(points, swingRawPoint{low, i})
+		}
+	}
+	// 価格昇順 insertion sort
+	for i := 1; i < len(points); i++ {
+		for j := i; j > 0 && points[j].price.LessThan(points[j-1].price); j-- {
+			points[j], points[j-1] = points[j-1], points[j]
+		}
+	}
+	return points
+}
+
+// clusterSwingPoints 昇順済み points を tolerance 内でクラスタ統合して SwingLevel 配列を返す。
+func clusterSwingPoints(points []swingRawPoint, tolerance decimal.Decimal) []SwingLevel {
+	var levels []SwingLevel
+	i := 0
+	for i < len(points) {
+		cluster := []swingRawPoint{points[i]}
+		j := i + 1
+		ref := points[i].price
+		for j < len(points) && !ref.IsZero() {
+			diff := points[j].price.Sub(ref).Abs().Div(ref)
+			if diff.LessThanOrEqual(tolerance) {
+				cluster = append(cluster, points[j])
+				j++
+			} else {
+				break
+			}
+		}
+		var sum decimal.Decimal
+		maxIdx := cluster[0].idx
+		for _, c := range cluster {
+			sum = sum.Add(c.price)
+			if c.idx > maxIdx {
+				maxIdx = c.idx
+			}
+		}
+		avg := sum.Div(decimal.NewFromInt(int64(len(cluster))))
+		levels = append(levels, SwingLevel{Price: avg, Touches: len(cluster), LastIdx: maxIdx})
+		i = j
+	}
+	return levels
+}
+
+// CalculateSupportResistance スイング高安を検出しクラスタ集約してレベル配列を返す（昇順）。
+// lookback: スイング判定の左右本数（既定3）。tolerance: 同一レベルとみなす相対許容（既定0.015=1.5%）。
+// データ不足は nil。support/resistance の区別は usecase 側で最新終値と比較して付与する。
+func CalculateSupportResistance(prices []*models.StockBrandDailyPrice, lookback int, tolerance decimal.Decimal) []SwingLevel {
+	n := len(prices)
+	if lookback <= 0 || n < 2*lookback+1 {
+		return nil
+	}
+	points := detectSwingPoints(prices, lookback)
+	if len(points) == 0 {
+		return []SwingLevel{}
+	}
+	return clusterSwingPoints(points, tolerance)
+}
+
 // CalculateRollingVWAP 期間 period の移動 VWAP を計算する（既定 period=14）。
 // 典型価格 (H+L+C)/3 を出来高加重平均する。index < period-1 は未確定で Zero。
 // 期間内の出来高合計がゼロの場合はゼロ除算回避のため Zero のままとする。

--- a/domain_service/technical_indicators_test.go
+++ b/domain_service/technical_indicators_test.go
@@ -232,6 +232,162 @@ func TestCalculateOBV(t *testing.T) {
 	})
 }
 
+// --- Ichimoku ---
+
+func TestCalculateIchimoku(t *testing.T) {
+	t.Run("データ不足(len < spanB)はnil", func(t *testing.T) {
+		rows := make([][]float64, 30) // spanB=52 必要
+		for i := range rows {
+			rows[i] = []float64{100, 90, 95, 1000}
+		}
+		assert.Nil(t, CalculateIchimoku(pricesFromOHLCV(rows...), 9, 26, 52))
+	})
+
+	t.Run("period=0はnil", func(t *testing.T) {
+		rows := make([][]float64, 60)
+		for i := range rows {
+			rows[i] = []float64{100, 90, 95, 1000}
+		}
+		prices := pricesFromOHLCV(rows...)
+		assert.Nil(t, CalculateIchimoku(prices, 0, 26, 52))
+		assert.Nil(t, CalculateIchimoku(prices, 9, 0, 52))
+		assert.Nil(t, CalculateIchimoku(prices, 9, 26, 0))
+	})
+
+	t.Run("配列長がlen(prices)と一致する", func(t *testing.T) {
+		rows := make([][]float64, 60)
+		for i := range rows {
+			rows[i] = []float64{float64(100 + i), float64(90 + i), float64(95 + i), 1000}
+		}
+		prices := pricesFromOHLCV(rows...)
+		ich := CalculateIchimoku(prices, 9, 26, 52)
+		assert.NotNil(t, ich)
+		assert.Equal(t, len(prices), len(ich))
+	})
+
+	t.Run("横ばい価格: Tenkan=Kijun=SenkouA=SenkouB=価格", func(t *testing.T) {
+		rows := make([][]float64, 60)
+		for i := range rows {
+			rows[i] = []float64{100, 100, 100, 1000}
+		}
+		prices := pricesFromOHLCV(rows...)
+		ich := CalculateIchimoku(prices, 9, 26, 52)
+		assert.NotNil(t, ich)
+		expected := decimal.NewFromInt(100)
+		// index 51（spanB-1）以降は全ライン確定
+		assert.True(t, ich[51].Tenkan.Equal(expected), "Tenkan got %s", ich[51].Tenkan)
+		assert.True(t, ich[51].Kijun.Equal(expected), "Kijun got %s", ich[51].Kijun)
+		assert.True(t, ich[51].SenkouA.Equal(expected), "SenkouA got %s", ich[51].SenkouA)
+		assert.True(t, ich[51].SenkouB.Equal(expected), "SenkouB got %s", ich[51].SenkouB)
+	})
+
+	t.Run("index < conv-1 は Tenkan がゼロ", func(t *testing.T) {
+		rows := make([][]float64, 60)
+		for i := range rows {
+			rows[i] = []float64{float64(100 + i), float64(90 + i), float64(95 + i), 1000}
+		}
+		ich := CalculateIchimoku(pricesFromOHLCV(rows...), 9, 26, 52)
+		assert.True(t, ich[7].Tenkan.IsZero(), "index 7 Tenkan should be zero")
+		assert.False(t, ich[8].Tenkan.IsZero(), "index 8 Tenkan should be non-zero")
+	})
+}
+
+// --- SupportResistance ---
+
+func TestCalculateSupportResistance(t *testing.T) {
+	t.Run("データ不足はnil", func(t *testing.T) {
+		rows := make([][]float64, 5) // lookback=3 → 2*3+1=7 必要
+		for i := range rows {
+			rows[i] = []float64{100, 90, 95, 1000}
+		}
+		result := CalculateSupportResistance(pricesFromOHLCV(rows...), 3, decimal.NewFromFloat(0.015))
+		assert.Nil(t, result)
+	})
+
+	t.Run("lookback=0はnil", func(t *testing.T) {
+		rows := make([][]float64, 20)
+		for i := range rows {
+			rows[i] = []float64{100, 90, 95, 1000}
+		}
+		result := CalculateSupportResistance(pricesFromOHLCV(rows...), 0, decimal.NewFromFloat(0.015))
+		assert.Nil(t, result)
+	})
+
+	t.Run("単調増加: スイング安値なし→レベルが少ない", func(t *testing.T) {
+		rows := make([][]float64, 20)
+		for i := range rows {
+			rows[i] = []float64{float64(100 + i), float64(90 + i), float64(95 + i), 1000}
+		}
+		result := CalculateSupportResistance(pricesFromOHLCV(rows...), 3, decimal.NewFromFloat(0.015))
+		assert.NotNil(t, result)
+		// 単調増加なのでスイング高値は最後の1点のみ（端を除いた範囲）
+		// スイング安値は検出されない
+		assert.LessOrEqual(t, len(result), 2)
+	})
+
+	t.Run("明確な天底: レベルと Touches が期待通り", func(t *testing.T) {
+		// 高値100→ピーク110→谷90→ピーク112→谷88→高値105
+		rows := [][]float64{
+			{100, 98, 99, 1000},
+			{102, 99, 101, 1000},
+			{105, 100, 103, 1000},
+			{110, 105, 108, 1000}, // ピーク高値
+			{107, 102, 104, 1000},
+			{103, 98, 100, 1000},
+			{100, 90, 92, 1000},  // 谷安値
+			{101, 92, 98, 1000},
+			{104, 97, 102, 1000},
+			{108, 103, 106, 1000},
+			{112, 108, 110, 1000}, // ピーク高値
+			{109, 104, 106, 1000},
+			{105, 100, 102, 1000},
+			{101, 88, 90, 1000},   // 谷安値
+			{102, 90, 98, 1000},
+			{104, 95, 101, 1000},
+			{106, 99, 103, 1000},
+		}
+		prices := pricesFromOHLCV(rows...)
+		tol := decimal.NewFromFloat(0.015)
+		result := CalculateSupportResistance(prices, 3, tol)
+		assert.NotNil(t, result)
+		assert.Greater(t, len(result), 0)
+		// レベルは price 昇順
+		for i := 1; i < len(result); i++ {
+			assert.True(t, result[i].Price.GreaterThanOrEqual(result[i-1].Price),
+				"levels should be ascending: %s < %s", result[i-1].Price, result[i].Price)
+		}
+	})
+
+	t.Run("tolerance による統合: 近接した2スイングが1レベルに集約", func(t *testing.T) {
+		// 高値100(index=3)と高値101(index=7)の1%差 → tol=1.5% で統合される
+		// lookback=3 なのでループは i=3..n-4
+		rows := [][]float64{
+			{95, 85, 90, 1000},
+			{96, 86, 91, 1000},
+			{97, 87, 92, 1000},
+			{100, 90, 95, 1000}, // index=3: スイング高値100（[0..6]で最大）
+			{97, 87, 92, 1000},
+			{95, 85, 90, 1000},
+			{96, 86, 91, 1000},
+			{101, 91, 96, 1000}, // index=7: スイング高値101（[4..10]で最大）
+			{98, 88, 93, 1000},
+			{96, 86, 91, 1000},
+			{95, 85, 90, 1000},
+		}
+		prices := pricesFromOHLCV(rows...)
+		tol := decimal.NewFromFloat(0.015)
+		result := CalculateSupportResistance(prices, 3, tol)
+		// 100と101は1%差なので tol=1.5% で統合→Touches>=2
+		hasMerged := false
+		for _, lv := range result {
+			if lv.Touches >= 2 {
+				hasMerged = true
+			}
+		}
+		assert.True(t, hasMerged, "近接スイングが統合されたレベルが存在するはず: %+v", result)
+	})
+}
+
 // --- VWAP ---
 
 func TestCalculateRollingVWAP(t *testing.T) {

--- a/models/technical_indicators.go
+++ b/models/technical_indicators.go
@@ -15,13 +15,28 @@ type TechnicalIndicatorPoint struct {
 	MinusDI *decimal.Decimal `json:"minusDI"`
 	OBV     *decimal.Decimal `json:"obv"`
 	VWAP    *decimal.Decimal `json:"vwap"`
+	Tenkan  *decimal.Decimal `json:"tenkan"`
+	Kijun   *decimal.Decimal `json:"kijun"`
+	SenkouA *decimal.Decimal `json:"senkouA"`
+	SenkouB *decimal.Decimal `json:"senkouB"`
+	Chikou  *decimal.Decimal `json:"chikou"`
+}
+
+// SupportResistanceLevel サポート/レジスタンスレベル。
+type SupportResistanceLevel struct {
+	Price    *decimal.Decimal `json:"price"`
+	Kind     string           `json:"kind"`     // "support" | "resistance"
+	Touches  int              `json:"touches"`
+	LastDate string           `json:"lastDate"` // YYYY-MM-DD
 }
 
 // TechnicalIndicators 銘柄の指定期間テクニカル指標時系列。
 type TechnicalIndicators struct {
-	Symbol      string                    `json:"symbol"`
-	From        string                    `json:"from"`
-	To          string                    `json:"to"`
-	TradingDays int                       `json:"tradingDays"`
-	Points      []TechnicalIndicatorPoint `json:"points"`
+	Symbol                  string                    `json:"symbol"`
+	From                    string                    `json:"from"`
+	To                      string                    `json:"to"`
+	TradingDays             int                       `json:"tradingDays"`
+	Points                  []TechnicalIndicatorPoint `json:"points"`
+	FuturePoints            []TechnicalIndicatorPoint `json:"futurePoints"`
+	SupportResistanceLevels []SupportResistanceLevel  `json:"supportResistanceLevels"`
 }

--- a/usecase/technical_indicators_interactor.go
+++ b/usecase/technical_indicators_interactor.go
@@ -18,12 +18,19 @@ import (
 const minTechnicalIndicatorDays = 40
 
 const (
-	atrPeriod   = 14
-	stochK      = 14
-	stochD      = 3
-	adxPeriod   = 14
-	vwapPeriod  = 14
+	atrPeriod            = 14
+	stochK               = 14
+	stochD               = 3
+	adxPeriod            = 14
+	vwapPeriod           = 14
+	ichimokuConv         = 9
+	ichimokuBase         = 26
+	ichimokuSpanB        = 52
+	ichimokuDisplacement = 26
+	srLookback           = 3
 )
+
+var srTolerance = decimal.NewFromFloat(0.015)
 
 type technicalIndicatorsInteractorImpl struct {
 	stockBrandsDailyStockPriceRepository repositories.StockBrandsDailyPriceRepository
@@ -55,8 +62,10 @@ func (t *technicalIndicatorsInteractorImpl) GetTechnicalIndicators(ctx context.C
 	}
 
 	result := &models.TechnicalIndicators{
-		Symbol:      symbol,
-		TradingDays: len(prices),
+		Symbol:                  symbol,
+		TradingDays:             len(prices),
+		FuturePoints:            []models.TechnicalIndicatorPoint{},
+		SupportResistanceLevels: []models.SupportResistanceLevel{},
 	}
 	if len(prices) > 0 {
 		result.From = prices[0].Date.Format(util.DateLayout)
@@ -72,7 +81,12 @@ func (t *technicalIndicatorsInteractorImpl) GetTechnicalIndicators(ctx context.C
 	adx := domain_service.CalculateADX(prices, adxPeriod)
 	obv := domain_service.CalculateOBV(prices)
 	vwap := domain_service.CalculateRollingVWAP(prices, vwapPeriod)
-	result.Points = buildTechnicalIndicatorPoints(prices, atr, stoch, adx, obv, vwap)
+	ich := domain_service.CalculateIchimoku(prices, ichimokuConv, ichimokuBase, ichimokuSpanB)
+	levels := domain_service.CalculateSupportResistance(prices, srLookback, srTolerance)
+
+	result.Points = buildTechnicalIndicatorPoints(prices, atr, stoch, adx, obv, vwap, ich)
+	result.FuturePoints = buildFuturePoints(prices, ich)
+	result.SupportResistanceLevels = buildSupportResistanceLevels(levels, prices)
 
 	return result, nil
 }
@@ -84,8 +98,10 @@ func buildTechnicalIndicatorPoints(
 	adx []domain_service.ADXResult,
 	obv []decimal.Decimal,
 	vwap []decimal.Decimal,
+	ich []domain_service.IchimokuResult,
 ) []models.TechnicalIndicatorPoint {
-	points := make([]models.TechnicalIndicatorPoint, len(prices))
+	n := len(prices)
+	points := make([]models.TechnicalIndicatorPoint, n)
 	for i, p := range prices {
 		c := p.Close
 		pt := models.TechnicalIndicatorPoint{
@@ -125,7 +141,119 @@ func buildTechnicalIndicatorPoints(
 			v := vwap[i]
 			pt.VWAP = &v
 		}
+		applyIchimokuShift(&pt, prices, ich, i, n)
 		points[i] = pt
 	}
 	return points
+}
+
+// applyIchimokuShift 一目均衡表のシフトを適用して pt に書き込む。
+// - Tenkan/Kijun: 当日値をそのまま
+// - SenkouA/B: Points[i] には ich[i-disp] の生値（+26日先に投影されるため）
+// - Chikou: Points[i-disp] に prices[i].Close を書く（front で当日として描画すると -26日に見える）
+func applyIchimokuShift(pt *models.TechnicalIndicatorPoint, prices []*models.StockBrandDailyPrice, ich []domain_service.IchimokuResult, i, n int) {
+	if ich == nil {
+		return
+	}
+	disp := ichimokuDisplacement
+	if !ich[i].Tenkan.IsZero() {
+		v := ich[i].Tenkan
+		pt.Tenkan = &v
+	}
+	if !ich[i].Kijun.IsZero() {
+		v := ich[i].Kijun
+		pt.Kijun = &v
+	}
+	// SenkouA/B を当日 i に表示するには ich[i-disp] の生値を使う
+	if i >= disp {
+		if !ich[i-disp].SenkouA.IsZero() {
+			v := ich[i-disp].SenkouA
+			pt.SenkouA = &v
+		}
+		if !ich[i-disp].SenkouB.IsZero() {
+			v := ich[i-disp].SenkouB
+			pt.SenkouB = &v
+		}
+	}
+	// Chikou: i+disp < n の日は prices[i+disp].Close を当日ポイントに置く。
+	// front は Points[i].date に Chikou 値を描画 → 26日先の終値が 26日前の位置に表示される。
+	if i+disp < n {
+		v := prices[i+disp].Close
+		pt.Chikou = &v
+	}
+}
+
+func buildFuturePoints(prices []*models.StockBrandDailyPrice, ich []domain_service.IchimokuResult) []models.TechnicalIndicatorPoint {
+	if ich == nil {
+		return []models.TechnicalIndicatorPoint{}
+	}
+	n := len(prices)
+	if n == 0 {
+		return []models.TechnicalIndicatorPoint{}
+	}
+
+	disp := ichimokuDisplacement
+	lastDate := prices[n-1].Date
+	futureDates := nextBusinessDays(lastDate, disp)
+	futurePoints := make([]models.TechnicalIndicatorPoint, disp)
+
+	for j := range disp {
+		pt := models.TechnicalIndicatorPoint{
+			Date: futureDates[j].Format(util.DateLayout),
+		}
+		// j 番目の未来点のスパン = ich[n-disp+j] の生値（+disp シフト後の値）
+		srcIdx := n - disp + j
+		if srcIdx >= 0 && srcIdx < n {
+			if !ich[srcIdx].SenkouA.IsZero() {
+				v := ich[srcIdx].SenkouA
+				pt.SenkouA = &v
+			}
+			if !ich[srcIdx].SenkouB.IsZero() {
+				v := ich[srcIdx].SenkouB
+				pt.SenkouB = &v
+			}
+		}
+		futurePoints[j] = pt
+	}
+	return futurePoints
+}
+
+// nextBusinessDays lastDate の翌日から count 本の営業日（土日スキップ）を返す。
+func nextBusinessDays(lastDate time.Time, count int) []time.Time {
+	dates := make([]time.Time, 0, count)
+	cur := lastDate
+	for len(dates) < count {
+		cur = cur.AddDate(0, 0, 1)
+		if cur.Weekday() == time.Saturday || cur.Weekday() == time.Sunday {
+			continue
+		}
+		dates = append(dates, cur)
+	}
+	return dates
+}
+
+func buildSupportResistanceLevels(levels []domain_service.SwingLevel, prices []*models.StockBrandDailyPrice) []models.SupportResistanceLevel {
+	if len(levels) == 0 || len(prices) == 0 {
+		return []models.SupportResistanceLevel{}
+	}
+	lastClose := prices[len(prices)-1].Close
+	result := make([]models.SupportResistanceLevel, 0, len(levels))
+	for _, lv := range levels {
+		price := lv.Price
+		kind := "resistance"
+		if price.LessThanOrEqual(lastClose) {
+			kind = "support"
+		}
+		lastDate := ""
+		if lv.LastIdx >= 0 && lv.LastIdx < len(prices) {
+			lastDate = prices[lv.LastIdx].Date.Format(util.DateLayout)
+		}
+		result = append(result, models.SupportResistanceLevel{
+			Price:    &price,
+			Kind:     kind,
+			Touches:  lv.Touches,
+			LastDate: lastDate,
+		})
+	}
+	return result
 }


### PR DESCRIPTION
## Summary

- `domain_service/technical_indicators.go`: `CalculateIchimoku`（転換線/基準線/先行スパンA・B）と `CalculateSupportResistance`（スイング高安検出＋クラスタ集約）を追加
- `models/technical_indicators.go`: `TechnicalIndicatorPoint` に Ichimoku 5 フィールド（tenkan/kijun/senkouA/senkouB/chikou）、`TechnicalIndicators` に `FuturePoints`（未来26本の雲）・`SupportResistanceLevels` を追加
- `usecase/technical_indicators_interactor.go`: Ichimoku シフト（SenkouA/B は +26、Chikou は front で -26 描画）、未来営業日生成、サポレジ kind 分類を実装
- `CLAUDE.md`: PR・CI・main 最新化フローセクションを追加

## Test plan

- [ ] `ENVCODE=unit go test ./domain_service/... ./usecase/...` がすべて green
- [ ] `make lint` が 0 issues
- [ ] `go build ./...` がエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)