### PR TITLE
feat: デイトレ反省ダッシュボード第一弾（大損寄与率 + 惚れ込み検出）

### DIFF
--- a/entrypoint/api/handler/daytrade_handler.go
+++ b/entrypoint/api/handler/daytrade_handler.go
@@ -200,6 +200,31 @@ func (h *DaytradeHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, h.logger, stats)
 }
 
+func (h *DaytradeHandler) GetInsights(w http.ResponseWriter, r *http.Request) {
+	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	if err != nil {
+		http.Error(w, "fromの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
+		return
+	}
+	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
+	if err != nil {
+		http.Error(w, "toの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
+		return
+	}
+	if from != nil && to != nil && from.After(*to) {
+		http.Error(w, "fromはto以前の日付である必要があります", http.StatusBadRequest)
+		return
+	}
+
+	insights, err := h.usecase.GetInsights(r.Context(), from, to)
+	if err != nil {
+		h.logger.Error("daytrade insights failed", zap.Error(err))
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, h.logger, insights)
+}
+
 type daytradeRangeResponse struct {
 	Min *string `json:"min"`
 	Max *string `json:"max"`

--- a/entrypoint/api/router/router.go
+++ b/entrypoint/api/router/router.go
@@ -62,6 +62,7 @@ func NewRouter(
 		mux.HandleFunc("/daytrade/executions", daytradeHandler.GetExecutionsByDate)
 		mux.HandleFunc("/daytrade/range", daytradeHandler.GetCoveredRange)
 		mux.HandleFunc("/daytrade/stats", daytradeHandler.GetStats)
+		mux.HandleFunc("/daytrade/insights", daytradeHandler.GetInsights)
 	}
 	return mux
 }

--- a/infrastructure/database/daytrade_execution.go
+++ b/infrastructure/database/daytrade_execution.go
@@ -289,6 +289,32 @@ func (r *DaytradeExecutionRepositoryImpl) FindByDate(ctx context.Context, date t
 	return results, nil
 }
 
+func (r *DaytradeExecutionRepositoryImpl) FindByDateRange(ctx context.Context, from, to *time.Time) ([]*models.DaytradeExecution, error) {
+	tx, ok := GetTxQuery(ctx)
+	if !ok {
+		tx = r.query
+	}
+
+	q := tx.DaytradeExecution
+	stmt := q.WithContext(ctx)
+	if from != nil {
+		stmt = stmt.Where(q.ExecutedOn.Gte(*from))
+	}
+	if to != nil {
+		stmt = stmt.Where(q.ExecutedOn.Lte(*to))
+	}
+	rows, err := stmt.Order(q.ExecutedOn.Asc(), q.ID.Asc()).Find()
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, errors.Wrap(err, "DaytradeExecutionRepositoryImpl.FindByDateRange error")
+	}
+
+	results := make([]*models.DaytradeExecution, 0, len(rows))
+	for _, row := range rows {
+		results = append(results, r.convertToDomainModel(row))
+	}
+	return results, nil
+}
+
 type coveredRangeRow struct {
 	MinDate sql.NullTime `gorm:"column:min_date"`
 	MaxDate sql.NullTime `gorm:"column:max_date"`

--- a/mock/repositories/daytrade_execution.go
+++ b/mock/repositories/daytrade_execution.go
@@ -132,6 +132,21 @@ func (mr *MockDaytradeExecutionRepositoryMockRecorder) FindByDate(ctx, date any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByDate", reflect.TypeOf((*MockDaytradeExecutionRepository)(nil).FindByDate), ctx, date)
 }
 
+// FindByDateRange mocks base method.
+func (m *MockDaytradeExecutionRepository) FindByDateRange(ctx context.Context, from, to *time.Time) ([]*models.DaytradeExecution, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByDateRange", ctx, from, to)
+	ret0, _ := ret[0].([]*models.DaytradeExecution)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByDateRange indicates an expected call of FindByDateRange.
+func (mr *MockDaytradeExecutionRepositoryMockRecorder) FindByDateRange(ctx, from, to any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByDateRange", reflect.TypeOf((*MockDaytradeExecutionRepository)(nil).FindByDateRange), ctx, from, to)
+}
+
 // GetCoveredRange mocks base method.
 func (m *MockDaytradeExecutionRepository) GetCoveredRange(ctx context.Context) (*time.Time, *time.Time, error) {
 	m.ctrl.T.Helper()

--- a/mock/usecase/daytrade_interactor.go
+++ b/mock/usecase/daytrade_interactor.go
@@ -74,6 +74,21 @@ func (mr *MockDaytradeInteractorMockRecorder) GetExecutionsByDate(ctx, date any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecutionsByDate", reflect.TypeOf((*MockDaytradeInteractor)(nil).GetExecutionsByDate), ctx, date)
 }
 
+// GetInsights mocks base method.
+func (m *MockDaytradeInteractor) GetInsights(ctx context.Context, from, to *time.Time) (*models.DaytradeInsights, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInsights", ctx, from, to)
+	ret0, _ := ret[0].(*models.DaytradeInsights)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInsights indicates an expected call of GetInsights.
+func (mr *MockDaytradeInteractorMockRecorder) GetInsights(ctx, from, to any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInsights", reflect.TypeOf((*MockDaytradeInteractor)(nil).GetInsights), ctx, from, to)
+}
+
 // GetPeriodStats mocks base method.
 func (m *MockDaytradeInteractor) GetPeriodStats(ctx context.Context, from, to *time.Time) (*models.DaytradePeriodStats, error) {
 	m.ctrl.T.Helper()

--- a/models/daytrade_execution.go
+++ b/models/daytrade_execution.go
@@ -85,6 +85,52 @@ type DaytradeStatsAggregate struct {
 	MaxLoss     int64 // MIN(profit_loss)。データなしなら 0
 }
 
+// DaytradeTradeApprox は「銘柄×日×売買方向」で集約した1トレード近似
+type DaytradeTradeApprox struct {
+	TickerSymbol string
+	BrandName    string
+	ExecutedOn   time.Time
+	Direction    string // tradeKind が空なら marginKind、それ以外は tradeKind
+	ProfitLoss   int64
+	TradeAmount  int64
+	WinCount     int // 集約行のうち profit_loss > 0 の件数
+	LossCount    int // 集約行のうち profit_loss < 0 の件数
+}
+
+// DaytradeInsights デイトレ反省ダッシュボード（/daytrade/insights API レスポンス）
+type DaytradeInsights struct {
+	LossConcentration DaytradeLossConcentration `json:"lossConcentration"`
+	FavoriteTraps     []DaytradeFavoriteTrap    `json:"favoriteTraps"`
+}
+
+// DaytradeLossConcentration 大損寄与率（パレート分析）
+type DaytradeLossConcentration struct {
+	TotalLoss   int64                `json:"totalLoss"`   // 負けトレード損失合計（絶対値）
+	Top1Ratio   float64              `json:"top1Ratio"`   // 上位1件が総損失に占める割合
+	Top3Ratio   float64              `json:"top3Ratio"`
+	Top5Ratio   float64              `json:"top5Ratio"`
+	WorstTrades []DaytradeWorstTrade `json:"worstTrades"` // 損失上位5件（損失大きい順）
+}
+
+// DaytradeWorstTrade 損失上位トレード
+type DaytradeWorstTrade struct {
+	TickerSymbol string `json:"tickerSymbol"`
+	BrandName    string `json:"brandName"`
+	ExecutedOn   string `json:"executedOn"` // YYYY-MM-DD
+	Direction    string `json:"direction"`
+	ProfitLoss   int64  `json:"profitLoss"`
+}
+
+// DaytradeFavoriteTrap 惚れ込み検出（頻繁に取引するが期待値マイナスの銘柄）
+type DaytradeFavoriteTrap struct {
+	TickerSymbol string  `json:"tickerSymbol"`
+	BrandName    string  `json:"brandName"`
+	TradeCount   int     `json:"tradeCount"` // 集約後トレード数
+	TotalPnl     int64   `json:"totalPnl"`
+	Expectancy   float64 `json:"expectancy"` // TotalPnl / TradeCount
+	WinRate      float64 `json:"winRate"`
+}
+
 // DaytradePeriodStats 期間統計（/daytrade/stats API レスポンス）
 type DaytradePeriodStats struct {
 	ProfitLoss    int64 `json:"profitLoss"`

--- a/repositories/daytrade_execution.go
+++ b/repositories/daytrade_execution.go
@@ -20,6 +20,8 @@ type DaytradeExecutionRepository interface {
 	AggregateByTickerSymbol(ctx context.Context, from, to *time.Time) ([]*models.DaytradeSymbolSummary, error)
 	// 指定日の明細を取得 (executed_on, id ASC)
 	FindByDate(ctx context.Context, date time.Time) ([]*models.DaytradeExecution, error)
+	// FindByDateRange は期間内の全明細を取得する。from / to は nil 可。両方 nil なら全期間。
+	FindByDateRange(ctx context.Context, from, to *time.Time) ([]*models.DaytradeExecution, error)
 	// 取り込み済みデータがカバーする期間。データが無ければ (nil, nil, nil)。
 	GetCoveredRange(ctx context.Context) (minDate, maxDate *time.Time, err error)
 	// AggregateStats スカラー集計（MAX/MIN 含む）。from / to は nil 可。両方 nil なら全期間。

--- a/usecase/daytrade/insights.go
+++ b/usecase/daytrade/insights.go
@@ -1,0 +1,195 @@
+package daytrade
+
+import (
+	"sort"
+	"time"
+
+	"github.com/Code0716/stock-price-repository/models"
+)
+
+// normalizeDirection は旧・新フォーマット両対応で売買方向を返す。
+// 旧フォーマット: tradeKind ∈ {売建, 買建, 現物買付, 現物売却}
+// 新フォーマット: tradeKind = "" → marginKind を使用
+func normalizeDirection(tradeKind, marginKind string) string {
+	if tradeKind != "" {
+		return tradeKind
+	}
+	return marginKind
+}
+
+type tradeApproxKey struct {
+	tickerSymbol string
+	executedOn   string // YYYY-MM-DD
+	direction    string
+}
+
+type tradeAccum struct {
+	brandName   string
+	executedOn  time.Time
+	direction   string
+	profitLoss  int64
+	tradeAmount int64
+	winCount    int
+	lossCount   int
+}
+
+// BuildTradeApprox は明細を「銘柄×日×売買方向」で集約して1トレード近似を返す。
+// 分割決済が複数行に割れている場合に合算する。
+// 同一銘柄・同一日に同方向で複数エントリーした場合は区別不能なため合算される（制約として許容）。
+func BuildTradeApprox(executions []*models.DaytradeExecution) []*models.DaytradeTradeApprox {
+	keys := make([]tradeApproxKey, 0)
+	acc := make(map[tradeApproxKey]*tradeAccum)
+
+	for _, ex := range executions {
+		dir := normalizeDirection(ex.TradeKind, ex.MarginKind)
+		k := tradeApproxKey{
+			tickerSymbol: ex.TickerSymbol,
+			executedOn:   ex.ExecutedOn.Format("2006-01-02"),
+			direction:    dir,
+		}
+		if _, exists := acc[k]; !exists {
+			keys = append(keys, k)
+			acc[k] = &tradeAccum{
+				brandName:  ex.BrandName,
+				executedOn: ex.ExecutedOn,
+				direction:  dir,
+			}
+		}
+		a := acc[k]
+		a.profitLoss += ex.ProfitLoss
+		a.tradeAmount += ex.TradeAmount
+		if ex.ProfitLoss > 0 {
+			a.winCount++
+		} else if ex.ProfitLoss < 0 {
+			a.lossCount++
+		}
+	}
+
+	results := make([]*models.DaytradeTradeApprox, 0, len(keys))
+	for _, k := range keys {
+		a := acc[k]
+		results = append(results, &models.DaytradeTradeApprox{
+			TickerSymbol: k.tickerSymbol,
+			BrandName:    a.brandName,
+			ExecutedOn:   a.executedOn,
+			Direction:    k.direction,
+			ProfitLoss:   a.profitLoss,
+			TradeAmount:  a.tradeAmount,
+			WinCount:     a.winCount,
+			LossCount:    a.lossCount,
+		})
+	}
+	return results
+}
+
+// ComputeInsights はトレード近似スライスから反省指標を計算する。
+func ComputeInsights(trades []*models.DaytradeTradeApprox) *models.DaytradeInsights {
+	return &models.DaytradeInsights{
+		LossConcentration: computeLossConcentration(trades),
+		FavoriteTraps:     computeFavoriteTraps(trades),
+	}
+}
+
+func computeLossConcentration(trades []*models.DaytradeTradeApprox) models.DaytradeLossConcentration {
+	lossTrades := make([]*models.DaytradeTradeApprox, 0)
+	for _, t := range trades {
+		if t.ProfitLoss < 0 {
+			lossTrades = append(lossTrades, t)
+		}
+	}
+
+	// 損失大きい順（profit_loss が最も小さい=最大損失）
+	sort.Slice(lossTrades, func(i, j int) bool {
+		return lossTrades[i].ProfitLoss < lossTrades[j].ProfitLoss
+	})
+
+	var totalLoss int64
+	for _, t := range lossTrades {
+		totalLoss += -t.ProfitLoss
+	}
+
+	worstN := min(5, len(lossTrades))
+	worst := make([]models.DaytradeWorstTrade, 0, worstN)
+	for i := range worstN {
+		t := lossTrades[i]
+		worst = append(worst, models.DaytradeWorstTrade{
+			TickerSymbol: t.TickerSymbol,
+			BrandName:    t.BrandName,
+			ExecutedOn:   t.ExecutedOn.Format("2006-01-02"),
+			Direction:    t.Direction,
+			ProfitLoss:   t.ProfitLoss,
+		})
+	}
+
+	ratio := func(topN int) float64 {
+		if totalLoss == 0 || len(lossTrades) == 0 {
+			return 0
+		}
+		var sum int64
+		for i := 0; i < topN && i < len(lossTrades); i++ {
+			sum += -lossTrades[i].ProfitLoss
+		}
+		return float64(sum) / float64(totalLoss)
+	}
+
+	return models.DaytradeLossConcentration{
+		TotalLoss:   totalLoss,
+		Top1Ratio:   ratio(1),
+		Top3Ratio:   ratio(3),
+		Top5Ratio:   ratio(5),
+		WorstTrades: worst,
+	}
+}
+
+type symbolAcc struct {
+	brandName  string
+	tradeCount int
+	totalPnl   int64
+	winCount   int
+}
+
+func computeFavoriteTraps(trades []*models.DaytradeTradeApprox) []models.DaytradeFavoriteTrap {
+	keyOrder := make([]string, 0)
+	acc := make(map[string]*symbolAcc)
+
+	for _, t := range trades {
+		if _, exists := acc[t.TickerSymbol]; !exists {
+			keyOrder = append(keyOrder, t.TickerSymbol)
+			acc[t.TickerSymbol] = &symbolAcc{brandName: t.BrandName}
+		}
+		a := acc[t.TickerSymbol]
+		a.tradeCount++
+		a.totalPnl += t.ProfitLoss
+		if t.ProfitLoss > 0 {
+			a.winCount++
+		}
+	}
+
+	traps := make([]models.DaytradeFavoriteTrap, 0)
+	for _, sym := range keyOrder {
+		a := acc[sym]
+		if a.totalPnl >= 0 {
+			continue // 期待値プラスの銘柄は惚れ込みではない
+		}
+		expectancy := float64(a.totalPnl) / float64(a.tradeCount)
+		winRate := float64(a.winCount) / float64(a.tradeCount)
+		traps = append(traps, models.DaytradeFavoriteTrap{
+			TickerSymbol: sym,
+			BrandName:    a.brandName,
+			TradeCount:   a.tradeCount,
+			TotalPnl:     a.totalPnl,
+			Expectancy:   expectancy,
+			WinRate:      winRate,
+		})
+	}
+
+	// 取引回数の多い順（惚れ込み度順）
+	sort.Slice(traps, func(i, j int) bool {
+		if traps[i].TradeCount != traps[j].TradeCount {
+			return traps[i].TradeCount > traps[j].TradeCount
+		}
+		return traps[i].TotalPnl < traps[j].TotalPnl // 同数なら損失大きい順
+	})
+
+	return traps
+}

--- a/usecase/daytrade/insights_test.go
+++ b/usecase/daytrade/insights_test.go
@@ -1,0 +1,222 @@
+package daytrade
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Code0716/stock-price-repository/models"
+)
+
+var baseDate = time.Date(2026, 5, 21, 0, 0, 0, 0, time.Local)
+
+func TestNormalizeDirection(t *testing.T) {
+	tests := []struct {
+		name       string
+		tradeKind  string
+		marginKind string
+		want       string
+	}{
+		{"新フォーマット: tradeKind空 → marginKindを使用", "", "返済売", "返済売"},
+		{"新フォーマット: tradeKind空 → marginKind返済買", "", "返済買", "返済買"},
+		{"旧フォーマット: tradeKind優先", "売建", "返済買", "売建"},
+		{"旧フォーマット: 現物売却", "現物売却", "", "現物売却"},
+		{"両方空", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeDirection(tt.tradeKind, tt.marginKind)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuildTradeApprox(t *testing.T) {
+	tests := []struct {
+		name       string
+		executions []*models.DaytradeExecution
+		wantLen    int
+		wantPnl    map[string]int64 // key: ticker+direction
+	}{
+		{
+			name: "分割決済2行が1トレードに集約される",
+			executions: []*models.DaytradeExecution{
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, MarginKind: "返済売", ProfitLoss: 1000, TradeAmount: 500000},
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, MarginKind: "返済売", ProfitLoss: 500, TradeAmount: 300000},
+			},
+			wantLen: 1,
+			wantPnl: map[string]int64{"9984:返済売": 1500},
+		},
+		{
+			name: "同一銘柄・同日・別方向は別トレード",
+			executions: []*models.DaytradeExecution{
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, MarginKind: "返済売", ProfitLoss: 1000, TradeAmount: 500000},
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, MarginKind: "返済買", ProfitLoss: -500, TradeAmount: 300000},
+			},
+			wantLen: 2,
+			wantPnl: map[string]int64{"9984:返済売": 1000, "9984:返済買": -500},
+		},
+		{
+			name: "別銘柄は別トレード",
+			executions: []*models.DaytradeExecution{
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, MarginKind: "返済売", ProfitLoss: 1000, TradeAmount: 500000},
+				{TickerSymbol: "5803", BrandName: "FujiKumi", ExecutedOn: baseDate, MarginKind: "返済売", ProfitLoss: -800, TradeAmount: 200000},
+			},
+			wantLen: 2,
+			wantPnl: map[string]int64{"9984:返済売": 1000, "5803:返済売": -800},
+		},
+		{
+			name: "旧フォーマット(tradeKind非空)でも正しく集約",
+			executions: []*models.DaytradeExecution{
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, TradeKind: "売建", MarginKind: "返済売", ProfitLoss: 1000, TradeAmount: 500000},
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, TradeKind: "売建", MarginKind: "返済売", ProfitLoss: 460, TradeAmount: 300000},
+			},
+			wantLen: 1,
+			wantPnl: map[string]int64{"9984:売建": 1460},
+		},
+		{
+			name:       "空スライス",
+			executions: []*models.DaytradeExecution{},
+			wantLen:    0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildTradeApprox(tt.executions)
+			assert.Len(t, got, tt.wantLen)
+			for _, trade := range got {
+				key := trade.TickerSymbol + ":" + trade.Direction
+				if expected, ok := tt.wantPnl[key]; ok {
+					assert.Equal(t, expected, trade.ProfitLoss, "ProfitLoss for %s", key)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeLossConcentration(t *testing.T) {
+	tests := []struct {
+		name          string
+		trades        []*models.DaytradeTradeApprox
+		wantTotalLoss int64
+		wantTop1Min   float64 // top1 ratio >= this
+		wantTop1Max   float64 // top1 ratio <= this
+		wantWorstLen  int
+	}{
+		{
+			name: "損失3件: 上位1件の寄与率が最大",
+			trades: []*models.DaytradeTradeApprox{
+				{TickerSymbol: "A", BrandName: "A", ExecutedOn: baseDate, Direction: "返済売", ProfitLoss: -10000},
+				{TickerSymbol: "B", BrandName: "B", ExecutedOn: baseDate, Direction: "返済売", ProfitLoss: -3000},
+				{TickerSymbol: "C", BrandName: "C", ExecutedOn: baseDate, Direction: "返済売", ProfitLoss: -1000},
+				{TickerSymbol: "D", BrandName: "D", ExecutedOn: baseDate, Direction: "返済売", ProfitLoss: 2000}, // 勝ちは含めない
+			},
+			wantTotalLoss: 14000,
+			wantTop1Min:   0.71,
+			wantTop1Max:   0.72,
+			wantWorstLen:  3,
+		},
+		{
+			name: "損失ゼロ（全勝）",
+			trades: []*models.DaytradeTradeApprox{
+				{TickerSymbol: "A", BrandName: "A", ExecutedOn: baseDate, Direction: "返済売", ProfitLoss: 5000},
+			},
+			wantTotalLoss: 0,
+			wantTop1Min:   0,
+			wantTop1Max:   0,
+			wantWorstLen:  0,
+		},
+		{
+			name:          "空スライス",
+			trades:        []*models.DaytradeTradeApprox{},
+			wantTotalLoss: 0,
+			wantTop1Min:   0,
+			wantTop1Max:   0,
+			wantWorstLen:  0,
+		},
+		{
+			name: "損失が5件以上 → worst は5件まで",
+			trades: func() []*models.DaytradeTradeApprox {
+				trades := make([]*models.DaytradeTradeApprox, 7)
+				for i := range trades {
+					trades[i] = &models.DaytradeTradeApprox{
+						TickerSymbol: "X",
+						BrandName:    "X",
+						ExecutedOn:   baseDate,
+						Direction:    "返済売",
+						ProfitLoss:   int64(-(i + 1) * 1000),
+					}
+				}
+				return trades
+			}(),
+			wantTotalLoss: 28000,
+			wantTop1Min:   0.24,
+			wantTop1Max:   0.26,
+			wantWorstLen:  5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeLossConcentration(tt.trades)
+			assert.Equal(t, tt.wantTotalLoss, got.TotalLoss)
+			assert.GreaterOrEqual(t, got.Top1Ratio, tt.wantTop1Min)
+			assert.LessOrEqual(t, got.Top1Ratio, tt.wantTop1Max)
+			assert.Len(t, got.WorstTrades, tt.wantWorstLen)
+			// Top3Ratio >= Top1Ratio
+			assert.GreaterOrEqual(t, got.Top3Ratio, got.Top1Ratio)
+			// Top5Ratio >= Top3Ratio
+			assert.GreaterOrEqual(t, got.Top5Ratio, got.Top3Ratio)
+		})
+	}
+}
+
+func TestComputeFavoriteTraps(t *testing.T) {
+	tests := []struct {
+		name      string
+		trades    []*models.DaytradeTradeApprox
+		wantSyms  []string  // 期待される ticker の順序（回数降順）
+		wantCount []int
+	}{
+		{
+			name: "期待値プラスは除外、マイナスだけ回数降順",
+			trades: []*models.DaytradeTradeApprox{
+				// 9984: 3回取引、合計マイナス
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, ProfitLoss: 1000},
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate.AddDate(0, 0, 1), ProfitLoss: -2000},
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate.AddDate(0, 0, 2), ProfitLoss: -500},
+				// 5803: 2回取引、合計マイナス
+				{TickerSymbol: "5803", BrandName: "FujiKumi", ExecutedOn: baseDate, ProfitLoss: -800},
+				{TickerSymbol: "5803", BrandName: "FujiKumi", ExecutedOn: baseDate.AddDate(0, 0, 1), ProfitLoss: -200},
+				// 7974: 1回取引、合計プラス（除外される）
+				{TickerSymbol: "7974", BrandName: "Nintendo", ExecutedOn: baseDate, ProfitLoss: 3000},
+			},
+			wantSyms:  []string{"9984", "5803"},
+			wantCount: []int{3, 2},
+		},
+		{
+			name: "全銘柄がプラス → 空リスト",
+			trades: []*models.DaytradeTradeApprox{
+				{TickerSymbol: "9984", BrandName: "SBG", ExecutedOn: baseDate, ProfitLoss: 1000},
+			},
+			wantSyms:  []string{},
+			wantCount: []int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeFavoriteTraps(tt.trades)
+			assert.Len(t, got, len(tt.wantSyms))
+			for i, sym := range tt.wantSyms {
+				if i < len(got) {
+					assert.Equal(t, sym, got[i].TickerSymbol)
+					assert.Equal(t, tt.wantCount[i], got[i].TradeCount)
+					assert.Less(t, got[i].TotalPnl, int64(0), "惚れ込み銘柄のPnLは負のはず")
+				}
+			}
+		})
+	}
+}

--- a/usecase/daytrade_interactor.go
+++ b/usecase/daytrade_interactor.go
@@ -22,6 +22,8 @@ type DaytradeInteractor interface {
 	GetCoveredRange(ctx context.Context) (minDate, maxDate *time.Time, err error)
 	// GetPeriodStats は最大ドローダウン・最大連敗を含む期間統計を返す。from / to は nil 可。
 	GetPeriodStats(ctx context.Context, from, to *time.Time) (*models.DaytradePeriodStats, error)
+	// GetInsights は大損寄与率・惚れ込み検出を含む反省指標を返す。from / to は nil 可。
+	GetInsights(ctx context.Context, from, to *time.Time) (*models.DaytradeInsights, error)
 }
 
 type daytradeInteractorImpl struct {
@@ -94,6 +96,15 @@ func (u *daytradeInteractorImpl) GetExecutionsByDate(ctx context.Context, date t
 
 func (u *daytradeInteractorImpl) GetCoveredRange(ctx context.Context) (*time.Time, *time.Time, error) {
 	return u.repo.GetCoveredRange(ctx)
+}
+
+func (u *daytradeInteractorImpl) GetInsights(ctx context.Context, from, to *time.Time) (*models.DaytradeInsights, error) {
+	executions, err := u.repo.FindByDateRange(ctx, from, to)
+	if err != nil {
+		return nil, errors.Wrap(err, "FindByDateRange error")
+	}
+	trades := daytrade.BuildTradeApprox(executions)
+	return daytrade.ComputeInsights(trades), nil
 }
 
 func (u *daytradeInteractorImpl) GetPeriodStats(ctx context.Context, from, to *time.Time) (*models.DaytradePeriodStats, error) {


### PR DESCRIPTION
## Summary

- `GET /daytrade/insights` エンドポイント追加
- 「銘柄×日×売買方向」集約による1トレード近似（約定時刻・順序不要）
- 大損寄与率: 期間損失の上位1/3/5トレードが占める割合を算出（退場防止の最重要指標）
- 惚れ込み検出: 期待値マイナスなのに取引頻度が高い銘柄を回数降順で列挙
- 旧/新SBI CSVフォーマット両対応の `normalizeDirection` 実装
- ユニットテスト13ケース追加（方向正規化・集約・パレート・惚れ込みの各ケース）

## 設計上の制約（明示）

- `daytrade_executions` に約定時刻・約定順がないため、時間帯分析・順序系ティルト検知は対象外
- 同一銘柄・同日・同方向の複数エントリーは区別不能なため合算（分割決済への対応として許容）

## Test plan

- [ ] `make test-unit` がグリーンになること
- [ ] `make test-e2e` がグリーンになること（Docker MySQL 必要）
- [ ] `GET /daytrade/insights` が `lossConcentration` + `favoriteTraps` を含むJSONを返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)