### PR TITLE
feat: 予想配当利回りを valuation API に追加

### DIFF
--- a/entrypoint/api/handler/fin_statement_handler.go
+++ b/entrypoint/api/handler/fin_statement_handler.go
@@ -36,7 +36,8 @@ type FinStatementResponse struct {
 	ForecastNetSales     *string `json:"forecastNetSales"`
 	ForecastOperatingProfit *string `json:"forecastOperatingProfit"`
 	ForecastProfit       *string `json:"forecastProfit"`
-	ForecastEPS          *string `json:"forecastEps"`
+	ForecastEPS                    *string `json:"forecastEps"`
+	ForecastDividendPerShareAnnual *string `json:"forecastDividendPerShareAnnual"`
 }
 
 type GetFinStatementsResponse struct {
@@ -94,6 +95,10 @@ func toFinStatementResponse(s *models.FinStatement) *FinStatementResponse {
 	if s.ForecastEPS != nil {
 		v := s.ForecastEPS.String()
 		resp.ForecastEPS = &v
+	}
+	if s.ForecastDividendPerShareAnnual != nil {
+		v := s.ForecastDividendPerShareAnnual.String()
+		resp.ForecastDividendPerShareAnnual = &v
 	}
 	return resp
 }

--- a/entrypoint/api/handler/valuation_handler_test.go
+++ b/entrypoint/api/handler/valuation_handler_test.go
@@ -25,6 +25,8 @@ func TestValuationHandler_GetValuation(t *testing.T) {
 	eps := decimal.NewFromFloat(100)
 	feps := decimal.NewFromFloat(125)
 	bps := decimal.NewFromFloat(500)
+	dps := decimal.NewFromFloat(20)
+	divYld := decimal.NewFromFloat(0.02)
 
 	type fields struct {
 		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockValuationInteractor
@@ -38,7 +40,53 @@ func TestValuationHandler_GetValuation(t *testing.T) {
 		wantBody       interface{}
 	}{
 		{
-			name: "正常系: バリュエーション指標を返す",
+			name: "正常系: バリュエーション指標（予想配当利回り含む）を返す",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockValuationInteractor {
+					m := mock_usecase.NewMockValuationInteractor(ctrl)
+					m.EXPECT().GetValuation(gomock.Any(), "7203").Return(&models.Valuation{
+						Symbol:                         "7203",
+						Close:                          &close,
+						PriceDate:                      "2025-06-01",
+						PER:                            &per,
+						ForwardPER:                     &fwdPer,
+						PBR:                            &pbr,
+						ROE:                            &roe,
+						TrailingEPS:                    &eps,
+						ForecastEPS:                    &feps,
+						BPS:                            &bps,
+						ForecastDividendPerShareAnnual: &dps,
+						ForecastDividendYield:          &divYld,
+						FiscalPeriod:                   "2025-03",
+					}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/valuation?symbol=7203", nil),
+			wantStatusCode: http.StatusOK,
+			wantBody: &models.Valuation{
+				Symbol:                         "7203",
+				Close:                          &close,
+				PriceDate:                      "2025-06-01",
+				PER:                            &per,
+				ForwardPER:                     &fwdPer,
+				PBR:                            &pbr,
+				ROE:                            &roe,
+				TrailingEPS:                    &eps,
+				ForecastEPS:                    &feps,
+				BPS:                            &bps,
+				ForecastDividendPerShareAnnual: &dps,
+				ForecastDividendYield:          &divYld,
+				FiscalPeriod:                   "2025-03",
+			},
+		},
+		{
+			name: "正常系: DPS/配当利回りなし（nilフィールドが含まれる）",
 			fields: fields{
 				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockValuationInteractor {
 					m := mock_usecase.NewMockValuationInteractor(ctrl)

--- a/infrastructure/database/fin_statement.go
+++ b/infrastructure/database/fin_statement.go
@@ -23,25 +23,26 @@ func NewFinStatementRepositoryImpl(db *gorm.DB) repositories.FinStatementReposit
 }
 
 type finStatementRow struct {
-	ID                      string           `gorm:"column:id"`
-	TickerSymbol            string           `gorm:"column:ticker_symbol"`
-	StockBrandID            *string          `gorm:"column:stock_brand_id"`
-	DisclosedDate           time.Time        `gorm:"column:disclosed_date"`
-	FiscalYearEnd           *time.Time       `gorm:"column:fiscal_year_end"`
-	TypeOfDocument          string           `gorm:"column:type_of_document"`
-	TypeOfCurrentPeriod     string           `gorm:"column:type_of_current_period"`
-	NetSales                *decimal.Decimal `gorm:"column:net_sales"`
-	OperatingProfit         *decimal.Decimal `gorm:"column:operating_profit"`
-	OrdinaryProfit          *decimal.Decimal `gorm:"column:ordinary_profit"`
-	Profit                  *decimal.Decimal `gorm:"column:profit"`
-	EarningsPerShare        *decimal.Decimal `gorm:"column:earnings_per_share"`
-	BookValuePerShare       *decimal.Decimal `gorm:"column:book_value_per_share"`
-	ForecastNetSales        *decimal.Decimal `gorm:"column:forecast_net_sales"`
-	ForecastOperatingProfit *decimal.Decimal `gorm:"column:forecast_operating_profit"`
-	ForecastProfit          *decimal.Decimal `gorm:"column:forecast_profit"`
-	ForecastEPS             *decimal.Decimal `gorm:"column:forecast_eps"`
-	CreatedAt               time.Time        `gorm:"column:created_at"`
-	UpdatedAt               time.Time        `gorm:"column:updated_at"`
+	ID                             string           `gorm:"column:id"`
+	TickerSymbol                   string           `gorm:"column:ticker_symbol"`
+	StockBrandID                   *string          `gorm:"column:stock_brand_id"`
+	DisclosedDate                  time.Time        `gorm:"column:disclosed_date"`
+	FiscalYearEnd                  *time.Time       `gorm:"column:fiscal_year_end"`
+	TypeOfDocument                 string           `gorm:"column:type_of_document"`
+	TypeOfCurrentPeriod            string           `gorm:"column:type_of_current_period"`
+	NetSales                       *decimal.Decimal `gorm:"column:net_sales"`
+	OperatingProfit                *decimal.Decimal `gorm:"column:operating_profit"`
+	OrdinaryProfit                 *decimal.Decimal `gorm:"column:ordinary_profit"`
+	Profit                         *decimal.Decimal `gorm:"column:profit"`
+	EarningsPerShare               *decimal.Decimal `gorm:"column:earnings_per_share"`
+	BookValuePerShare              *decimal.Decimal `gorm:"column:book_value_per_share"`
+	ForecastNetSales               *decimal.Decimal `gorm:"column:forecast_net_sales"`
+	ForecastOperatingProfit        *decimal.Decimal `gorm:"column:forecast_operating_profit"`
+	ForecastProfit                 *decimal.Decimal `gorm:"column:forecast_profit"`
+	ForecastEPS                    *decimal.Decimal `gorm:"column:forecast_eps"`
+	ForecastDividendPerShareAnnual *decimal.Decimal `gorm:"column:forecast_dividend_per_share_annual"`
+	CreatedAt                      time.Time        `gorm:"column:created_at"`
+	UpdatedAt                      time.Time        `gorm:"column:updated_at"`
 }
 
 func (finStatementRow) TableName() string { return "fin_statement" }
@@ -54,25 +55,26 @@ func (r *FinStatementRepositoryImpl) Upsert(ctx context.Context, statements []*m
 	rows := make([]*finStatementRow, 0, len(statements))
 	for _, s := range statements {
 		rows = append(rows, &finStatementRow{
-			ID:                      s.ID,
-			TickerSymbol:            s.TickerSymbol,
-			StockBrandID:            s.StockBrandID,
-			DisclosedDate:           s.DisclosedDate,
-			FiscalYearEnd:           s.FiscalYearEnd,
-			TypeOfDocument:          s.TypeOfDocument,
-			TypeOfCurrentPeriod:     s.TypeOfCurrentPeriod,
-			NetSales:                s.NetSales,
-			OperatingProfit:         s.OperatingProfit,
-			OrdinaryProfit:          s.OrdinaryProfit,
-			Profit:                  s.Profit,
-			EarningsPerShare:        s.EarningsPerShare,
-			BookValuePerShare:       s.BookValuePerShare,
-			ForecastNetSales:        s.ForecastNetSales,
-			ForecastOperatingProfit: s.ForecastOperatingProfit,
-			ForecastProfit:          s.ForecastProfit,
-			ForecastEPS:             s.ForecastEPS,
-			CreatedAt:               s.CreatedAt,
-			UpdatedAt:               s.UpdatedAt,
+			ID:                             s.ID,
+			TickerSymbol:                   s.TickerSymbol,
+			StockBrandID:                   s.StockBrandID,
+			DisclosedDate:                  s.DisclosedDate,
+			FiscalYearEnd:                  s.FiscalYearEnd,
+			TypeOfDocument:                 s.TypeOfDocument,
+			TypeOfCurrentPeriod:            s.TypeOfCurrentPeriod,
+			NetSales:                       s.NetSales,
+			OperatingProfit:                s.OperatingProfit,
+			OrdinaryProfit:                 s.OrdinaryProfit,
+			Profit:                         s.Profit,
+			EarningsPerShare:               s.EarningsPerShare,
+			BookValuePerShare:              s.BookValuePerShare,
+			ForecastNetSales:               s.ForecastNetSales,
+			ForecastOperatingProfit:        s.ForecastOperatingProfit,
+			ForecastProfit:                 s.ForecastProfit,
+			ForecastEPS:                    s.ForecastEPS,
+			ForecastDividendPerShareAnnual: s.ForecastDividendPerShareAnnual,
+			CreatedAt:                      s.CreatedAt,
+			UpdatedAt:                      s.UpdatedAt,
 		})
 	}
 
@@ -85,6 +87,7 @@ func (r *FinStatementRepositoryImpl) Upsert(ctx context.Context, statements []*m
 				"net_sales", "operating_profit", "ordinary_profit", "profit",
 				"earnings_per_share", "book_value_per_share",
 				"forecast_net_sales", "forecast_operating_profit", "forecast_profit", "forecast_eps",
+				"forecast_dividend_per_share_annual",
 				"fiscal_year_end", "type_of_current_period", "updated_at",
 			}),
 		}).
@@ -119,24 +122,25 @@ func (r *FinStatementRepositoryImpl) FindBySymbol(ctx context.Context, filter *m
 
 func (r *FinStatementRepositoryImpl) convertToDomainModel(row *finStatementRow) *models.FinStatement {
 	return &models.FinStatement{
-		ID:                      row.ID,
-		TickerSymbol:            row.TickerSymbol,
-		StockBrandID:            row.StockBrandID,
-		DisclosedDate:           row.DisclosedDate,
-		FiscalYearEnd:           row.FiscalYearEnd,
-		TypeOfDocument:          row.TypeOfDocument,
-		TypeOfCurrentPeriod:     row.TypeOfCurrentPeriod,
-		NetSales:                row.NetSales,
-		OperatingProfit:         row.OperatingProfit,
-		OrdinaryProfit:          row.OrdinaryProfit,
-		Profit:                  row.Profit,
-		EarningsPerShare:        row.EarningsPerShare,
-		BookValuePerShare:       row.BookValuePerShare,
-		ForecastNetSales:        row.ForecastNetSales,
-		ForecastOperatingProfit: row.ForecastOperatingProfit,
-		ForecastProfit:          row.ForecastProfit,
-		ForecastEPS:             row.ForecastEPS,
-		CreatedAt:               row.CreatedAt,
-		UpdatedAt:               row.UpdatedAt,
+		ID:                             row.ID,
+		TickerSymbol:                   row.TickerSymbol,
+		StockBrandID:                   row.StockBrandID,
+		DisclosedDate:                  row.DisclosedDate,
+		FiscalYearEnd:                  row.FiscalYearEnd,
+		TypeOfDocument:                 row.TypeOfDocument,
+		TypeOfCurrentPeriod:            row.TypeOfCurrentPeriod,
+		NetSales:                       row.NetSales,
+		OperatingProfit:                row.OperatingProfit,
+		OrdinaryProfit:                 row.OrdinaryProfit,
+		Profit:                         row.Profit,
+		EarningsPerShare:               row.EarningsPerShare,
+		BookValuePerShare:              row.BookValuePerShare,
+		ForecastNetSales:               row.ForecastNetSales,
+		ForecastOperatingProfit:        row.ForecastOperatingProfit,
+		ForecastProfit:                 row.ForecastProfit,
+		ForecastEPS:                    row.ForecastEPS,
+		ForecastDividendPerShareAnnual: row.ForecastDividendPerShareAnnual,
+		CreatedAt:                      row.CreatedAt,
+		UpdatedAt:                      row.UpdatedAt,
 	}
 }

--- a/infrastructure/database/gen_model/fin_statement.gen.go
+++ b/infrastructure/database/gen_model/fin_statement.gen.go
@@ -12,25 +12,26 @@ const TableNameFinStatement = "fin_statement"
 
 // FinStatement mapped from table <fin_statement>
 type FinStatement struct {
-	ID                      string     `gorm:"column:id;type:char(36);primaryKey" json:"id"`
-	TickerSymbol            string     `gorm:"column:ticker_symbol;type:varchar(10);not null;comment:証券コード" json:"ticker_symbol"`                     // 証券コード
-	StockBrandID            *string    `gorm:"column:stock_brand_id;type:char(36);comment:銘柄ID" json:"stock_brand_id"`                                // 銘柄ID
-	DisclosedDate           time.Time  `gorm:"column:disclosed_date;type:date;not null;comment:開示日" json:"disclosed_date"`                            // 開示日
-	FiscalYearEnd           *time.Time `gorm:"column:fiscal_year_end;type:date;comment:当期末日" json:"fiscal_year_end"`                                  // 当期末日
-	TypeOfDocument          *string    `gorm:"column:type_of_document;type:varchar(64);comment:開示書類種別" json:"type_of_document"`                       // 開示書類種別
-	TypeOfCurrentPeriod     *string    `gorm:"column:type_of_current_period;type:varchar(10);comment:当会計期間の種類" json:"type_of_current_period"`         // 当会計期間の種類
-	NetSales                *float64   `gorm:"column:net_sales;type:decimal(20,2);comment:売上高" json:"net_sales"`                                      // 売上高
-	OperatingProfit         *float64   `gorm:"column:operating_profit;type:decimal(20,2);comment:営業利益" json:"operating_profit"`                       // 営業利益
-	OrdinaryProfit          *float64   `gorm:"column:ordinary_profit;type:decimal(20,2);comment:経常利益" json:"ordinary_profit"`                         // 経常利益
-	Profit                  *float64   `gorm:"column:profit;type:decimal(20,2);comment:当期純利益" json:"profit"`                                          // 当期純利益
-	EarningsPerShare        *float64   `gorm:"column:earnings_per_share;type:decimal(20,4);comment:EPS" json:"earnings_per_share"`                    // EPS
-	BookValuePerShare       *float64   `gorm:"column:book_value_per_share;type:decimal(20,4);comment:BPS" json:"book_value_per_share"`                // BPS
-	ForecastNetSales        *float64   `gorm:"column:forecast_net_sales;type:decimal(20,2);comment:通期予想売上高" json:"forecast_net_sales"`                // 通期予想売上高
-	ForecastOperatingProfit *float64   `gorm:"column:forecast_operating_profit;type:decimal(20,2);comment:通期予想営業利益" json:"forecast_operating_profit"` // 通期予想営業利益
-	ForecastProfit          *float64   `gorm:"column:forecast_profit;type:decimal(20,2);comment:通期予想純利益" json:"forecast_profit"`                      // 通期予想純利益
-	ForecastEps             *float64   `gorm:"column:forecast_eps;type:decimal(20,4);comment:通期予想EPS" json:"forecast_eps"`                            // 通期予想EPS
-	CreatedAt               time.Time  `gorm:"column:created_at;type:datetime;not null" json:"created_at"`
-	UpdatedAt               time.Time  `gorm:"column:updated_at;type:datetime;not null" json:"updated_at"`
+	ID                             string     `gorm:"column:id;type:char(36);primaryKey" json:"id"`
+	TickerSymbol                   string     `gorm:"column:ticker_symbol;type:varchar(10);not null;comment:証券コード" json:"ticker_symbol"`                                                // 証券コード
+	StockBrandID                   *string    `gorm:"column:stock_brand_id;type:char(36);comment:銘柄ID" json:"stock_brand_id"`                                                           // 銘柄ID
+	DisclosedDate                  time.Time  `gorm:"column:disclosed_date;type:date;not null;comment:開示日" json:"disclosed_date"`                                                       // 開示日
+	FiscalYearEnd                  *time.Time `gorm:"column:fiscal_year_end;type:date;comment:当期末日" json:"fiscal_year_end"`                                                             // 当期末日
+	TypeOfDocument                 *string    `gorm:"column:type_of_document;type:varchar(64);comment:開示書類種別" json:"type_of_document"`                                                  // 開示書類種別
+	TypeOfCurrentPeriod            *string    `gorm:"column:type_of_current_period;type:varchar(10);comment:当会計期間の種類" json:"type_of_current_period"`                                    // 当会計期間の種類
+	NetSales                       *float64   `gorm:"column:net_sales;type:decimal(20,2);comment:売上高" json:"net_sales"`                                                                 // 売上高
+	OperatingProfit                *float64   `gorm:"column:operating_profit;type:decimal(20,2);comment:営業利益" json:"operating_profit"`                                                  // 営業利益
+	OrdinaryProfit                 *float64   `gorm:"column:ordinary_profit;type:decimal(20,2);comment:経常利益" json:"ordinary_profit"`                                                    // 経常利益
+	Profit                         *float64   `gorm:"column:profit;type:decimal(20,2);comment:当期純利益" json:"profit"`                                                                     // 当期純利益
+	EarningsPerShare               *float64   `gorm:"column:earnings_per_share;type:decimal(20,4);comment:EPS" json:"earnings_per_share"`                                               // EPS
+	BookValuePerShare              *float64   `gorm:"column:book_value_per_share;type:decimal(20,4);comment:BPS" json:"book_value_per_share"`                                           // BPS
+	ForecastNetSales               *float64   `gorm:"column:forecast_net_sales;type:decimal(20,2);comment:通期予想売上高" json:"forecast_net_sales"`                                           // 通期予想売上高
+	ForecastOperatingProfit        *float64   `gorm:"column:forecast_operating_profit;type:decimal(20,2);comment:通期予想営業利益" json:"forecast_operating_profit"`                            // 通期予想営業利益
+	ForecastProfit                 *float64   `gorm:"column:forecast_profit;type:decimal(20,2);comment:通期予想純利益" json:"forecast_profit"`                                                 // 通期予想純利益
+	ForecastEps                    *float64   `gorm:"column:forecast_eps;type:decimal(20,4);comment:通期予想EPS" json:"forecast_eps"`                                                       // 通期予想EPS
+	ForecastDividendPerShareAnnual *float64   `gorm:"column:forecast_dividend_per_share_annual;type:decimal(20,4);comment:1株あたり当期予想配当（年間合計）" json:"forecast_dividend_per_share_annual"` // 1株あたり当期予想配当（年間合計）
+	CreatedAt                      time.Time  `gorm:"column:created_at;type:datetime;not null" json:"created_at"`
+	UpdatedAt                      time.Time  `gorm:"column:updated_at;type:datetime;not null" json:"updated_at"`
 }
 
 // TableName FinStatement's table name

--- a/infrastructure/database/gen_query/fin_statement.gen.go
+++ b/infrastructure/database/gen_query/fin_statement.gen.go
@@ -45,6 +45,7 @@ func newFinStatement(db *gorm.DB, opts ...gen.DOOption) finStatement {
 	_finStatement.ForecastOperatingProfit = field.NewFloat64(tableName, "forecast_operating_profit")
 	_finStatement.ForecastProfit = field.NewFloat64(tableName, "forecast_profit")
 	_finStatement.ForecastEps = field.NewFloat64(tableName, "forecast_eps")
+	_finStatement.ForecastDividendPerShareAnnual = field.NewFloat64(tableName, "forecast_dividend_per_share_annual")
 	_finStatement.CreatedAt = field.NewTime(tableName, "created_at")
 	_finStatement.UpdatedAt = field.NewTime(tableName, "updated_at")
 
@@ -56,26 +57,27 @@ func newFinStatement(db *gorm.DB, opts ...gen.DOOption) finStatement {
 type finStatement struct {
 	finStatementDo
 
-	ALL                     field.Asterisk
-	ID                      field.String
-	TickerSymbol            field.String  // 証券コード
-	StockBrandID            field.String  // 銘柄ID
-	DisclosedDate           field.Time    // 開示日
-	FiscalYearEnd           field.Time    // 当期末日
-	TypeOfDocument          field.String  // 開示書類種別
-	TypeOfCurrentPeriod     field.String  // 当会計期間の種類
-	NetSales                field.Float64 // 売上高
-	OperatingProfit         field.Float64 // 営業利益
-	OrdinaryProfit          field.Float64 // 経常利益
-	Profit                  field.Float64 // 当期純利益
-	EarningsPerShare        field.Float64 // EPS
-	BookValuePerShare       field.Float64 // BPS
-	ForecastNetSales        field.Float64 // 通期予想売上高
-	ForecastOperatingProfit field.Float64 // 通期予想営業利益
-	ForecastProfit          field.Float64 // 通期予想純利益
-	ForecastEps             field.Float64 // 通期予想EPS
-	CreatedAt               field.Time
-	UpdatedAt               field.Time
+	ALL                            field.Asterisk
+	ID                             field.String
+	TickerSymbol                   field.String  // 証券コード
+	StockBrandID                   field.String  // 銘柄ID
+	DisclosedDate                  field.Time    // 開示日
+	FiscalYearEnd                  field.Time    // 当期末日
+	TypeOfDocument                 field.String  // 開示書類種別
+	TypeOfCurrentPeriod            field.String  // 当会計期間の種類
+	NetSales                       field.Float64 // 売上高
+	OperatingProfit                field.Float64 // 営業利益
+	OrdinaryProfit                 field.Float64 // 経常利益
+	Profit                         field.Float64 // 当期純利益
+	EarningsPerShare               field.Float64 // EPS
+	BookValuePerShare              field.Float64 // BPS
+	ForecastNetSales               field.Float64 // 通期予想売上高
+	ForecastOperatingProfit        field.Float64 // 通期予想営業利益
+	ForecastProfit                 field.Float64 // 通期予想純利益
+	ForecastEps                    field.Float64 // 通期予想EPS
+	ForecastDividendPerShareAnnual field.Float64 // 1株あたり当期予想配当（年間合計）
+	CreatedAt                      field.Time
+	UpdatedAt                      field.Time
 
 	fieldMap map[string]field.Expr
 }
@@ -109,6 +111,7 @@ func (f *finStatement) updateTableName(table string) *finStatement {
 	f.ForecastOperatingProfit = field.NewFloat64(table, "forecast_operating_profit")
 	f.ForecastProfit = field.NewFloat64(table, "forecast_profit")
 	f.ForecastEps = field.NewFloat64(table, "forecast_eps")
+	f.ForecastDividendPerShareAnnual = field.NewFloat64(table, "forecast_dividend_per_share_annual")
 	f.CreatedAt = field.NewTime(table, "created_at")
 	f.UpdatedAt = field.NewTime(table, "updated_at")
 
@@ -127,7 +130,7 @@ func (f *finStatement) GetFieldByName(fieldName string) (field.OrderExpr, bool) 
 }
 
 func (f *finStatement) fillFieldMap() {
-	f.fieldMap = make(map[string]field.Expr, 19)
+	f.fieldMap = make(map[string]field.Expr, 20)
 	f.fieldMap["id"] = f.ID
 	f.fieldMap["ticker_symbol"] = f.TickerSymbol
 	f.fieldMap["stock_brand_id"] = f.StockBrandID
@@ -145,6 +148,7 @@ func (f *finStatement) fillFieldMap() {
 	f.fieldMap["forecast_operating_profit"] = f.ForecastOperatingProfit
 	f.fieldMap["forecast_profit"] = f.ForecastProfit
 	f.fieldMap["forecast_eps"] = f.ForecastEps
+	f.fieldMap["forecast_dividend_per_share_annual"] = f.ForecastDividendPerShareAnnual
 	f.fieldMap["created_at"] = f.CreatedAt
 	f.fieldMap["updated_at"] = f.UpdatedAt
 }

--- a/models/fin_statement.go
+++ b/models/fin_statement.go
@@ -23,8 +23,9 @@ type FinStatement struct {
 	ForecastNetSales     *decimal.Decimal
 	ForecastOperatingProfit *decimal.Decimal
 	ForecastProfit       *decimal.Decimal
-	ForecastEPS          *decimal.Decimal
-	CreatedAt            time.Time
+	ForecastEPS                    *decimal.Decimal
+	ForecastDividendPerShareAnnual *decimal.Decimal
+	CreatedAt                      time.Time
 	UpdatedAt            time.Time
 }
 

--- a/models/valuation.go
+++ b/models/valuation.go
@@ -15,6 +15,8 @@ type Valuation struct {
 	TrailingEPS *decimal.Decimal `json:"trailingEps"` // 実績(FY)EPS（算出根拠）
 	ForecastEPS *decimal.Decimal `json:"forecastEps"` // 通期予想EPS
 	BPS         *decimal.Decimal `json:"bps"`         // 1株あたり純資産
+	ForecastDividendPerShareAnnual *decimal.Decimal `json:"forecastDividendPerShareAnnual"` // 1株あたり年間予想配当
+	ForecastDividendYield          *decimal.Decimal `json:"forecastDividendYield"`          // 予想配当利回り（比率: 0.02=2%）
 	// FiscalPeriod 実績EPSの決算期末（例 "2025-03"）。trailingEPSが無い場合は ""。
 	FiscalPeriod string `json:"fiscalPeriod"`
 }

--- a/usecase/sync_fin_statements.go
+++ b/usecase/sync_fin_statements.go
@@ -56,6 +56,7 @@ func (si *stockBrandInteractorImpl) SyncFinStatements(ctx context.Context, ticke
 		stmt.ForecastOperatingProfit = parseDecimalPtr(info.ForecastOperatingProfit)
 		stmt.ForecastProfit = parseDecimalPtr(info.ForecastProfit)
 		stmt.ForecastEPS = parseDecimalPtr(info.ForecastEarningsPerShare)
+		stmt.ForecastDividendPerShareAnnual = parseDecimalPtr(info.ForecastDividendPerShareAnnual)
 
 		statements = append(statements, stmt)
 	}

--- a/usecase/valuation_interactor.go
+++ b/usecase/valuation_interactor.go
@@ -24,7 +24,7 @@ type valuationInteractorImpl struct {
 	stockBrandsDailyStockPriceRepository repositories.StockBrandsDailyPriceRepository
 }
 
-// ValuationInteractor 評価指標（PER/PBR/ROE/予想PER）算出インターフェース。
+// ValuationInteractor 評価指標（PER/PBR/ROE/予想PER/予想配当利回り）算出インターフェース。
 type ValuationInteractor interface {
 	GetValuation(ctx context.Context, symbol string) (*models.Valuation, error)
 }
@@ -65,60 +65,81 @@ func (v *valuationInteractorImpl) GetValuation(ctx context.Context, symbol strin
 	}
 
 	// 財務12件（disclosed_date 降順）から各値を抽出
-	trailingEPS, forecastEPS, bps, fiscalPeriod := extractFinancialValues(statements)
-	result.TrailingEPS = trailingEPS
-	result.ForecastEPS = forecastEPS
-	result.BPS = bps
-	result.FiscalPeriod = fiscalPeriod
+	fv := extractFinancialValues(statements)
+	result.TrailingEPS = fv.trailingEPS
+	result.ForecastEPS = fv.forecastEPS
+	result.BPS = fv.bps
+	result.ForecastDividendPerShareAnnual = fv.forecastDPS
+	result.FiscalPeriod = fv.fiscalPeriod
 
 	// 指標を算出（終値が取れている場合のみ）
 	if result.Close != nil {
 		close := *result.Close
-		computed := computeValuation(close, trailingEPS, forecastEPS, bps)
+		computed := computeValuation(close, fv.trailingEPS, fv.forecastEPS, fv.bps, fv.forecastDPS)
 		result.PER = computed.PER
 		result.ForwardPER = computed.ForwardPER
 		result.PBR = computed.PBR
 		result.ROE = computed.ROE
+		result.ForecastDividendYield = computed.ForecastDividendYield
 	}
 
 	return result, nil
 }
 
-// extractFinancialValues 財務スライス（disclosed_date 降順）から実績EPS/予想EPS/BPSを抽出する。
+// financialValues extractFinancialValues の戻り値をまとめた構造体。
+type financialValues struct {
+	trailingEPS  *decimal.Decimal
+	forecastEPS  *decimal.Decimal
+	bps          *decimal.Decimal
+	forecastDPS  *decimal.Decimal
+	fiscalPeriod string
+}
+
+// extractFinancialValues 財務スライス（disclosed_date 降順）から実績EPS/予想EPS/BPS/予想DPSを抽出する。
 // 実績EPS は通期(FY)決算のみ使用する（四半期EPSは期中累計で年換算でないため除外）。
-func extractFinancialValues(statements []*models.FinStatement) (trailingEPS *decimal.Decimal, forecastEPS *decimal.Decimal, bps *decimal.Decimal, fiscalPeriod string) {
+func extractFinancialValues(statements []*models.FinStatement) financialValues {
+	var v financialValues
 	for _, s := range statements {
-		if trailingEPS == nil && s.TypeOfCurrentPeriod == typeOfCurrentPeriodFY && s.EarningsPerShare != nil {
-			trailingEPS = s.EarningsPerShare
-			if s.FiscalYearEnd != nil {
-				fiscalPeriod = s.FiscalYearEnd.Format("2006-01")
-			}
+		extractTrailingEPS(s, &v)
+		if v.forecastEPS == nil && s.ForecastEPS != nil {
+			v.forecastEPS = s.ForecastEPS
 		}
-		if forecastEPS == nil && s.ForecastEPS != nil {
-			forecastEPS = s.ForecastEPS
+		if v.bps == nil && s.BookValuePerShare != nil {
+			v.bps = s.BookValuePerShare
 		}
-		if bps == nil && s.BookValuePerShare != nil {
-			bps = s.BookValuePerShare
+		if v.forecastDPS == nil && s.ForecastDividendPerShareAnnual != nil {
+			v.forecastDPS = s.ForecastDividendPerShareAnnual
 		}
-		if trailingEPS != nil && forecastEPS != nil && bps != nil {
+		if v.trailingEPS != nil && v.forecastEPS != nil && v.bps != nil && v.forecastDPS != nil {
 			break
 		}
 	}
-	return
+	return v
+}
+
+func extractTrailingEPS(s *models.FinStatement, v *financialValues) {
+	if v.trailingEPS != nil || s.TypeOfCurrentPeriod != typeOfCurrentPeriodFY || s.EarningsPerShare == nil {
+		return
+	}
+	v.trailingEPS = s.EarningsPerShare
+	if s.FiscalYearEnd != nil {
+		v.fiscalPeriod = s.FiscalYearEnd.Format("2006-01")
+	}
 }
 
 // valuationMetrics computeValuation の戻り値。
 type valuationMetrics struct {
-	PER        *decimal.Decimal
-	ForwardPER *decimal.Decimal
-	PBR        *decimal.Decimal
-	ROE        *decimal.Decimal
+	PER                   *decimal.Decimal
+	ForwardPER            *decimal.Decimal
+	PBR                   *decimal.Decimal
+	ROE                   *decimal.Decimal
+	ForecastDividendYield *decimal.Decimal
 }
 
 // computeValuation 終値と財務値から評価指標を算出する純粋関数。
 // 割る数が nil/0/負 のときは該当指標を nil とする。
 // ただし ROE は負EPS（赤字）でも算出する（負ROEは意味があるため）。
-func computeValuation(close decimal.Decimal, trailingEPS, forecastEPS, bps *decimal.Decimal) valuationMetrics {
+func computeValuation(close decimal.Decimal, trailingEPS, forecastEPS, bps, forecastDPS *decimal.Decimal) valuationMetrics {
 	m := valuationMetrics{}
 
 	// PER = close / trailingEPS（EPS > 0 のときのみ）
@@ -143,6 +164,12 @@ func computeValuation(close decimal.Decimal, trailingEPS, forecastEPS, bps *deci
 	if trailingEPS != nil && bps != nil && bps.IsPositive() {
 		v := trailingEPS.Div(*bps)
 		m.ROE = &v
+	}
+
+	// ForecastDividendYield = forecastDPS / close（close > 0 のときのみ）
+	if forecastDPS != nil && close.IsPositive() {
+		v := forecastDPS.Div(close)
+		m.ForecastDividendYield = &v
 	}
 
 	return m

--- a/usecase/valuation_interactor_test.go
+++ b/usecase/valuation_interactor_test.go
@@ -24,10 +24,12 @@ func TestComputeValuation(t *testing.T) {
 		trailingEPS *decimal.Decimal
 		forecastEPS *decimal.Decimal
 		bps         *decimal.Decimal
+		forecastDPS *decimal.Decimal
 		wantPER     *float64
 		wantFwdPER  *float64
 		wantPBR     *float64
 		wantROE     *float64
+		wantDivYld  *float64
 	}{
 		{
 			name:        "正常系: 全指標算出",
@@ -35,10 +37,38 @@ func TestComputeValuation(t *testing.T) {
 			trailingEPS: dec(100),
 			forecastEPS: dec(125),
 			bps:         dec(500),
+			forecastDPS: dec(20),
 			wantPER:     ptr(10.0),
 			wantFwdPER:  ptr(8.0),
 			wantPBR:     ptr(2.0),
 			wantROE:     ptr(0.2),
+			wantDivYld:  ptr(0.02), // 20 / 1000
+		},
+		{
+			name:        "配当利回り: DPS=50, Close=2500 → 0.02",
+			close:       2500,
+			trailingEPS: dec(100),
+			forecastEPS: dec(125),
+			bps:         dec(500),
+			forecastDPS: dec(50),
+			wantPER:     ptr(25.0),
+			wantFwdPER:  ptr(20.0),
+			wantPBR:     ptr(5.0),
+			wantROE:     ptr(0.2),
+			wantDivYld:  ptr(0.02), // 50 / 2500
+		},
+		{
+			name:        "DPS=nil: ForecastDividendYield=nil",
+			close:       1000,
+			trailingEPS: dec(100),
+			forecastEPS: dec(125),
+			bps:         dec(500),
+			forecastDPS: nil,
+			wantPER:     ptr(10.0),
+			wantFwdPER:  ptr(8.0),
+			wantPBR:     ptr(2.0),
+			wantROE:     ptr(0.2),
+			wantDivYld:  nil,
 		},
 		{
 			name:        "赤字EPS: PER=nil, ROE は負で算出",
@@ -46,10 +76,12 @@ func TestComputeValuation(t *testing.T) {
 			trailingEPS: dec(-50),
 			forecastEPS: dec(30),
 			bps:         dec(500),
+			forecastDPS: dec(10),
 			wantPER:     nil,
 			wantFwdPER:  ptr(1000.0 / 30),
 			wantPBR:     ptr(2.0),
 			wantROE:     ptr(-0.1),
+			wantDivYld:  ptr(0.01),
 		},
 		{
 			name:        "EPS=0: PER=nil, ROE=0 (ゼロEPS/BPSは0算出)",
@@ -57,10 +89,12 @@ func TestComputeValuation(t *testing.T) {
 			trailingEPS: dec(0),
 			forecastEPS: dec(0),
 			bps:         dec(500),
+			forecastDPS: nil,
 			wantPER:     nil,
 			wantFwdPER:  nil,
 			wantPBR:     ptr(2.0),
-			wantROE:     ptr(0.0), // trailingEPS=0, bps>0 → ROE=0 (EPS=0は赤字でないため算出する)
+			wantROE:     ptr(0.0), // trailingEPS=0, bps>0 → ROE=0
+			wantDivYld:  nil,
 		},
 		{
 			name:        "BPS=0: PBR/ROE=nil",
@@ -68,10 +102,12 @@ func TestComputeValuation(t *testing.T) {
 			trailingEPS: dec(100),
 			forecastEPS: dec(120),
 			bps:         dec(0),
+			forecastDPS: nil,
 			wantPER:     ptr(10.0),
 			wantFwdPER:  ptr(1000.0 / 120),
 			wantPBR:     nil,
 			wantROE:     nil,
+			wantDivYld:  nil,
 		},
 		{
 			name:        "EPS/BPS=nil: PER/ROE=nil",
@@ -79,22 +115,25 @@ func TestComputeValuation(t *testing.T) {
 			trailingEPS: nil,
 			forecastEPS: nil,
 			bps:         nil,
+			forecastDPS: nil,
 			wantPER:     nil,
 			wantFwdPER:  nil,
 			wantPBR:     nil,
 			wantROE:     nil,
+			wantDivYld:  nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			close := decimal.NewFromFloat(tt.close)
-			got := computeValuation(close, tt.trailingEPS, tt.forecastEPS, tt.bps)
+			got := computeValuation(close, tt.trailingEPS, tt.forecastEPS, tt.bps, tt.forecastDPS)
 
 			assertDecPtr(t, "PER", tt.wantPER, got.PER)
 			assertDecPtr(t, "ForwardPER", tt.wantFwdPER, got.ForwardPER)
 			assertDecPtr(t, "PBR", tt.wantPBR, got.PBR)
 			assertDecPtr(t, "ROE", tt.wantROE, got.ROE)
+			assertDecPtr(t, "ForecastDividendYield", tt.wantDivYld, got.ForecastDividendYield)
 		})
 	}
 }
@@ -130,8 +169,9 @@ func TestValuationInteractor_GetValuation(t *testing.T) {
 	eps := decimal.NewFromFloat(100)
 	forecastEPS := decimal.NewFromFloat(125)
 	bps := decimal.NewFromFloat(500)
+	dps := decimal.NewFromFloat(50)
 
-	makeStmts := func(period string, hasEPS, hasBPS, hasFEPS bool) []*models.FinStatement {
+	makeStmts := func(period string, hasEPS, hasBPS, hasFEPS, hasDPS bool) []*models.FinStatement {
 		s := &models.FinStatement{
 			TickerSymbol:        "7203",
 			DisclosedDate:       now,
@@ -146,6 +186,9 @@ func TestValuationInteractor_GetValuation(t *testing.T) {
 		}
 		if hasFEPS {
 			s.ForecastEPS = &forecastEPS
+		}
+		if hasDPS {
+			s.ForecastDividendPerShareAnnual = &dps
 		}
 		return []*models.FinStatement{s}
 	}
@@ -162,7 +205,33 @@ func TestValuationInteractor_GetValuation(t *testing.T) {
 		check   func(t *testing.T, got *models.Valuation)
 	}{
 		{
-			name: "正常系: FY決算でPER/PBR/ROE/予想PER全算出",
+			name: "正常系: FY決算でPER/PBR/ROE/予想PER/予想配当利回り全算出",
+			fields: fields{
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().GetLatestPriceBySymbol(gomock.Any(), "7203").Return(makePrice(2500), nil)
+					return m
+				},
+				finRepo: func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository {
+					m := mock_repositories.NewMockFinStatementRepository(ctrl)
+					m.EXPECT().FindBySymbol(gomock.Any(), &models.FinStatementFilter{TickerSymbol: "7203", Limit: 12}).
+						Return(makeStmts("FY", true, true, true, true), nil)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.Valuation) {
+				assert.Equal(t, "7203", got.Symbol)
+				assert.NotNil(t, got.Close)
+				assertDecPtr(t, "PER", ptr(25.0), got.PER)       // 2500/100
+				assertDecPtr(t, "ForwardPER", ptr(20.0), got.ForwardPER) // 2500/125
+				assertDecPtr(t, "PBR", ptr(5.0), got.PBR)        // 2500/500
+				assertDecPtr(t, "ROE", ptr(0.2), got.ROE)         // 100/500
+				assertDecPtr(t, "ForecastDividendYield", ptr(0.02), got.ForecastDividendYield) // 50/2500
+				assert.Equal(t, "2025-03", got.FiscalPeriod)
+			},
+		},
+		{
+			name: "DPS=nil: ForecastDividendYield=nil",
 			fields: fields{
 				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
 					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
@@ -171,19 +240,15 @@ func TestValuationInteractor_GetValuation(t *testing.T) {
 				},
 				finRepo: func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository {
 					m := mock_repositories.NewMockFinStatementRepository(ctrl)
-					m.EXPECT().FindBySymbol(gomock.Any(), &models.FinStatementFilter{TickerSymbol: "7203", Limit: 12}).
-						Return(makeStmts("FY", true, true, true), nil)
+					m.EXPECT().FindBySymbol(gomock.Any(), gomock.Any()).
+						Return(makeStmts("FY", true, true, true, false), nil) // DPS なし
 					return m
 				},
 			},
 			check: func(t *testing.T, got *models.Valuation) {
-				assert.Equal(t, "7203", got.Symbol)
-				assert.NotNil(t, got.Close)
-				assertDecPtr(t, "PER", ptr(10.0), got.PER)
-				assertDecPtr(t, "ForwardPER", ptr(8.0), got.ForwardPER)
-				assertDecPtr(t, "PBR", ptr(2.0), got.PBR)
-				assertDecPtr(t, "ROE", ptr(0.2), got.ROE)
-				assert.Equal(t, "2025-03", got.FiscalPeriod)
+				assert.Nil(t, got.ForecastDividendYield)
+				assert.Nil(t, got.ForecastDividendPerShareAnnual)
+				assert.NotNil(t, got.PER)
 			},
 		},
 		{
@@ -197,7 +262,7 @@ func TestValuationInteractor_GetValuation(t *testing.T) {
 				finRepo: func(ctrl *gomock.Controller) *mock_repositories.MockFinStatementRepository {
 					m := mock_repositories.NewMockFinStatementRepository(ctrl)
 					m.EXPECT().FindBySymbol(gomock.Any(), gomock.Any()).
-						Return(makeStmts("1Q", true, true, true), nil) // 1Q = 四半期
+						Return(makeStmts("1Q", true, true, true, false), nil) // 1Q = 四半期
 					return m
 				},
 			},
@@ -228,6 +293,7 @@ func TestValuationInteractor_GetValuation(t *testing.T) {
 				assert.Nil(t, got.PER)
 				assert.Nil(t, got.PBR)
 				assert.Nil(t, got.ROE)
+				assert.Nil(t, got.ForecastDividendYield)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- `fin_statement` テーブルの `forecast_dividend_per_share_annual` カラム（db-migrations #5 で追加）を活用し、j-Quants API から取得した年間予想配当をDBに保存・APIで返却する
- `GET /valuation?symbol=` レスポンスに `forecastDividendPerShareAnnual` / `forecastDividendYield` を追加
- `GET /fin-statements?symbol=` レスポンスにも `forecastDividendPerShareAnnual` を追加
- 利回りは ROE と同じ流儀で比率（0.02 = 2%）で返す
- db-migrations submodule を PR #5 マージ後のコミット（000013）に更新

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `models/fin_statement.go` | `ForecastDividendPerShareAnnual` フィールド追加 |
| `models/valuation.go` | `ForecastDividendPerShareAnnual` / `ForecastDividendYield` フィールド追加 |
| `infrastructure/database/fin_statement.go` | finStatementRow・Upsert・convertToDomainModel に対応 |
| `usecase/sync_fin_statements.go` | gateway→model 変換に DPS 追加 |
| `usecase/valuation_interactor.go` | extractFinancialValues / computeValuation に DPS・利回り算出追加 |
| `entrypoint/api/handler/fin_statement_handler.go` | FinStatementResponse に追加 |
| gen_model / gen_query | `make gen` で自動再生成 |
| `usecase/valuation_interactor_test.go` | 利回り正常系・DPS nil 系テスト追加 |
| `entrypoint/api/handler/valuation_handler_test.go` | 新フィールド対応 |

## Test plan

- [x] `ENVCODE=unit go test ./...` 全パス
- [x] `make lint` 0 issues
- [x] `make gen / make mock / make di` 完了（gen_model に新カラム反映）
- [x] ローカル MySQL に migration 000013 適用済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)