### PR TITLE
fix: TOPIX代理ETFを1305.Tへ変更し、指数のゼロ円行をスキップ

### DIFF
--- a/infrastructure/gateway/stock_api_model.go
+++ b/infrastructure/gateway/stock_api_model.go
@@ -54,8 +54,9 @@ type StockAPISymbol string
 const (
 	StockAPISymbolNikkei   StockAPISymbol = "^N225"
 	StockAPISymbolDji      StockAPISymbol = "^DJI"
-	// StockAPISymbolTopixETF NEXT FUNDS TOPIX連動ETF (1306.T) を TOPIX 代理として使用（Yahoo に TOPIX 指数本体が無いため）
-	StockAPISymbolTopixETF StockAPISymbol = "1306.T"
+	// StockAPISymbolTopixETF iFreeETF TOPIX (1305.T) を TOPIX 代理として使用。
+	// Yahoo に TOPIX 指数本体が無く、1306.T は 1:10 分割が Yahoo の adjclose に未反映でリターン系列が壊れるため 1305.T を採用。
+	StockAPISymbolTopixETF StockAPISymbol = "1305.T"
 )
 
 func (s StockAPISymbol) String() string {

--- a/usecase/create_nikkei_and_dji_historical_data_test.go
+++ b/usecase/create_nikkei_and_dji_historical_data_test.go
@@ -93,6 +93,10 @@ func Test_indexInteractorImpl_CreateNikkeiAndDjiHistoricalData(t *testing.T) {
 								Volume:          500000,
 								AdjustmentClose: decimal.NewFromInt(1940),
 							},
+							{
+								// Yahoo が祝日等に返す null 行（decimal ゼロ値）はスキップされる
+								Date: time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC),
+							},
 						},
 					}, nil)
 					return mock

--- a/usecase/index_interactor.go
+++ b/usecase/index_interactor.go
@@ -51,6 +51,11 @@ type IndexInteractor interface {
 func (ii *indexInteractorImpl) apiResponseToModel(info *gateway.StockChartWithRangeAPIResponseInfo, t time.Time) models.IndexStockAverageDailyPrices {
 	var result models.IndexStockAverageDailyPrices
 	for _, v := range info.Indicator {
+		// Yahoo は祝日・取得時点未確定の日に null を返し decimal ゼロ値になる。
+		// ゼロ円行を保存するとベンチマークリターンが -100% に壊れるためスキップする。
+		if v.Close.IsZero() {
+			continue
+		}
 		result = append(result, &models.IndexStockAverageDailyPrice{
 			Date:      v.Date,
 			High:      v.High,


### PR DESCRIPTION
## 問題

PR #94/#95 の TOPIX ベンチマークで実データ検証したところ2つのデータ品質問題が発覚:

1. **1306.T の分割未調整**: Yahoo Finance は 1306.T の 1:10 分割を adjclose に反映しておらず（splits イベントも空）、10年で close 1331→406 と系列が断絶。benchmarkReturn が -76% になる
2. **祝日 null→0 保存**(既存バグ): Yahoo は祝日・未確定日に null を返し、0円行として保存されていた（nikkei テーブルに2018年祝日の0円行多数）。期間端点に0円行が来ると benchmarkReturn = -100% に壊れる

## 修正

- 代理 ETF を **1305.T (iFreeETF TOPIX)** に変更 — 10年 close 倍率 x3.05 が TOPIX 実倍率と一致し系列が連続（1308.T/1475.T も同等だが最も流動性の高い 1305 を採用）
- `apiResponseToModel` で Close がゼロの行をスキップ（nikkei/dji/topix 共通の修正）
- テスト: TOPIX フィクスチャにゼロ円行を追加し、件数厳密検証でスキップを担保

## マージ後の運用

ローカル/本番 DB のクリーンアップが必要（topix_daily_price 全削除→再取得、nikkei/dji の0円行 DELETE）。ローカルは本 PR マージ後に実施済みになる予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)