### PR TITLE
fix: TOPIX連動ETF (1306.T) の取得パスを修正（^前置による404）

### DIFF
--- a/test/e2e/create_nikkei_and_dji_historical_data_test.go
+++ b/test/e2e/create_nikkei_and_dji_historical_data_test.go
@@ -98,8 +98,8 @@ func TestE2E_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 					},
 				}, nil)
 
-				// TOPIX ETF (1306.T) を TOPIX 代理として使用
-				mockStockAPI.EXPECT().GetIndexPriceChart(
+				// TOPIX ETF (1306.T) を TOPIX 代理として使用（ETF なので GetStockPriceChart）
+				mockStockAPI.EXPECT().GetStockPriceChart(
 					gomock.Any(),
 					gateway.StockAPISymbolTopixETF,
 					gateway.StockAPIInterval1D,

--- a/usecase/create_nikkei_and_dji_historical_data.go
+++ b/usecase/create_nikkei_and_dji_historical_data.go
@@ -31,8 +31,9 @@ func (ii *indexInteractorImpl) CreateNikkeiAndDjiHistoricalData(ctx context.Cont
 		return errors.Wrap(err, "CreateNikkeiAndDjiHistoricalData")
 	}
 	// TOPIX連動ETF (1306.T) の取得
-	// NEXT FUNDS TOPIX連動ETF (1306.T) を TOPIX 代理として使用（Yahoo に TOPIX 指数本体が無いため）
-	topixDailyPrices, err := ii.stockAPIClient.GetIndexPriceChart(
+	// NEXT FUNDS TOPIX連動ETF (1306.T) を TOPIX 代理として使用（Yahoo に TOPIX 指数本体が無いため）。
+	// ETF は通常の上場銘柄なので GetIndexPriceChart（"^" 前置）ではなく GetStockPriceChart を使う。
+	topixDailyPrices, err := ii.stockAPIClient.GetStockPriceChart(
 		ctx,
 		gateway.StockAPISymbolTopixETF,
 		gateway.StockAPIInterval1D,

--- a/usecase/create_nikkei_and_dji_historical_data_test.go
+++ b/usecase/create_nikkei_and_dji_historical_data_test.go
@@ -77,7 +77,7 @@ func Test_indexInteractorImpl_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 						},
 					}, nil)
 					// TOPIX ETF
-					mock.EXPECT().GetIndexPriceChart(
+					mock.EXPECT().GetStockPriceChart(
 						gomock.Any(),
 						gateway.StockAPISymbolTopixETF,
 						gateway.StockAPIInterval1D,
@@ -211,7 +211,7 @@ func Test_indexInteractorImpl_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 					mock := mock_gateway.NewMockStockAPIClient(ctrl)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolNikkei, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolDji, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
-					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(nil, errors.New("api error"))
+					mock.EXPECT().GetStockPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(nil, errors.New("api error"))
 					return mock
 				},
 				tx:               nil,
@@ -232,7 +232,7 @@ func Test_indexInteractorImpl_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 					mock := mock_gateway.NewMockStockAPIClient(ctrl)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolNikkei, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolDji, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
-					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
+					mock.EXPECT().GetStockPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					return mock
 				},
 				tx: func(ctrl *gomock.Controller) *mock_repositories.MockTransaction {
@@ -257,7 +257,7 @@ func Test_indexInteractorImpl_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 					mock := mock_gateway.NewMockStockAPIClient(ctrl)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolNikkei, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolDji, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
-					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
+					mock.EXPECT().GetStockPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					return mock
 				},
 				tx: func(ctrl *gomock.Controller) *mock_repositories.MockTransaction {
@@ -288,7 +288,7 @@ func Test_indexInteractorImpl_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 					mock := mock_gateway.NewMockStockAPIClient(ctrl)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolNikkei, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolDji, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
-					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
+					mock.EXPECT().GetStockPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					return mock
 				},
 				tx: func(ctrl *gomock.Controller) *mock_repositories.MockTransaction {
@@ -323,7 +323,7 @@ func Test_indexInteractorImpl_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 					mock := mock_gateway.NewMockStockAPIClient(ctrl)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolNikkei, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolDji, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
-					mock.EXPECT().GetIndexPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
+					mock.EXPECT().GetStockPriceChart(gomock.Any(), gateway.StockAPISymbolTopixETF, gomock.Any(), gomock.Any()).Return(&gateway.StockChartWithRangeAPIResponseInfo{}, nil)
 					return mock
 				},
 				tx: func(ctrl *gomock.Controller) *mock_repositories.MockTransaction {


### PR DESCRIPTION
## 概要

PR #94 の TOPIX ベンチマーク対応で、1306.T の日足取得が `GetIndexPriceChart` を使っていたため、シンボルが `^1306.T` に変換され Yahoo Finance が 404 を返してバックフィルが失敗していた（`create_nikkei_and_dji_historical_data_v1` がエラー終了）。

## 修正

- ETF は通常の上場銘柄なので `GetStockPriceChart`（`.T` 補完のみで `^` を付けない）に変更
- テストの EXPECT も `GetStockPriceChart` に追従

## 確認

- `ENVCODE=unit go test ./usecase/` pass
- `make lint` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)