### PR TITLE
fix: シグナル精度評価の先読み日数を25→40に拡張し usecase/handler ユニットテストを追加

### DIFF
--- a/domain_service/signal_performance.go
+++ b/domain_service/signal_performance.go
@@ -8,9 +8,9 @@ import (
 )
 
 // ForwardReturns シグナル日以降の価格系列（昇順）から各 horizon のリターンを計算する。
-// prices は当該銘柄のシグナル日 *以降*（シグナル日当日を含む）の日足を date 昇順で渡すこと。
-// 返値 baseFound=false はシグナル日の価格行が存在しないことを示す。その場合 returns は nil。
-// action="Sell" のとき符号を反転する。
+// prices は呼び出し側（filterPricesFrom）がシグナル日以降（当日含む）に切り取った日足を date 昇順で渡すこと。
+// prices[0] が P0（基準価格）となる。baseFound=false は prices が空、または prices[0].Adjclose がゼロのとき。
+// その場合 returns は nil。action="Sell" のとき符号を反転する。
 func ForwardReturns(prices []*models.StockBrandDailyPrice, action string, horizons []int) (map[int]*decimal.Decimal, bool) {
 	if len(prices) == 0 {
 		return nil, false

--- a/entrypoint/api/handler/signal_performance_handler_test.go
+++ b/entrypoint/api/handler/signal_performance_handler_test.go
@@ -1,0 +1,266 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	mock_driver "github.com/Code0716/stock-price-repository/mock/driver"
+	mock_usecase "github.com/Code0716/stock-price-repository/mock/usecase"
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/Code0716/stock-price-repository/util"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+)
+
+func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
+	// 固定日付
+	fixedDate, _ := time.Parse(util.DateLayout, "2024-03-31")
+
+	// 正常系レスポンスのサンプル
+	okResult := &models.SignalPerformance{
+		From:      fixedDate.AddDate(0, 0, -90),
+		To:        fixedDate,
+		Horizons:  []int{5, 10, 20},
+		Summaries: []*models.SignalPerformanceSummary{},
+		Signals:   []*models.EvaluatedSignal{},
+	}
+
+	type fields struct {
+		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor
+		httpServer func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer
+	}
+
+	tests := []struct {
+		name           string
+		fields         fields
+		req            *http.Request
+		wantStatusCode int
+		wantBody       interface{}
+	}{
+		{
+			name: "正常系: to/from 指定 → usecase に渡る",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					m := mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+					from := fixedDate.AddDate(0, 0, -90)
+					m.EXPECT().GetSignalPerformance(gomock.Any(), gomock.Eq(&models.SignalPerformanceFilter{
+						From: from,
+						To:   fixedDate,
+					})).Return(okResult, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?to=2024-03-31", nil),
+			wantStatusCode: http.StatusOK,
+			wantBody:       okResult,
+		},
+		{
+			name: "正常系: パラメータ省略時 to=今日 / from=to-90日 が usecase に渡る",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					m := mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+					// 実際の handler が計算する today/from と同じ値で比較
+					now := time.Now()
+					today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+					from := today.AddDate(0, 0, -90)
+					m.EXPECT().GetSignalPerformance(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ interface{}, f *models.SignalPerformanceFilter) (*models.SignalPerformance, error) {
+							// to は今日
+							assert.Equal(t, today.Truncate(24*time.Hour), f.To.Truncate(24*time.Hour))
+							// from は to-90日
+							assert.Equal(t, from.Truncate(24*time.Hour), f.From.Truncate(24*time.Hour))
+							return &models.SignalPerformance{
+								From:      f.From,
+								To:        f.To,
+								Horizons:  []int{5, 10, 20},
+								Summaries: []*models.SignalPerformanceSummary{},
+								Signals:   []*models.EvaluatedSignal{},
+							}, nil
+						},
+					)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance", nil),
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "正常系: method 指定時 → usecase にフィルタが渡る",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					m := mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+					from := fixedDate.AddDate(0, 0, -90)
+					m.EXPECT().GetSignalPerformance(gomock.Any(), gomock.Eq(&models.SignalPerformanceFilter{
+						From:   from,
+						To:     fixedDate,
+						Method: "find_macd_bullish_stock_v1",
+					})).Return(&models.SignalPerformance{
+						From:     from,
+						To:       fixedDate,
+						Horizons: []int{5, 10, 20},
+						Summaries: []*models.SignalPerformanceSummary{
+							{
+								Method:      "find_macd_bullish_stock_v1",
+								SignalCount: 3,
+								Stats: map[int]*models.HorizonStats{
+									5:  {EvaluatedCount: 3, WinRate: decimal.NewFromFloat(0.667)},
+									10: {EvaluatedCount: 3, WinRate: decimal.NewFromFloat(0.333)},
+									20: {EvaluatedCount: 3, WinRate: decimal.NewFromFloat(0.667)},
+								},
+							},
+						},
+						Signals: []*models.EvaluatedSignal{},
+					}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("find_macd_bullish_stock_v1")
+					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?to=2024-03-31&method=find_macd_bullish_stock_v1", nil),
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "異常系: from > to → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					return mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					from := fixedDate.AddDate(0, 0, 10) // to より後
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&from, nil)
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?from=2024-04-10&to=2024-03-31", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "fromはtoより前の日付を指定してください\n",
+		},
+		{
+			name: "異常系: 期間 366 日超 → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					return mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					from := fixedDate.AddDate(-1, 0, -2) // 367日以上前
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&from, nil)
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?from=2023-01-01&to=2024-03-31", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "期間は最大366日以内で指定してください\n",
+		},
+		{
+			name: "異常系: to の日付形式が不正 → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					return mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, errors.New("invalid date"))
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?to=invalid", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "toの日付形式が不正です（YYYY-MM-DD）\n",
+		},
+		{
+			name: "異常系: from の日付形式が不正 → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					return mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, errors.New("invalid date"))
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?from=invalid", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "fromの日付形式が不正です（YYYY-MM-DD）\n",
+		},
+		{
+			name: "異常系: usecase がエラーを返す → 500",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockSignalPerformanceInteractor {
+					m := mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
+					m.EXPECT().GetSignalPerformance(gomock.Any(), gomock.Any()).Return(nil, errors.New("db error"))
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/signal-performance", nil),
+			wantStatusCode: http.StatusInternalServerError,
+			wantBody:       "内部サーバーエラー\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			h := NewSignalPerformanceHandler(tt.fields.usecase(ctrl), tt.fields.httpServer(ctrl), zap.NewNop())
+			w := httptest.NewRecorder()
+			h.GetSignalPerformance(w, tt.req)
+
+			assert.Equal(t, tt.wantStatusCode, w.Code)
+			if tt.wantBody == nil {
+				return
+			}
+			if tt.wantStatusCode == http.StatusOK {
+				if tt.wantBody != nil {
+					wantJSON, err := json.Marshal(tt.wantBody)
+					assert.NoError(t, err)
+					assert.JSONEq(t, string(wantJSON), w.Body.String())
+				}
+			} else {
+				assert.Equal(t, tt.wantBody, w.Body.String())
+			}
+		})
+	}
+}

--- a/usecase/signal_performance_interactor.go
+++ b/usecase/signal_performance_interactor.go
@@ -13,9 +13,7 @@ import (
 )
 
 const (
-	signalPerformanceMaxDays      = 366
-	signalPerformanceDefaultDays  = 90
-	signalPerformancePriceLookAhead = 25 // +20 horizon の先読み余裕
+	signalPerformancePriceLookAhead = 40 // +20営業日 ≈ 29.4暦日 + 祝日・連休バッファ
 )
 
 var signalPerformanceHorizons = []int{5, 10, 20}

--- a/usecase/signal_performance_interactor_test.go
+++ b/usecase/signal_performance_interactor_test.go
@@ -1,0 +1,369 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mock_repositories "github.com/Code0716/stock-price-repository/mock/repositories"
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/pkg/errors"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+// --- テストヘルパー ---
+
+func spDate(y, m, d int) time.Time {
+	return time.Date(y, time.Month(m), d, 0, 0, 0, 0, time.UTC)
+}
+
+func spSignal(symbol, method, action string, date time.Time) *models.AnalyzeStockBrandPriceHistory {
+	return &models.AnalyzeStockBrandPriceHistory{
+		ID:           "id-" + symbol,
+		TickerSymbol: symbol,
+		Name:         symbol + "株式会社",
+		Method:       method,
+		Action:       action,
+		CreatedAt:    date,
+	}
+}
+
+func spPrice(symbol string, date time.Time, adjclose float64) *models.StockBrandDailyPrice {
+	return &models.StockBrandDailyPrice{
+		TickerSymbol: symbol,
+		Date:         date,
+		Adjclose:     decimal.NewFromFloat(adjclose),
+	}
+}
+
+// --- GetSignalPerformance テスト ---
+
+func TestSignalPerformanceInteractor_GetSignalPerformance(t *testing.T) {
+	from := spDate(2024, 1, 4)
+	to := spDate(2024, 3, 31)
+	// to+40日
+	wantPriceTo := to.AddDate(0, 0, signalPerformancePriceLookAhead)
+
+	signalDate := spDate(2024, 1, 10)
+	method1 := models.AnalyzeStockBrandPriceHistoryMethodFindMACDBullishV1
+	method2 := models.AnalyzeStockBrandPriceHistoryMethodFindTriangleV1
+
+	// シグナル日から始まる価格（昇順、25本以上用意して horizon=20 まで評価可能に）
+	makePrices := func(symbol string, start time.Time, n int, base float64) []*models.StockBrandDailyPrice {
+		prices := make([]*models.StockBrandDailyPrice, n)
+		for i := 0; i < n; i++ {
+			prices[i] = spPrice(symbol, start.AddDate(0, 0, i), base+float64(i))
+		}
+		return prices
+	}
+
+	type fields struct {
+		analyzeRepo func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository
+		priceRepo   func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository
+	}
+
+	tests := []struct {
+		name    string
+		filter  *models.SignalPerformanceFilter
+		fields  fields
+		wantErr bool
+		check   func(t *testing.T, got *models.SignalPerformance)
+	}{
+		{
+			name: "正常系: 複数手法のシグナルを集計し summaries が返る / priceTo が to+40日であること（P1回帰）",
+			filter: &models.SignalPerformanceFilter{
+				From: from,
+				To:   to,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Eq(&models.SignalPerformanceFilter{
+						From: from,
+						To:   to,
+					})).Return([]*models.AnalyzeStockBrandPriceHistory{
+						spSignal("7203", method1, models.AnalyzeStockBrandPriceHistoryActionBuy, signalDate),
+						spSignal("6758", method2, models.AnalyzeStockBrandPriceHistoryActionBuy, signalDate),
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, f models.ListRangePricesBySymbolsFilter) ([]*models.StockBrandDailyPrice, error) {
+							// P1回帰: DateTo が to+40日であること
+							assert.NotNil(t, f.DateTo)
+							assert.Equal(t, wantPriceTo.Truncate(24*time.Hour), f.DateTo.Truncate(24*time.Hour))
+							assert.Len(t, f.Symbols, 2)
+
+							// 各銘柄 30 本分の価格を返す
+							var prices []*models.StockBrandDailyPrice
+							prices = append(prices, makePrices("7203", signalDate, 30, 1000)...)
+							prices = append(prices, makePrices("6758", signalDate, 30, 2000)...)
+							return prices, nil
+						},
+					)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				assert.Equal(t, from, got.From)
+				assert.Equal(t, to, got.To)
+				assert.ElementsMatch(t, signalPerformanceHorizons, got.Horizons)
+				assert.Len(t, got.Summaries, 2)
+				// method 未指定なので Signals は空
+				assert.Empty(t, got.Signals)
+				// 各サマリは SignalCount=1 / SkippedCount=0
+				for _, s := range got.Summaries {
+					assert.Equal(t, 1, s.SignalCount)
+					assert.Equal(t, 0, s.SkippedCount)
+					// horizon=5,10,20 全て評価済み（30本あるので）
+					for _, h := range signalPerformanceHorizons {
+						st := s.Stats[h]
+						assert.NotNil(t, st)
+						assert.Equal(t, 1, st.EvaluatedCount)
+					}
+				}
+			},
+		},
+		{
+			name: "正常系: method 指定時は Signals 明細が非空",
+			filter: &models.SignalPerformanceFilter{
+				From:   from,
+				To:     to,
+				Method: method1,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Eq(&models.SignalPerformanceFilter{
+						From:   from,
+						To:     to,
+						Method: method1,
+					})).Return([]*models.AnalyzeStockBrandPriceHistory{
+						spSignal("7203", method1, models.AnalyzeStockBrandPriceHistoryActionBuy, signalDate),
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).Return(
+						makePrices("7203", signalDate, 30, 1000), nil,
+					)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				// method 指定時は Signals に明細が入る
+				assert.NotEmpty(t, got.Signals)
+				assert.Equal(t, method1, got.Signals[0].Method)
+			},
+		},
+		{
+			name: "正常系: method 未指定時は Signals が空スライス",
+			filter: &models.SignalPerformanceFilter{
+				From: from,
+				To:   to,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return([]*models.AnalyzeStockBrandPriceHistory{
+						spSignal("7203", method1, models.AnalyzeStockBrandPriceHistoryActionBuy, signalDate),
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).Return(
+						makePrices("7203", signalDate, 30, 1000), nil,
+					)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				assert.Equal(t, []*models.EvaluatedSignal{}, got.Signals)
+			},
+		},
+		{
+			name: "正常系: シグナル0件 → 空レスポンス / priceRepo は呼ばれない",
+			filter: &models.SignalPerformanceFilter{
+				From: from,
+				To:   to,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return([]*models.AnalyzeStockBrandPriceHistory{}, nil)
+					return m
+				},
+				// priceRepo の EXPECT は設定しない（呼ばれない）
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					return mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				assert.Equal(t, from, got.From)
+				assert.Equal(t, to, got.To)
+				assert.Empty(t, got.Summaries)
+				assert.Equal(t, []*models.EvaluatedSignal{}, got.Signals)
+			},
+		},
+		{
+			name: "異常系: analyzeRepo エラー → エラー伝播",
+			filter: &models.SignalPerformanceFilter{
+				From: from,
+				To:   to,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return(nil, errors.New("db error"))
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					return mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "異常系: priceRepo エラー → エラー伝播",
+			filter: &models.SignalPerformanceFilter{
+				From: from,
+				To:   to,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return([]*models.AnalyzeStockBrandPriceHistory{
+						spSignal("7203", method1, models.AnalyzeStockBrandPriceHistoryActionBuy, signalDate),
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).Return(nil, errors.New("db error"))
+					return m
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "正常系: Sell シグナルのリターン符号反転",
+			filter: &models.SignalPerformanceFilter{
+				From:   from,
+				To:     to,
+				Method: method1,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return([]*models.AnalyzeStockBrandPriceHistory{
+						spSignal("7203", method1, models.AnalyzeStockBrandPriceHistoryActionSell, signalDate),
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					// 価格が上昇するリストを返す（Sell の場合はリターン符号が反転されて負になるはず）
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).Return(
+						makePrices("7203", signalDate, 30, 1000), nil,
+					)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				assert.NotEmpty(t, got.Signals)
+				sig := got.Signals[0]
+				assert.Equal(t, models.AnalyzeStockBrandPriceHistoryActionSell, sig.Action)
+				// 価格が上昇しているので Sell では全 horizon でリターンが負
+				for _, h := range signalPerformanceHorizons {
+					r := sig.Returns[h]
+					assert.NotNil(t, r)
+					assert.True(t, r.IsNegative(), "Sell時リターンは負であるべき (horizon=%d, r=%v)", h, r)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			interactor := NewSignalPerformanceInteractor(
+				tt.fields.analyzeRepo(ctrl),
+				tt.fields.priceRepo(ctrl),
+			)
+			got, err := interactor.GetSignalPerformance(context.Background(), tt.filter)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}
+
+// --- filterPricesFrom 単体テスト ---
+
+func TestFilterPricesFrom(t *testing.T) {
+	d := func(day int) time.Time { return spDate(2024, 1, day) }
+
+	prices := []*models.StockBrandDailyPrice{
+		spPrice("7203", d(3), 100),
+		spPrice("7203", d(4), 101),
+		spPrice("7203", d(5), 102),
+		spPrice("7203", d(8), 103),
+	}
+
+	tests := []struct {
+		name       string
+		signalDate time.Time
+		wantLen    int
+		wantFirst  float64
+	}{
+		{
+			name:       "シグナル日と一致する価格から返す",
+			signalDate: d(4),
+			wantLen:    3,
+			wantFirst:  101,
+		},
+		{
+			name:       "シグナル日以降の最初の価格から返す（営業日ずれ）",
+			signalDate: d(6),
+			wantLen:    1,
+			wantFirst:  103,
+		},
+		{
+			name:       "全価格より前のシグナル日 → 全件返す",
+			signalDate: d(1),
+			wantLen:    4,
+			wantFirst:  100,
+		},
+		{
+			name:       "全価格より後のシグナル日 → nil",
+			signalDate: d(10),
+			wantLen:    0,
+			wantFirst:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterPricesFrom(prices, tt.signalDate)
+			assert.Len(t, got, tt.wantLen)
+			if tt.wantLen > 0 {
+				v, _ := got[0].Adjclose.Float64()
+				assert.InDelta(t, tt.wantFirst, v, 1e-9)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 背景・問題

`GET /signal-performance` API（PR#89）に 2 つの問題があった。

**バグ: 先読み日数不足による「未到来」誤判定**

`signalPerformancePriceLookAhead = 25`（暦日）では、horizon=20（営業日）の評価に必要な価格本数が足りないケースがあった。+20 営業日は最大 ≈ 29.4 暦日 + 祝日・連休バッファが必要なため、過去期間を指定すると `to` 近傍 ~10 日分のシグナルの `+20d` が DB にデータがあるにも関わらず「未到来」扱いになっていた。

**未作成テスト**

プランで必須とされていた usecase / handler のユニットテストが未作成だった。

## 変更内容

- `usecase/signal_performance_interactor.go`
  - `signalPerformancePriceLookAhead`: `25` → `40`（+20営業日 ≈ 29.4暦日 + 祝日・連休バッファ）
  - handler 側でハードコード済みで重複していた `signalPerformanceMaxDays`（366）/ `signalPerformanceDefaultDays`（90）定数を削除
- `domain_service/signal_performance.go`
  - `ForwardReturns` doc コメントを実挙動に合わせて修正（挙動変更なし）
- `usecase/signal_performance_interactor_test.go`（新規）
  - 正常系（複数手法集計・priceTo=to+40日 の P1 回帰）
  - method 指定時 → Signals 明細あり / 未指定 → 空スライス
  - シグナル 0 件 → priceRepo 未呼び出し
  - analyzeRepo エラー / priceRepo エラーの伝播
  - Sell シグナル符号反転
  - `filterPricesFrom` 単体テスト
- `entrypoint/api/handler/signal_performance_handler_test.go`（新規）
  - from > to → 400
  - 期間 366 日超 → 400
  - to / from 不正日付形式 → 400
  - パラメータ省略時の to=今日 / from=to-90日 の計算を DoAndReturn で検証
  - usecase エラー → 500
  - 正常系 → 200 + JSON

## テスト確認

```
ENVCODE=unit go test -count=1 ./usecase/... ./entrypoint/api/handler/... ./domain_service/...
```

全パッケージ PASS、golangci-lint 0 issues。