### PR TITLE
feat: 戦略ランキングの銘柄ドリルダウン API を追加

### DIFF
--- a/entrypoint/api/handler/strategy_ranking_handler.go
+++ b/entrypoint/api/handler/strategy_ranking_handler.go
@@ -2,13 +2,20 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
 
+	"github.com/Code0716/stock-price-repository/domain_service"
 	"github.com/Code0716/stock-price-repository/driver"
 	"github.com/Code0716/stock-price-repository/usecase"
 	"go.uber.org/zap"
 )
 
-// StrategyRankingHandler GET /strategy-ranking のハンドラ。
+const (
+	strategyRankingStocksDefaultLimit = 100
+	strategyRankingStocksMaxLimit     = 2000
+)
+
+// StrategyRankingHandler GET /strategy-ranking および GET /strategy-ranking-stocks のハンドラ。
 type StrategyRankingHandler struct {
 	usecase    usecase.StrategyRankingInteractor
 	httpServer driver.HTTPServer
@@ -31,4 +38,49 @@ func (h *StrategyRankingHandler) GetStrategyRanking(w http.ResponseWriter, r *ht
 		return
 	}
 	respondJSON(w, h.logger, result)
+}
+
+// GetStrategyRankingStocks GET /strategy-ranking-stocks?strategy=<id>&limit=<n>
+func (h *StrategyRankingHandler) GetStrategyRankingStocks(w http.ResponseWriter, r *http.Request) {
+	strategy := r.URL.Query().Get("strategy")
+	if strategy == "" {
+		http.Error(w, "strategy パラメータは必須です", http.StatusBadRequest)
+		return
+	}
+	if !isValidStrategy(strategy) {
+		http.Error(w, "strategy が不正です", http.StatusBadRequest)
+		return
+	}
+
+	limit := strategyRankingStocksDefaultLimit
+	if ls := r.URL.Query().Get("limit"); ls != "" {
+		v, err := strconv.Atoi(ls)
+		if err != nil {
+			http.Error(w, "limit は整数で指定してください", http.StatusBadRequest)
+			return
+		}
+		if v <= 0 || v > strategyRankingStocksMaxLimit {
+			http.Error(w, "limit は 1 以上 2000 以下で指定してください", http.StatusBadRequest)
+			return
+		}
+		limit = v
+	}
+
+	result, err := h.usecase.GetStrategyRankingStocks(r.Context(), strategy, limit)
+	if err != nil {
+		h.logger.Error("failed to get strategy ranking stocks", zap.Error(err), zap.String("strategy", strategy))
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+	respondJSON(w, h.logger, result)
+}
+
+// isValidStrategy 戦略 ID が既知の5定数のいずれかか確認する。
+func isValidStrategy(strategy string) bool {
+	for _, s := range domain_service.StrategyOrder {
+		if s == strategy {
+			return true
+		}
+	}
+	return false
 }

--- a/entrypoint/api/handler/strategy_ranking_handler_test.go
+++ b/entrypoint/api/handler/strategy_ranking_handler_test.go
@@ -140,3 +140,182 @@ func TestStrategyRankingHandler_GetStrategyRanking(t *testing.T) {
 		})
 	}
 }
+
+func TestStrategyRankingHandler_GetStrategyRankingStocks(t *testing.T) {
+	type fields struct {
+		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor
+		httpServer func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		req            *http.Request
+		wantStatusCode int
+		wantBody       interface{}
+	}{
+		{
+			name: "正常系: 計算済みデータを limit 件で返す",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					m := mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+					m.EXPECT().GetStrategyRankingStocks(gomock.Any(), gomock.Eq("macd_bullish"), gomock.Eq(10)).Return(&models.StrategyStocks{
+						Computed:   true,
+						ComputedAt: "2026-06-10T00:00:00Z",
+						Strategy:   "macd_bullish",
+						Label:      "MACD強気",
+						TotalCount: 100,
+						Items: []*models.StrategyStockResult{
+							{TickerSymbol: "7203", Name: "トヨタ自動車", TotalReturn: decimal.NewFromFloat(0.15)},
+						},
+					}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks?strategy=macd_bullish&limit=10", nil),
+			wantStatusCode: http.StatusOK,
+			wantBody: &models.StrategyStocks{
+				Computed:   true,
+				ComputedAt: "2026-06-10T00:00:00Z",
+				Strategy:   "macd_bullish",
+				Label:      "MACD強気",
+				TotalCount: 100,
+				Items: []*models.StrategyStockResult{
+					{TickerSymbol: "7203", Name: "トヨタ自動車", TotalReturn: decimal.NewFromFloat(0.15)},
+				},
+			},
+		},
+		{
+			name: "正常系: limit 省略時デフォルト100",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					m := mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+					m.EXPECT().GetStrategyRankingStocks(gomock.Any(), gomock.Eq("bollinger_breakout"), gomock.Eq(100)).Return(&models.StrategyStocks{
+						Computed: false,
+						Strategy: "bollinger_breakout",
+						Items:    []*models.StrategyStockResult{},
+					}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks?strategy=bollinger_breakout", nil),
+			wantStatusCode: http.StatusOK,
+			wantBody: &models.StrategyStocks{
+				Computed: false,
+				Strategy: "bollinger_breakout",
+				Items:    []*models.StrategyStockResult{},
+			},
+		},
+		{
+			name: "異常系: strategy パラメータなし → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					return mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "strategy パラメータは必須です\n",
+		},
+		{
+			name: "異常系: 不正な strategy → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					return mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks?strategy=invalid_strategy", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "strategy が不正です\n",
+		},
+		{
+			name: "異常系: limit が整数でない → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					return mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks?strategy=macd_bullish&limit=abc", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "limit は整数で指定してください\n",
+		},
+		{
+			name: "異常系: limit が範囲外（0） → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					return mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks?strategy=macd_bullish&limit=0", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "limit は 1 以上 2000 以下で指定してください\n",
+		},
+		{
+			name: "異常系: limit が範囲外（2001） → 400",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					return mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks?strategy=macd_bullish&limit=2001", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "limit は 1 以上 2000 以下で指定してください\n",
+		},
+		{
+			name: "異常系: UseCaseがエラーを返す → 500",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStrategyRankingInteractor {
+					m := mock_usecase.NewMockStrategyRankingInteractor(ctrl)
+					m.EXPECT().GetStrategyRankingStocks(gomock.Any(), gomock.Eq("macd_bullish"), gomock.Eq(100)).Return(nil, errors.New("redis error"))
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					return mock_driver.NewMockHTTPServer(ctrl)
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/strategy-ranking-stocks?strategy=macd_bullish", nil),
+			wantStatusCode: http.StatusInternalServerError,
+			wantBody:       "内部サーバーエラー\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			h := NewStrategyRankingHandler(tt.fields.usecase(ctrl), tt.fields.httpServer(ctrl), zap.NewNop())
+			w := httptest.NewRecorder()
+			h.GetStrategyRankingStocks(w, tt.req)
+
+			assert.Equal(t, tt.wantStatusCode, w.Code)
+			if tt.wantStatusCode == http.StatusOK {
+				wantJSON, err := json.Marshal(tt.wantBody)
+				assert.NoError(t, err)
+				assert.JSONEq(t, string(wantJSON), w.Body.String())
+			} else {
+				assert.Equal(t, tt.wantBody, w.Body.String())
+			}
+		})
+	}
+}

--- a/entrypoint/api/router/router.go
+++ b/entrypoint/api/router/router.go
@@ -33,6 +33,7 @@ func NewRouter(
 	}
 	if strategyRankingHandler != nil {
 		mux.HandleFunc("/strategy-ranking", strategyRankingHandler.GetStrategyRanking)
+		mux.HandleFunc("/strategy-ranking-stocks", strategyRankingHandler.GetStrategyRankingStocks)
 	}
 	if valuationHandler != nil {
 		mux.HandleFunc("/valuation", valuationHandler.GetValuation)

--- a/mock/usecase/strategy_ranking_interactor.go
+++ b/mock/usecase/strategy_ranking_interactor.go
@@ -70,3 +70,18 @@ func (mr *MockStrategyRankingInteractorMockRecorder) GetStrategyRanking(ctx any)
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStrategyRanking", reflect.TypeOf((*MockStrategyRankingInteractor)(nil).GetStrategyRanking), ctx)
 }
+
+// GetStrategyRankingStocks mocks base method.
+func (m *MockStrategyRankingInteractor) GetStrategyRankingStocks(ctx context.Context, strategy string, limit int) (*models.StrategyStocks, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStrategyRankingStocks", ctx, strategy, limit)
+	ret0, _ := ret[0].(*models.StrategyStocks)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStrategyRankingStocks indicates an expected call of GetStrategyRankingStocks.
+func (mr *MockStrategyRankingInteractorMockRecorder) GetStrategyRankingStocks(ctx, strategy, limit any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStrategyRankingStocks", reflect.TypeOf((*MockStrategyRankingInteractor)(nil).GetStrategyRankingStocks), ctx, strategy, limit)
+}

--- a/models/strategy_ranking.go
+++ b/models/strategy_ranking.go
@@ -18,10 +18,33 @@ type StrategyRankingItem struct {
 
 // StrategyRanking 全戦略の横断集計（Redis に JSON で保存する）。
 type StrategyRanking struct {
-	Computed    bool                `json:"computed"`    // バッチ未実行なら false
-	ComputedAt  string              `json:"computedAt"`  // RFC3339 or ""
-	Universe    string              `json:"universe"`    // "main_markets"
-	TotalStocks int                 `json:"totalStocks"` // ユニバースの銘柄数
-	Params      BacktestParams      `json:"params"`
+	Computed    bool                  `json:"computed"`    // バッチ未実行なら false
+	ComputedAt  string                `json:"computedAt"`  // RFC3339 or ""
+	Universe    string                `json:"universe"`    // "main_markets"
+	TotalStocks int                   `json:"totalStocks"` // ユニバースの銘柄数
+	Params      BacktestParams        `json:"params"`
 	Items       []StrategyRankingItem `json:"items"` // AvgTotalReturn 降順
+}
+
+// StrategyStockResult 1戦略×1銘柄のバックテスト結果（ドリルダウン用）。
+type StrategyStockResult struct {
+	TickerSymbol string          `json:"tickerSymbol"`
+	Name         string          `json:"name"`
+	TotalReturn  decimal.Decimal `json:"totalReturn"`
+	Trades       int             `json:"trades"`
+	WinRate      decimal.Decimal `json:"winRate"`
+	ProfitFactor decimal.Decimal `json:"profitFactor"`
+	MaxDrawdown  decimal.Decimal `json:"maxDrawdown"`
+	PayoffRatio  decimal.Decimal `json:"payoffRatio"`
+	AvgHoldDays  float64         `json:"avgHoldDays"`
+}
+
+// StrategyStocks ドリルダウン API レスポンス（Redis に JSON で保存する）。
+type StrategyStocks struct {
+	Computed   bool                   `json:"computed"`   // バッチ未実行なら false
+	ComputedAt string                 `json:"computedAt"` // RFC3339 or ""
+	Strategy   string                 `json:"strategy"`
+	Label      string                 `json:"label"`
+	TotalCount int                    `json:"totalCount"` // limit 適用前の全件数
+	Items      []*StrategyStockResult `json:"items"`      // TotalReturn 降順
 }

--- a/usecase/strategy_ranking_interactor.go
+++ b/usecase/strategy_ranking_interactor.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	strategyRankingRedisKey = "strategy_ranking:v1"
-	strategyRankingUniverse = "main_markets"
+	strategyRankingRedisKey        = "strategy_ranking:v1"
+	strategyRankingStocksKeyPrefix = "strategy_ranking:v1:stocks:"
+	strategyRankingUniverse        = "main_markets"
 	// strategyRankingMinDays は指標ウォームアップに必要な最低日数（backtest_interactor.go と同値）。
 	strategyRankingMinDays = 80
 )
@@ -37,6 +38,8 @@ type strategyAcc struct {
 	sumPF          decimal.Decimal
 	totalTrades    int
 	bestCount      int
+	// stocks 銘柄別のドリルダウン結果リスト（ドリルダウン API 用）
+	stocks []*models.StrategyStockResult
 }
 
 // newAccs 戦略ごとの集計アキュムレータを初期化して返す。
@@ -60,12 +63,13 @@ func mergeAccs(dst, src map[string]*strategyAcc) {
 		d.sumPF = d.sumPF.Add(sa.sumPF)
 		d.totalTrades += sa.totalTrades
 		d.bestCount += sa.bestCount
+		d.stocks = append(d.stocks, sa.stocks...)
 	}
 }
 
 // accumulateResults 日足と exitParams から各戦略の結果を accs に集計する。
 // 集計用途のため Equity/TradeList を構築しない RunBacktestMetrics を使う。
-func accumulateResults(prices []*models.StockBrandDailyPrice, exitParams domain_service.ExitParams, accs map[string]*strategyAcc) {
+func accumulateResults(brand *models.StockBrand, prices []*models.StockBrandDailyPrice, exitParams domain_service.ExitParams, accs map[string]*strategyAcc) {
 	results := make(map[string]models.BacktestResult, len(domain_service.StrategyOrder))
 	for _, s := range domain_service.StrategyOrder {
 		signals := domain_service.EntrySignalsByStrategy(s, prices)
@@ -85,6 +89,18 @@ func accumulateResults(prices []*models.StockBrandDailyPrice, exitParams domain_
 			a.sumWinRate = a.sumWinRate.Add(res.WinRate)
 			a.sumPF = a.sumPF.Add(res.ProfitFactor)
 		}
+		// 銘柄別ドリルダウン用に結果を蓄積
+		a.stocks = append(a.stocks, &models.StrategyStockResult{
+			TickerSymbol: brand.TickerSymbol,
+			Name:         brand.Name,
+			TotalReturn:  res.TotalReturn,
+			Trades:       res.Trades,
+			WinRate:      res.WinRate,
+			ProfitFactor: res.ProfitFactor,
+			MaxDrawdown:  res.MaxDrawdown,
+			PayoffRatio:  res.PayoffRatio,
+			AvgHoldDays:  res.AvgHoldDays,
+		})
 	}
 	// この銘柄で最高 TotalReturn の戦略の bestCount を加算する
 	bestStrategy := ""
@@ -113,6 +129,9 @@ type StrategyRankingInteractor interface {
 	ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years, concurrency int) (int, error)
 	// GetStrategyRanking Redis から集計を返す。未計算なら Computed=false の空の StrategyRanking を返す。
 	GetStrategyRanking(ctx context.Context) (*models.StrategyRanking, error)
+	// GetStrategyRankingStocks Redis から戦略別の銘柄ドリルダウン結果を返す。
+	// 未計算なら Computed=false の空の StrategyStocks を返す。Items は limit 件に切り、TotalCount は全件数。
+	GetStrategyRankingStocks(ctx context.Context, strategy string, limit int) (*models.StrategyStocks, error)
 }
 
 func NewStrategyRankingInteractor(
@@ -140,6 +159,32 @@ func (r *strategyRankingInteractorImpl) GetStrategyRanking(ctx context.Context) 
 		return nil, errors.Wrap(err, "json.Unmarshal error")
 	}
 	return &ranking, nil
+}
+
+func (r *strategyRankingInteractorImpl) GetStrategyRankingStocks(ctx context.Context, strategy string, limit int) (*models.StrategyStocks, error) {
+	key := strategyRankingStocksKeyPrefix + strategy
+	raw, err := r.redisClient.Get(ctx, key).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return &models.StrategyStocks{
+				Computed: false,
+				Strategy: strategy,
+				Items:    []*models.StrategyStockResult{},
+			}, nil
+		}
+		return nil, errors.Wrap(err, "redisClient.Get error")
+	}
+	var stocks models.StrategyStocks
+	if err := json.Unmarshal([]byte(raw), &stocks); err != nil {
+		return nil, errors.Wrap(err, "json.Unmarshal error")
+	}
+	// TotalCount は全件数
+	stocks.TotalCount = len(stocks.Items)
+	// limit 件に切る
+	if limit > 0 && len(stocks.Items) > limit {
+		stocks.Items = stocks.Items[:limit]
+	}
+	return &stocks, nil
 }
 
 func (r *strategyRankingInteractorImpl) ComputeAndSaveStrategyRanking(ctx context.Context, params models.BacktestParams, years, concurrency int) (int, error) {
@@ -206,6 +251,32 @@ func (r *strategyRankingInteractorImpl) ComputeAndSaveStrategyRanking(ctx contex
 		return processed, errors.Wrap(err, "redisClient.Set error")
 	}
 
+	// 戦略別銘柄ドリルダウンデータを Redis に保存
+	computedAt := now.Format(time.RFC3339)
+	for _, s := range domain_service.StrategyOrder {
+		a := accs[s]
+		// TotalReturn 降順にソート
+		sort.SliceStable(a.stocks, func(i, j int) bool {
+			return a.stocks[i].TotalReturn.GreaterThan(a.stocks[j].TotalReturn)
+		})
+		stocksPayload := models.StrategyStocks{
+			Computed:   true,
+			ComputedAt: computedAt,
+			Strategy:   s,
+			Label:      domain_service.StrategyLabels[s],
+			TotalCount: len(a.stocks),
+			Items:      a.stocks,
+		}
+		sb, err := json.Marshal(stocksPayload)
+		if err != nil {
+			return processed, errors.Wrap(err, "json.Marshal stocks error for "+s)
+		}
+		key := strategyRankingStocksKeyPrefix + s
+		if err := r.redisClient.Set(ctx, key, string(sb), 0).Err(); err != nil {
+			return processed, errors.Wrap(err, "redisClient.Set stocks error for "+s)
+		}
+	}
+
 	log.Printf("strategy ranking: completed. processed=%d/%d brands", processed, len(brands))
 	return processed, nil
 }
@@ -252,7 +323,7 @@ func (r *strategyRankingInteractorImpl) runWorkers(
 				if len(prices) < strategyRankingMinDays {
 					continue
 				}
-				accumulateResults(prices, exitParams, local)
+				accumulateResults(brand, prices, exitParams, local)
 				if n := processed.Add(1); n%200 == 0 {
 					log.Printf("strategy ranking: processed %d/%d brands", n, len(brands))
 				}

--- a/usecase/strategy_ranking_interactor_test.go
+++ b/usecase/strategy_ranking_interactor_test.go
@@ -189,3 +189,111 @@ func TestStrategyRankingInteractor_ComputeAndSaveStrategyRanking_PriceError(t *t
 	_, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5, 2)
 	assert.Error(t, err)
 }
+
+func TestStrategyRankingInteractor_ComputeAndSaveStrategyRanking_SavesStockKeys(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mr, client := newTestRedis(t)
+
+	brandRepo := mock_repositories.NewMockStockBrandRepository(ctrl)
+	priceRepo := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+
+	brands := []*models.StockBrand{
+		{ID: "A", TickerSymbol: "7203", Name: "トヨタ自動車"},
+		{ID: "B", TickerSymbol: "6758", Name: "ソニーグループ"},
+	}
+	brandRepo.EXPECT().FindAllMainMarkets(gomock.Any()).Return(brands, nil)
+
+	prices := testPrices(90)
+	for range brands {
+		priceRepo.EXPECT().ListDailyPricesBySymbol(gomock.Any(), gomock.Any()).Return(prices, nil)
+	}
+
+	params := models.BacktestParams{
+		TakeProfit:  decimal.NewFromFloat(0.10),
+		StopLoss:    decimal.NewFromFloat(0.05),
+		MaxHoldDays: 20,
+	}
+
+	interactor := NewStrategyRankingInteractor(brandRepo, priceRepo, client)
+	n, err := interactor.ComputeAndSaveStrategyRanking(context.Background(), params, 5, 2)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// 戦略ごとの銘柄キーが Redis に保存されているか確認
+	for _, s := range []string{"macd_bullish", "bollinger_breakout", "triangle_formation", "ma_cross", "multiple_signals"} {
+		key := strategyRankingStocksKeyPrefix + s
+		raw, err := mr.Get(key)
+		assert.NoError(t, err, "キー %s が存在しない", key)
+
+		var stocks models.StrategyStocks
+		assert.NoError(t, json.Unmarshal([]byte(raw), &stocks))
+		assert.True(t, stocks.Computed)
+		assert.Equal(t, s, stocks.Strategy)
+		assert.Equal(t, 2, stocks.TotalCount) // 2銘柄分
+		assert.Len(t, stocks.Items, 2)
+		// TotalReturn 降順確認
+		for i := 1; i < len(stocks.Items); i++ {
+			assert.True(t, stocks.Items[i-1].TotalReturn.GreaterThanOrEqual(stocks.Items[i].TotalReturn))
+		}
+	}
+}
+
+func TestStrategyRankingInteractor_GetStrategyRankingStocks_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	_, client := newTestRedis(t)
+
+	interactor := NewStrategyRankingInteractor(nil, nil, client)
+	got, err := interactor.GetStrategyRankingStocks(context.Background(), "macd_bullish", 100)
+	assert.NoError(t, err)
+	assert.False(t, got.Computed)
+	assert.Equal(t, "macd_bullish", got.Strategy)
+	assert.Empty(t, got.Items)
+}
+
+func TestStrategyRankingInteractor_GetStrategyRankingStocks_Found(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mr, client := newTestRedis(t)
+
+	// 3銘柄分のデータを Redis にセット（TotalReturn 降順保存済み想定）
+	items := []*models.StrategyStockResult{
+		{TickerSymbol: "7203", Name: "トヨタ自動車", TotalReturn: decimal.NewFromFloat(0.15)},
+		{TickerSymbol: "6758", Name: "ソニーグループ", TotalReturn: decimal.NewFromFloat(0.10)},
+		{TickerSymbol: "9984", Name: "ソフトバンクグループ", TotalReturn: decimal.NewFromFloat(0.05)},
+	}
+	payload := models.StrategyStocks{
+		Computed:   true,
+		ComputedAt: "2026-06-10T00:00:00Z",
+		Strategy:   "macd_bullish",
+		Label:      "MACD強気",
+		TotalCount: 3,
+		Items:      items,
+	}
+	b, _ := json.Marshal(payload)
+	mr.Set(strategyRankingStocksKeyPrefix+"macd_bullish", string(b))
+
+	interactor := NewStrategyRankingInteractor(nil, nil, client)
+
+	// limit=2 で切り取られ TotalCount=3 になるか確認
+	got, err := interactor.GetStrategyRankingStocks(context.Background(), "macd_bullish", 2)
+	assert.NoError(t, err)
+	assert.True(t, got.Computed)
+	assert.Equal(t, 3, got.TotalCount)
+	assert.Len(t, got.Items, 2)
+	assert.Equal(t, "7203", got.Items[0].TickerSymbol)
+	assert.Equal(t, "6758", got.Items[1].TickerSymbol)
+}
+
+func TestStrategyRankingInteractor_GetStrategyRankingStocks_InvalidJSON(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mr, client := newTestRedis(t)
+
+	mr.Set(strategyRankingStocksKeyPrefix+"macd_bullish", "invalid-json")
+
+	interactor := NewStrategyRankingInteractor(nil, nil, client)
+	_, err := interactor.GetStrategyRankingStocks(context.Background(), "macd_bullish", 100)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## 概要

戦略ランキングの銘柄ドリルダウン機能をバックエンドに追加する。

## 変更内容

- **バッチ拡張**: `ComputeAndSaveStrategyRanking` が従来の戦略別集計 (`strategy_ranking:v1`) に加え、戦略ごとの銘柄別バックテスト結果を Redis キー `strategy_ranking:v1:stocks:<strategy>` に TotalReturn 降順で保存するようになった。既存キーのペイロードは変更なし（後方互換）。
- **新モデル追加** (`models/strategy_ranking.go`):
  - `StrategyStockResult` — 1戦略×1銘柄の結果（tickerSymbol / name / totalReturn / trades / winRate / profitFactor / maxDrawdown / payoffRatio / avgHoldDays）
  - `StrategyStocks` — ドリルダウン API レスポンス（computed / computedAt / strategy / label / totalCount / items）
- **新 API**: `GET /strategy-ranking-stocks?strategy=<id>&limit=<n>`
  - `strategy` 必須・5定数のいずれか（不正 → 400）
  - `limit` 任意・デフォルト100・最大2000（不正 → 400）
  - Redis キー欠如（未計算）→ `computed: false` で空レスポンス
  - `items` は limit 件に切り、`totalCount` は全件数
- **usecase インターフェース拡張**: `StrategyRankingInteractor` に `GetStrategyRankingStocks` を追加し、モック (`mock/usecase/strategy_ranking_interactor.go`) を更新
- **テスト**: usecase 4ケース・handler 8ケースを追加（既存テストを含め全てパス）

## API レスポンス形 (JSON)

```json
{
  "computed": true,
  "computedAt": "2026-06-10T12:00:00+09:00",
  "strategy": "macd_bullish",
  "label": "MACD強気",
  "totalCount": 1500,
  "items": [
    {
      "tickerSymbol": "7203",
      "name": "トヨタ自動車",
      "totalReturn": "0.42",
      "trades": 12,
      "winRate": "0.75",
      "profitFactor": "2.1",
      "maxDrawdown": "-0.08",
      "payoffRatio": "1.8",
      "avgHoldDays": 6.5
    }
  ]
}
```

## Redis キー

| キー | 内容 |
|---|---|
| `strategy_ranking:v1` | 既存の戦略別集計（変更なし） |
| `strategy_ranking:v1:stocks:macd_bullish` | 銘柄別結果（新規） |
| `strategy_ranking:v1:stocks:bollinger_breakout` | 銘柄別結果（新規） |
| `strategy_ranking:v1:stocks:triangle_formation` | 銘柄別結果（新規） |
| `strategy_ranking:v1:stocks:ma_cross` | 銘柄別結果（新規） |
| `strategy_ranking:v1:stocks:multiple_signals` | 銘柄別結果（新規） |

## テスト計画

- [x] `ENVCODE=unit go test ./usecase/...` — 全テストパス
- [x] `ENVCODE=unit go test ./entrypoint/api/handler/...` — 全テストパス
- [x] `go build ./...` — ビルド成功
- [x] `make lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)