### PR TITLE
fix: バックテスト結果の decimal フィールドを Round(6/4) で丸める

### DIFF
--- a/domain_service/backtest.go
+++ b/domain_service/backtest.go
@@ -156,9 +156,9 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 			result.TradeList = append(result.TradeList, models.BacktestTrade{
 				EntryDate:  prices[entryIdx].Date.Format(util.DateLayout),
 				ExitDate:   prices[i].Date.Format(util.DateLayout),
-				EntryPrice: entryPrice,
-				ExitPrice:  exitClose,
-				Return:     ret,
+				EntryPrice: entryPrice.Round(6),
+				ExitPrice:  exitClose.Round(6),
+				Return:     ret.Round(6),
 				HoldDays:   i - entryIdx,
 				Reason:     reason,
 			})
@@ -199,7 +199,7 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 		if collectSeries {
 			result.Equity = append(result.Equity, models.BacktestEquityPoint{
 				Date:   prices[i].Date.Format(util.DateLayout),
-				Equity: eq,
+				Equity: eq.Round(6),
 			})
 		}
 	}
@@ -211,8 +211,8 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 	}
 
 	result.Trades = stats.trades
-	result.TotalReturn = realizedEquity.Sub(one)
-	result.MaxDrawdown = MaxDrawdown(equitySeries)
+	result.TotalReturn = realizedEquity.Sub(one).Round(6)
+	result.MaxDrawdown = MaxDrawdown(equitySeries).Round(6)
 	if stats.trades > 0 {
 		result.AvgHoldDays = float64(stats.holdDaysSum) / float64(stats.trades)
 	}
@@ -225,18 +225,18 @@ func fillTradeStats(result *models.BacktestResult, stats *tradeStats) {
 	if stats.trades == 0 {
 		return
 	}
-	result.WinRate = decimal.NewFromInt(int64(stats.wins)).Div(decimal.NewFromInt(int64(stats.trades)))
+	result.WinRate = decimal.NewFromInt(int64(stats.wins)).Div(decimal.NewFromInt(int64(stats.trades))).Round(4)
 
 	if !stats.grossLoss.IsZero() {
-		result.ProfitFactor = stats.grossProfit.Div(stats.grossLoss)
+		result.ProfitFactor = stats.grossProfit.Div(stats.grossLoss).Round(6)
 	}
 	if stats.wins > 0 {
-		result.AvgWin = stats.sumWin.Div(decimal.NewFromInt(int64(stats.wins)))
+		result.AvgWin = stats.sumWin.Div(decimal.NewFromInt(int64(stats.wins))).Round(6)
 	}
 	if stats.losses > 0 {
-		result.AvgLoss = stats.sumLoss.Div(decimal.NewFromInt(int64(stats.losses)))
+		result.AvgLoss = stats.sumLoss.Div(decimal.NewFromInt(int64(stats.losses))).Round(6)
 	}
 	if stats.losses > 0 && !result.AvgLoss.IsZero() {
-		result.PayoffRatio = result.AvgWin.Div(result.AvgLoss.Abs())
+		result.PayoffRatio = result.AvgWin.Div(result.AvgLoss.Abs()).Round(6)
 	}
 }

--- a/domain_service/backtest_test.go
+++ b/domain_service/backtest_test.go
@@ -189,7 +189,7 @@ func TestRunBacktest_WithCosts(t *testing.T) {
 		assert.Equal(t, 1, res.Trades)
 		retGot, _ := res.TradeList[0].Return.Float64()
 		retExp, _ := expectedRet.Float64()
-		assert.InDelta(t, retExp, retGot, 1e-9, "コストあり1トレードリターン")
+		assert.InDelta(t, retExp, retGot, 1e-6, "コストあり1トレードリターン（Round(6)分の誤差を許容）")
 
 		// コストなしより低いリターンになること
 		paramsNoCost := ExitParams{TakeProfit: decimal.NewFromFloat(0.10), StopLoss: decimal.NewFromFloat(0.05), MaxHoldDays: 10}


### PR DESCRIPTION
## 概要

`GET /backtest?symbol=7203` などのレスポンスで `totalReturn` 等の decimal 値が **300桁超の文字列**で返っていた問題を修正する。

shopspring/decimal の `Div` は精度無制限のため、`WinRate = wins/trades` のような単純な除算でも多数桁の文字列になる。
これをドメインサービス（`domain_service/backtest.go`）の出口一箇所で Round することで、handler に手を加えず修正する。

## 変更箇所

- `domain_service/backtest.go`
  - `runBacktest` 末尾: `TotalReturn.Round(6)`, `MaxDrawdown.Round(6)`
  - `fillTradeStats`: `WinRate.Round(4)`, `ProfitFactor/AvgWin/AvgLoss/PayoffRatio.Round(6)`
  - `closeTrade` 内 TradeList: `Return/EntryPrice/ExitPrice.Round(6)`
  - Equity ポイント: `eq.Round(6)`
- `domain_service/backtest_test.go`
  - コストあり1トレードのリターン精度比較を `1e-9 → 1e-6` に緩和（Round(6) で最大 0.5e-6 の丸め誤差が生じるため）

## 方針

- 比較演算（利確/損切り判定）の途中では丸めず、**最終出力のみ**で実施
- `signal_performance.go` の `calcHorizonStats` の `Round(6)/Round(4)` の流儀に準拠
- 戦略ランキングバッチ（`RunBacktestMetrics`）も同じ関数を使うため、Redis ペイロードが縮小される

## テスト

- `ENVCODE=unit go test ./...` 全 PASS
- `make lint` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)