### PR TITLE
feat: バックテストに手数料・スリッページを追加

### DIFF
--- a/domain_service/backtest.go
+++ b/domain_service/backtest.go
@@ -8,9 +8,11 @@ import (
 
 // ExitParams バックテストの共通イグジット・約定設定。
 type ExitParams struct {
-	TakeProfit  decimal.Decimal // 利確率（例: 0.10）
-	StopLoss    decimal.Decimal // 損切り率（例: 0.05、正の値で指定）
-	MaxHoldDays int             // 最大保有営業日数
+	TakeProfit     decimal.Decimal // 利確率（例: 0.10）
+	StopLoss       decimal.Decimal // 損切り率（例: 0.05、正の値で指定）
+	MaxHoldDays    int             // 最大保有営業日数
+	CommissionRate decimal.Decimal // 片道手数料率（例: 0.0005）。ゼロ値 = コストなし（後方互換）
+	SlippageRate   decimal.Decimal // 片道スリッページ率（例: 0.001）。ゼロ値 = コストなし
 }
 
 // tradeStats 約定確定時にインクリメンタルに加算する集計アキュムレータ。
@@ -56,6 +58,8 @@ func RunBacktestMetrics(prices []*models.StockBrandDailyPrice, entrySignals []bo
 }
 
 // exitReason 当日のリターンと保有日数から手仕舞い理由を返す。手仕舞い不要なら ""。
+// 判定は生の Close ベース（コスト考慮前）で行う。
+// コストを判定に含めると TakeProfit / StopLoss の閾値の意味が変わり挙動が複雑化するため。
 func exitReason(ret decimal.Decimal, holdDays int, params ExitParams) string {
 	switch {
 	case ret.GreaterThanOrEqual(params.TakeProfit):
@@ -66,6 +70,46 @@ func exitReason(ret decimal.Decimal, holdDays int, params ExitParams) string {
 		return "max_hold"
 	}
 	return ""
+}
+
+// effectiveEntryPrice 手数料・スリッページを加味した実効エントリー取得単価を返す。
+// ゼロ値の場合は生の Close をそのまま返す（後方互換）。
+//
+//	実効エントリー価格 = close × (1 + slippage) × (1 + commission)
+func effectiveEntryPrice(close, commissionRate, slippageRate decimal.Decimal) decimal.Decimal {
+	one := decimal.NewFromInt(1)
+	price := close
+	if !slippageRate.IsZero() {
+		price = price.Mul(one.Add(slippageRate))
+	}
+	if !commissionRate.IsZero() {
+		price = price.Mul(one.Add(commissionRate))
+	}
+	return price
+}
+
+// effectiveExitPrice コスト込みの手取りイグジット価格を返す。
+//
+//	手取りイグジット = close × (1 − slippage) × (1 − commission)
+func effectiveExitPrice(close, commissionRate, slippageRate decimal.Decimal) decimal.Decimal {
+	one := decimal.NewFromInt(1)
+	price := close
+	if !slippageRate.IsZero() {
+		price = price.Mul(one.Sub(slippageRate))
+	}
+	if !commissionRate.IsZero() {
+		price = price.Mul(one.Sub(commissionRate))
+	}
+	return price
+}
+
+// effectiveExitReturn コスト込みのトレードリターンを返す。
+// ゼロ値の場合は生のリターンをそのまま返す（後方互換）。
+//
+//	リターン = 手取りイグジット ÷ 実効エントリー価格 − 1
+func effectiveExitReturn(exitClose, effectiveEntry, commissionRate, slippageRate decimal.Decimal) decimal.Decimal {
+	exitEff := effectiveExitPrice(exitClose, commissionRate, slippageRate)
+	return exitEff.Div(effectiveEntry).Sub(decimal.NewFromInt(1))
 }
 
 func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, params ExitParams, collectSeries bool) models.BacktestResult {
@@ -89,15 +133,21 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 	realizedEquity := one // 直近に確定した資産（フラット時の資産）
 	inPosition := false
 	entryIdx := 0
-	var entryPrice, entryEquity decimal.Decimal
+	// entryPrice: コスト込みの実効取得単価（エクイティ計算・リターン算出に使用）
+	// entryClose: エントリー当日の生 Close（イグジット判定用）
+	var entryPrice, entryClose, entryEquity decimal.Decimal
 
 	equitySeries := make([]decimal.Decimal, 0, n)
 	var stats tradeStats
 
 	closeTrade := func(i int, reason string) {
-		exitPrice := prices[i].Close
-		ret := exitPrice.Div(entryPrice).Sub(one)
-		realizedEquity = entryEquity.Mul(exitPrice.Div(entryPrice))
+		exitClose := prices[i].Close
+		// 利確/損切りの判定は生 Close ベース済み（exitReason で実施）。
+		// 約定リターンとエクイティの計算にのみコストを適用する。
+		ret := effectiveExitReturn(exitClose, entryPrice, params.CommissionRate, params.SlippageRate)
+		// エクイティ更新: 手取りイグジット ÷ 実効エントリー
+		exitEffective := effectiveExitPrice(exitClose, params.CommissionRate, params.SlippageRate)
+		realizedEquity = entryEquity.Mul(exitEffective.Div(entryPrice))
 
 		// 約定をインクリメンタルに集計（TradeList 非依存）
 		stats.record(ret, i-entryIdx)
@@ -107,7 +157,7 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 				EntryDate:  prices[entryIdx].Date.Format(util.DateLayout),
 				ExitDate:   prices[i].Date.Format(util.DateLayout),
 				EntryPrice: entryPrice,
-				ExitPrice:  exitPrice,
+				ExitPrice:  exitClose,
 				Return:     ret,
 				HoldDays:   i - entryIdx,
 				Reason:     reason,
@@ -118,9 +168,10 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 
 	for i := 0; i < n; i++ {
 		// Step A: イグジット判定（エントリー当日は判定しない）
+		// 判定は生 Close ベース（コスト考慮前）
 		if inPosition && i > entryIdx {
-			ret := prices[i].Close.Div(entryPrice).Sub(one)
-			if reason := exitReason(ret, i-entryIdx, params); reason != "" {
+			rawRet := prices[i].Close.Div(entryClose).Sub(one)
+			if reason := exitReason(rawRet, i-entryIdx, params); reason != "" {
 				closeTrade(i, reason)
 			}
 		}
@@ -129,11 +180,15 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 		if !inPosition && entrySignals[i] {
 			inPosition = true
 			entryIdx = i
-			entryPrice = prices[i].Close
+			entryClose = prices[i].Close
+			// 実効エントリー価格（コスト込み取得単価）
+			entryPrice = effectiveEntryPrice(entryClose, params.CommissionRate, params.SlippageRate)
 			entryEquity = realizedEquity
 		}
 
 		// Step C: 当日のエクイティをマーク（保有中は時価評価）
+		// 時価評価は「生 Close ÷ 実効エントリー価格」ベースで算出する。
+		// これによりコスト込みのエクイティカーブが得られる。
 		var eq decimal.Decimal
 		if inPosition {
 			eq = entryEquity.Mul(prices[i].Close.Div(entryPrice))

--- a/domain_service/backtest_test.go
+++ b/domain_service/backtest_test.go
@@ -133,3 +133,98 @@ func f64FromDec(d decimal.Decimal) float64 {
 	v, _ := d.Float64()
 	return v
 }
+
+func TestRunBacktest_WithCosts(t *testing.T) {
+	t.Run("コストゼロ時は既存結果と完全一致", func(t *testing.T) {
+		paramsNoCost := ExitParams{
+			TakeProfit:  decimal.NewFromFloat(0.10),
+			StopLoss:    decimal.NewFromFloat(0.05),
+			MaxHoldDays: 10,
+		}
+		paramsZeroCost := ExitParams{
+			TakeProfit:     decimal.NewFromFloat(0.10),
+			StopLoss:       decimal.NewFromFloat(0.05),
+			MaxHoldDays:    10,
+			CommissionRate: decimal.Zero,
+			SlippageRate:   decimal.Zero,
+		}
+		prices := pricesFromCloses(100, 100, 110, 110, 110, 104)
+		signals := boolsAt(6, 1, 3)
+
+		resNoCost := RunBacktest(prices, signals, paramsNoCost)
+		resZeroCost := RunBacktest(prices, signals, paramsZeroCost)
+
+		assert.True(t, resNoCost.TotalReturn.Equal(resZeroCost.TotalReturn), "TotalReturn 後方互換")
+		assert.True(t, resNoCost.WinRate.Equal(resZeroCost.WinRate), "WinRate 後方互換")
+		assert.True(t, resNoCost.ProfitFactor.Equal(resZeroCost.ProfitFactor), "ProfitFactor 後方互換")
+		assert.Equal(t, resNoCost.Trades, resZeroCost.Trades, "Trades 後方互換")
+	})
+
+	t.Run("コストあり: 1トレードのリターンが手計算と一致", func(t *testing.T) {
+		// Close: 100 → 110
+		// commission = 0.001, slippage = 0.002
+		// 実効エントリー価格 = 100 × 1.002 × 1.001 = 100.3002
+		// 手取りイグジット = 110 × 0.998 × 0.999 = 109.6901...
+		// リターン = 109.6901... / 100.3002 - 1
+		commission := decimal.NewFromFloat(0.001)
+		slippage := decimal.NewFromFloat(0.002)
+		params := ExitParams{
+			TakeProfit:     decimal.NewFromFloat(0.10),
+			StopLoss:       decimal.NewFromFloat(0.05),
+			MaxHoldDays:    10,
+			CommissionRate: commission,
+			SlippageRate:   slippage,
+		}
+		prices := pricesFromCloses(100, 100, 110)
+		res := RunBacktest(prices, boolsAt(3, 1), params)
+
+		// 手計算
+		one := decimal.NewFromInt(1)
+		entryClose := decimal.NewFromFloat(100)
+		exitClose := decimal.NewFromFloat(110)
+		effEntry := entryClose.Mul(one.Add(slippage)).Mul(one.Add(commission))
+		effExit := exitClose.Mul(one.Sub(slippage)).Mul(one.Sub(commission))
+		expectedRet := effExit.Div(effEntry).Sub(one)
+
+		assert.Equal(t, 1, res.Trades)
+		retGot, _ := res.TradeList[0].Return.Float64()
+		retExp, _ := expectedRet.Float64()
+		assert.InDelta(t, retExp, retGot, 1e-9, "コストあり1トレードリターン")
+
+		// コストなしより低いリターンになること
+		paramsNoCost := ExitParams{TakeProfit: decimal.NewFromFloat(0.10), StopLoss: decimal.NewFromFloat(0.05), MaxHoldDays: 10}
+		resNoCost := RunBacktest(prices, boolsAt(3, 1), paramsNoCost)
+		assert.True(t, res.TradeList[0].Return.LessThan(resNoCost.TradeList[0].Return), "コストあり < コストなし")
+	})
+
+	t.Run("コストありで勝率/PFが変化する", func(t *testing.T) {
+		// コストが大きいと、薄い利益は損失に転じて勝率が下がる
+		// entry@100, exit@100.5（+0.5%）: コストなしなら勝ち、高コストなら負け
+		commission := decimal.NewFromFloat(0.003)
+		slippage := decimal.NewFromFloat(0.003)
+		paramsCost := ExitParams{
+			TakeProfit:     decimal.NewFromFloat(0.50),
+			StopLoss:       decimal.NewFromFloat(0.50),
+			MaxHoldDays:    1,
+			CommissionRate: commission,
+			SlippageRate:   slippage,
+		}
+		paramsNoCost := ExitParams{
+			TakeProfit:  decimal.NewFromFloat(0.50),
+			StopLoss:    decimal.NewFromFloat(0.50),
+			MaxHoldDays: 1,
+		}
+		// 0.5% 上昇 → コストなしなら勝ち、コストあり（片道0.6%）なら負け
+		prices := pricesFromCloses(100, 100, 100.5)
+		signals := boolsAt(3, 1)
+
+		resCost := RunBacktest(prices, signals, paramsCost)
+		resNoCost := RunBacktest(prices, signals, paramsNoCost)
+
+		assert.Equal(t, 1, resCost.Trades)
+		assert.Equal(t, 1, resNoCost.Trades)
+		// コストなしは勝ち（WinRate=1）、コストありは負け（WinRate=0）
+		assert.True(t, resNoCost.WinRate.Equal(decimal.NewFromInt(1)), "コストなし: 勝率1")
+		assert.True(t, resCost.WinRate.Equal(decimal.Zero), "コストあり: 勝率0")
+	})
+}

--- a/entrypoint/api/handler/backtest_handler.go
+++ b/entrypoint/api/handler/backtest_handler.go
@@ -53,6 +53,19 @@ func parsePositiveRate(raw string, def decimal.Decimal) (decimal.Decimal, bool) 
 	return decimal.NewFromFloat(f), true
 }
 
+// parseNonNegativeRate 0以上0.05以下のレート文字列をパースする。空なら0（コストなし）。
+// commission / slippage などコストパラメータ用（ゼロ値は後方互換でコストなし）。
+func parseNonNegativeRate(raw string) (decimal.Decimal, bool) {
+	if raw == "" {
+		return decimal.Zero, true
+	}
+	f, err := strconv.ParseFloat(raw, 64)
+	if err != nil || f < 0 || f > 0.05 {
+		return decimal.Zero, false
+	}
+	return decimal.NewFromFloat(f), true
+}
+
 func (h *BacktestHandler) validateGetBacktestParams(r *http.Request) (*getBacktestParams, error) {
 	p := &getBacktestParams{}
 
@@ -97,10 +110,21 @@ func (h *BacktestHandler) validateGetBacktestParams(r *http.Request) (*getBackte
 		maxHoldDays = d
 	}
 
+	commissionRate, ok := parseNonNegativeRate(h.httpServer.GetQueryParam(r, "commission"))
+	if !ok {
+		return nil, &validationError{message: "commissionは0以上0.05以下である必要があります"}
+	}
+	slippageRate, ok := parseNonNegativeRate(h.httpServer.GetQueryParam(r, "slippage"))
+	if !ok {
+		return nil, &validationError{message: "slippageは0以上0.05以下である必要があります"}
+	}
+
 	p.params = models.BacktestParams{
-		TakeProfit:  takeProfit,
-		StopLoss:    stopLoss,
-		MaxHoldDays: maxHoldDays,
+		TakeProfit:     takeProfit,
+		StopLoss:       stopLoss,
+		MaxHoldDays:    maxHoldDays,
+		CommissionRate: commissionRate,
+		SlippageRate:   slippageRate,
 	}
 	return p, nil
 }

--- a/entrypoint/api/handler/backtest_handler_test.go
+++ b/entrypoint/api/handler/backtest_handler_test.go
@@ -21,9 +21,11 @@ import (
 func TestBacktestHandler_GetBacktest(t *testing.T) {
 	date, _ := time.Parse(util.DateLayout, "2021-01-04")
 	defaultParams := models.BacktestParams{
-		TakeProfit:  decimal.NewFromFloat(0.10),
-		StopLoss:    decimal.NewFromFloat(0.05),
-		MaxHoldDays: 20,
+		TakeProfit:     decimal.NewFromFloat(0.10),
+		StopLoss:       decimal.NewFromFloat(0.05),
+		MaxHoldDays:    20,
+		CommissionRate: decimal.Zero,
+		SlippageRate:   decimal.Zero,
 	}
 
 	type fields struct {
@@ -62,6 +64,8 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("")
 					return m
 				},
 			},
@@ -150,6 +154,8 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("")
 					return m
 				},
 			},
@@ -177,6 +183,148 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 			} else {
 				assert.Equal(t, tt.wantBody, w.Body.String())
 			}
+		})
+	}
+}
+
+func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
+	type fields struct {
+		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor
+		httpServer func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		req            *http.Request
+		wantStatusCode int
+		wantBody       string
+	}{
+		{
+			name: "異常系: commissionが負値",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					return mock_usecase.NewMockBacktestInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("-0.001")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&commission=-0.001", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "commissionは0以上0.05以下である必要があります\n",
+		},
+		{
+			name: "異常系: commissionが0.05超",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					return mock_usecase.NewMockBacktestInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("0.06")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&commission=0.06", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "commissionは0以上0.05以下である必要があります\n",
+		},
+		{
+			name: "異常系: commissionが非数",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					return mock_usecase.NewMockBacktestInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("abc")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&commission=abc", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "commissionは0以上0.05以下である必要があります\n",
+		},
+		{
+			name: "異常系: slippageが0.05超",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					return mock_usecase.NewMockBacktestInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("0.1")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&slippage=0.1", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "slippageは0以上0.05以下である必要があります\n",
+		},
+		{
+			name: "異常系: slippageが負値",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					return mock_usecase.NewMockBacktestInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("-0.001")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&slippage=-0.001", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "slippageは0以上0.05以下である必要があります\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			h := NewBacktestHandler(tt.fields.usecase(ctrl), tt.fields.httpServer(ctrl), zap.NewNop())
+
+			w := httptest.NewRecorder()
+			h.GetBacktest(w, tt.req)
+
+			assert.Equal(t, tt.wantStatusCode, w.Code)
+			assert.Equal(t, tt.wantBody, w.Body.String())
 		})
 	}
 }

--- a/models/backtest.go
+++ b/models/backtest.go
@@ -4,9 +4,11 @@ import "github.com/shopspring/decimal"
 
 // BacktestParams バックテストの共通イグジット・約定パラメータ。
 type BacktestParams struct {
-	TakeProfit  decimal.Decimal `json:"takeProfit"`  // 利確率（例: 0.10 = +10%）
-	StopLoss    decimal.Decimal `json:"stopLoss"`    // 損切り率（例: 0.05 = -5%）
-	MaxHoldDays int             `json:"maxHoldDays"` // 最大保有営業日数
+	TakeProfit     decimal.Decimal `json:"takeProfit"`     // 利確率（例: 0.10 = +10%）
+	StopLoss       decimal.Decimal `json:"stopLoss"`       // 損切り率（例: 0.05 = -5%）
+	MaxHoldDays    int             `json:"maxHoldDays"`    // 最大保有営業日数
+	CommissionRate decimal.Decimal `json:"commissionRate"` // 片道手数料率（例: 0.0005）。ゼロ値 = コストなし
+	SlippageRate   decimal.Decimal `json:"slippageRate"`   // 片道スリッページ率（例: 0.001）。ゼロ値 = コストなし
 }
 
 // BacktestEquityPoint エクイティカーブの1点（初期資金=1.0 を起点とした倍率）。

--- a/usecase/backtest_interactor.go
+++ b/usecase/backtest_interactor.go
@@ -59,9 +59,11 @@ func (b *backtestInteractorImpl) GetBacktestComparison(ctx context.Context, symb
 	}
 
 	exitParams := domain_service.ExitParams{
-		TakeProfit:  params.TakeProfit,
-		StopLoss:    params.StopLoss,
-		MaxHoldDays: params.MaxHoldDays,
+		TakeProfit:     params.TakeProfit,
+		StopLoss:       params.StopLoss,
+		MaxHoldDays:    params.MaxHoldDays,
+		CommissionRate: params.CommissionRate,
+		SlippageRate:   params.SlippageRate,
 	}
 
 	for _, strategy := range domain_service.StrategyOrder {


### PR DESCRIPTION
## 概要

- `GET /backtest` に `commission` / `slippage` クエリパラメータを追加し、取引コストを考慮したバックテストを実行できるようにした
- コストゼロ時（パラメータ省略時）は従来と完全に同じ結果を返す（後方互換）

## 変更内容

### models/backtest.go
- `BacktestParams` に `CommissionRate` / `SlippageRate` フィールドを追加（JSON: `commissionRate` / `slippageRate`）

### domain_service/backtest.go
- `ExitParams` に `CommissionRate` / `SlippageRate` を追加
- 利確/損切り判定は生 Close ベースを維持（コスト込みにすると閾値の意味が変わるため）
- 約定リターンとエクイティカーブの計算にのみコストを反映
- `effectiveEntryPrice` / `effectiveExitPrice` / `effectiveExitReturn` ヘルパーを追加

### entrypoint/api/handler/backtest_handler.go
- `commission` / `slippage` クエリパラメータを追加（任意、デフォルト0）
- 範囲: 0以上0.05以下、超過・負値・非数は `400 Bad Request`

### usecase/backtest_interactor.go
- `models.BacktestParams` → `domain_service.ExitParams` 変換時に CommissionRate / SlippageRate を伝播

### 戦略ランキングバッチ
- **変更なし**（ゼロ値のままでコストなし＝従来挙動）

## API 仕様

### 新規クエリパラメータ

| パラメータ | 型 | 範囲 | デフォルト | 説明 |
|---|---|---|---|---|
| `commission` | float | 0.0〜0.05 | 0 | 片道手数料率 |
| `slippage` | float | 0.0〜0.05 | 0 | 片道スリッページ率 |

### レスポンス変化

`params` オブジェクトに `commissionRate` / `slippageRate` が追加される:

```json
{
  "params": {
    "takeProfit": "0.1",
    "stopLoss": "0.05",
    "maxHoldDays": 20,
    "commissionRate": "0.0005",
    "slippageRate": "0.001"
  }
}
```

### コスト計算式

- 実効エントリー価格 = Close × (1 + slippage) × (1 + commission)
- 手取りイグジット = Close × (1 - slippage) × (1 - commission)
- トレードリターン = 手取りイグジット ÷ 実効エントリー価格 - 1

## 後方互換確認

`commission` / `slippage` を省略した場合（または `0` を指定した場合）は従来と完全に同じ結果が返ることをテストで担保:

```go
// TestRunBacktest_WithCosts/コストゼロ時は既存結果と完全一致
```

## テスト

- `domain_service`: コストゼロ後方互換・手計算一致（commission=0.001, slippage=0.002）・勝率/PF変化
- `handler`: commission/slippage の400系（負値・0.05超・非数）

🤖 Generated with [Claude Code](https://claude.com/claude-code)