### PR TITLE
feat: バックテストに戦略別イグジットシグナルを追加（exitMode=signal）

### DIFF
--- a/domain_service/backtest.go
+++ b/domain_service/backtest.go
@@ -47,14 +47,20 @@ func (ts *tradeStats) record(ret decimal.Decimal, holdDays int) {
 // （利確/損切り/最大保有/データ末尾）で終値手仕舞いするバックテストを実行する。
 // 同時に保有できるポジションは1つ。エクイティは初期資金 1.0 起点の倍率。
 // Equity / TradeList も構築する（フロント表示・ドリルダウン用）。
-func RunBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, params ExitParams) models.BacktestResult {
-	return runBacktest(prices, entrySignals, params, true)
+//
+// exitSignals: 戦略固有の手仕舞いシグナル（ExitSignalsByStrategy の戻り値）。nil を渡すと
+// 共通ルール（TakeProfit/StopLoss/MaxHoldDays）のみで判定する従来動作になる（後方互換）。
+// 優先順位: 既存の TP/SL 判定 -> シグナルイグジット（同日成立時は既存判定を優先）。
+func RunBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, exitSignals []bool, params ExitParams) models.BacktestResult {
+	return runBacktest(prices, entrySignals, exitSignals, params, true)
 }
 
 // RunBacktestMetrics RunBacktest と同じ成績指標を返すが、Equity / TradeList は構築しない
 // （日次の Date.Format とスライス確保を省く）。全銘柄横断バッチなど、集計のみ必要な用途向け。
-func RunBacktestMetrics(prices []*models.StockBrandDailyPrice, entrySignals []bool, params ExitParams) models.BacktestResult {
-	return runBacktest(prices, entrySignals, params, false)
+//
+// exitSignals: 戦略固有の手仕舞いシグナル。nil を渡すと従来動作（後方互換）。
+func RunBacktestMetrics(prices []*models.StockBrandDailyPrice, entrySignals []bool, exitSignals []bool, params ExitParams) models.BacktestResult {
+	return runBacktest(prices, entrySignals, exitSignals, params, false)
 }
 
 // exitReason 当日のリターンと保有日数から手仕舞い理由を返す。手仕舞い不要なら ""。
@@ -68,6 +74,18 @@ func exitReason(ret decimal.Decimal, holdDays int, params ExitParams) string {
 		return "stop_loss"
 	case holdDays >= params.MaxHoldDays:
 		return "max_hold"
+	}
+	return ""
+}
+
+// decideExitReason 共通ルールと戦略シグナルを組み合わせて手仕舞い理由を返す。手仕舞い不要なら ""。
+// 優先順位: 共通ルール（TP/SL/MaxHold） > 戦略シグナル（signal_exit）。
+func decideExitReason(rawRet decimal.Decimal, holdDays int, exitSignals []bool, idx int, params ExitParams) string {
+	if reason := exitReason(rawRet, holdDays, params); reason != "" {
+		return reason
+	}
+	if exitSignals != nil && idx < len(exitSignals) && exitSignals[idx] {
+		return "signal_exit"
 	}
 	return ""
 }
@@ -112,7 +130,7 @@ func effectiveExitReturn(exitClose, effectiveEntry, commissionRate, slippageRate
 	return exitEff.Div(effectiveEntry).Sub(decimal.NewFromInt(1))
 }
 
-func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, params ExitParams, collectSeries bool) models.BacktestResult {
+func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, exitSignals []bool, params ExitParams, collectSeries bool) models.BacktestResult {
 	n := len(prices)
 	result := models.BacktestResult{
 		TotalReturn:  decimal.Zero,
@@ -171,7 +189,7 @@ func runBacktest(prices []*models.StockBrandDailyPrice, entrySignals []bool, par
 		// 判定は生 Close ベース（コスト考慮前）
 		if inPosition && i > entryIdx {
 			rawRet := prices[i].Close.Div(entryClose).Sub(one)
-			if reason := exitReason(rawRet, i-entryIdx, params); reason != "" {
+			if reason := decideExitReason(rawRet, i-entryIdx, exitSignals, i, params); reason != "" {
 				closeTrade(i, reason)
 			}
 		}

--- a/domain_service/backtest_test.go
+++ b/domain_service/backtest_test.go
@@ -38,7 +38,7 @@ func TestRunBacktest(t *testing.T) {
 
 	t.Run("利確で手仕舞い", func(t *testing.T) {
 		prices := pricesFromCloses(100, 100, 110)
-		res := RunBacktest(prices, boolsAt(3, 1), params)
+		res := RunBacktest(prices, boolsAt(3, 1), nil, params)
 		assert.Equal(t, 1, res.Trades)
 		assert.InDelta(t, 0.10, f64FromDec(res.TotalReturn), 1e-9)
 		assert.InDelta(t, 1.0, f64FromDec(res.WinRate), 1e-9)
@@ -48,7 +48,7 @@ func TestRunBacktest(t *testing.T) {
 
 	t.Run("損切りで手仕舞い", func(t *testing.T) {
 		prices := pricesFromCloses(100, 100, 94)
-		res := RunBacktest(prices, boolsAt(3, 1), params)
+		res := RunBacktest(prices, boolsAt(3, 1), nil, params)
 		assert.Equal(t, 1, res.Trades)
 		assert.InDelta(t, -0.06, f64FromDec(res.TotalReturn), 1e-9)
 		assert.InDelta(t, 0.0, f64FromDec(res.WinRate), 1e-9)
@@ -59,7 +59,7 @@ func TestRunBacktest(t *testing.T) {
 	t.Run("最大保有日数で手仕舞い", func(t *testing.T) {
 		p := ExitParams{TakeProfit: decimal.NewFromFloat(0.5), StopLoss: decimal.NewFromFloat(0.5), MaxHoldDays: 2}
 		prices := pricesFromCloses(100, 100, 101, 102, 103)
-		res := RunBacktest(prices, boolsAt(5, 1), p)
+		res := RunBacktest(prices, boolsAt(5, 1), nil, p)
 		assert.Equal(t, 1, res.Trades)
 		assert.Equal(t, "max_hold", res.TradeList[0].Reason)
 		assert.Equal(t, 2, res.TradeList[0].HoldDays)
@@ -69,7 +69,7 @@ func TestRunBacktest(t *testing.T) {
 	t.Run("データ末尾で強制クローズ", func(t *testing.T) {
 		p := ExitParams{TakeProfit: decimal.NewFromFloat(0.5), StopLoss: decimal.NewFromFloat(0.5), MaxHoldDays: 10}
 		prices := pricesFromCloses(100, 100, 101)
-		res := RunBacktest(prices, boolsAt(3, 1), p)
+		res := RunBacktest(prices, boolsAt(3, 1), nil, p)
 		assert.Equal(t, 1, res.Trades)
 		assert.Equal(t, "end_of_data", res.TradeList[0].Reason)
 		assert.InDelta(t, 0.01, f64FromDec(res.TotalReturn), 1e-9)
@@ -77,7 +77,7 @@ func TestRunBacktest(t *testing.T) {
 
 	t.Run("シグナルなしは取引0件", func(t *testing.T) {
 		prices := pricesFromCloses(100, 101, 102)
-		res := RunBacktest(prices, boolsAt(3), params)
+		res := RunBacktest(prices, boolsAt(3), nil, params)
 		assert.Equal(t, 0, res.Trades)
 		assert.True(t, res.TotalReturn.IsZero())
 		assert.Len(t, res.Equity, 3)
@@ -86,13 +86,13 @@ func TestRunBacktest(t *testing.T) {
 	t.Run("保有中は新規エントリーしない", func(t *testing.T) {
 		// day1でエントリー、day2にもシグナルがあるが保有中なので無視、day3でTP
 		prices := pricesFromCloses(100, 100, 105, 110)
-		res := RunBacktest(prices, boolsAt(4, 1, 2), params)
+		res := RunBacktest(prices, boolsAt(4, 1, 2), nil, params)
 		assert.Equal(t, 1, res.Trades) // 2回目のシグナルは無視される
 	})
 
 	t.Run("空入力やサイズ不一致は空結果", func(t *testing.T) {
-		assert.Equal(t, 0, RunBacktest(nil, nil, params).Trades)
-		assert.Equal(t, 0, RunBacktest(pricesFromCloses(100, 101), boolsAt(3), params).Trades)
+		assert.Equal(t, 0, RunBacktest(nil, nil, nil, params).Trades)
+		assert.Equal(t, 0, RunBacktest(pricesFromCloses(100, 101), boolsAt(3), nil, params).Trades)
 	})
 }
 
@@ -106,8 +106,8 @@ func TestRunBacktestMetrics(t *testing.T) {
 	prices := pricesFromCloses(100, 100, 110, 110, 110, 104)
 	signals := boolsAt(6, 1, 3)
 
-	full := RunBacktest(prices, signals, params)
-	metrics := RunBacktestMetrics(prices, signals, params)
+	full := RunBacktest(prices, signals, nil, params)
+	metrics := RunBacktestMetrics(prices, signals, nil, params)
 
 	// メトリクスは完全一致
 	assert.Equal(t, full.Trades, metrics.Trades)
@@ -151,8 +151,8 @@ func TestRunBacktest_WithCosts(t *testing.T) {
 		prices := pricesFromCloses(100, 100, 110, 110, 110, 104)
 		signals := boolsAt(6, 1, 3)
 
-		resNoCost := RunBacktest(prices, signals, paramsNoCost)
-		resZeroCost := RunBacktest(prices, signals, paramsZeroCost)
+		resNoCost := RunBacktest(prices, signals, nil, paramsNoCost)
+		resZeroCost := RunBacktest(prices, signals, nil, paramsZeroCost)
 
 		assert.True(t, resNoCost.TotalReturn.Equal(resZeroCost.TotalReturn), "TotalReturn 後方互換")
 		assert.True(t, resNoCost.WinRate.Equal(resZeroCost.WinRate), "WinRate 後方互換")
@@ -176,7 +176,7 @@ func TestRunBacktest_WithCosts(t *testing.T) {
 			SlippageRate:   slippage,
 		}
 		prices := pricesFromCloses(100, 100, 110)
-		res := RunBacktest(prices, boolsAt(3, 1), params)
+		res := RunBacktest(prices, boolsAt(3, 1), nil, params)
 
 		// 手計算
 		one := decimal.NewFromInt(1)
@@ -193,7 +193,7 @@ func TestRunBacktest_WithCosts(t *testing.T) {
 
 		// コストなしより低いリターンになること
 		paramsNoCost := ExitParams{TakeProfit: decimal.NewFromFloat(0.10), StopLoss: decimal.NewFromFloat(0.05), MaxHoldDays: 10}
-		resNoCost := RunBacktest(prices, boolsAt(3, 1), paramsNoCost)
+		resNoCost := RunBacktest(prices, boolsAt(3, 1), nil, paramsNoCost)
 		assert.True(t, res.TradeList[0].Return.LessThan(resNoCost.TradeList[0].Return), "コストあり < コストなし")
 	})
 
@@ -218,13 +218,72 @@ func TestRunBacktest_WithCosts(t *testing.T) {
 		prices := pricesFromCloses(100, 100, 100.5)
 		signals := boolsAt(3, 1)
 
-		resCost := RunBacktest(prices, signals, paramsCost)
-		resNoCost := RunBacktest(prices, signals, paramsNoCost)
+		resCost := RunBacktest(prices, signals, nil, paramsCost)
+		resNoCost := RunBacktest(prices, signals, nil, paramsNoCost)
 
 		assert.Equal(t, 1, resCost.Trades)
 		assert.Equal(t, 1, resNoCost.Trades)
 		// コストなしは勝ち（WinRate=1）、コストありは負け（WinRate=0）
 		assert.True(t, resNoCost.WinRate.Equal(decimal.NewFromInt(1)), "コストなし: 勝率1")
 		assert.True(t, resCost.WinRate.Equal(decimal.Zero), "コストあり: 勝率0")
+	})
+}
+
+// TestRunBacktest_WithExitSignals シグナルイグジット機能のテスト
+func TestRunBacktest_WithExitSignals(t *testing.T) {
+	params := ExitParams{
+		TakeProfit:  decimal.NewFromFloat(0.50), // 広め（シグナルが先に発火するよう）
+		StopLoss:    decimal.NewFromFloat(0.50),
+		MaxHoldDays: 30,
+	}
+
+	t.Run("exitSignals=nil なら従来動作と完全一致", func(t *testing.T) {
+		prices := pricesFromCloses(100, 100, 102, 104, 106)
+		signals := boolsAt(5, 1)
+
+		withNil := RunBacktest(prices, signals, nil, params)
+		withoutExitSignals := runBacktest(prices, signals, nil, params, true)
+
+		assert.Equal(t, withNil.Trades, withoutExitSignals.Trades)
+		assert.True(t, withNil.TotalReturn.Equal(withoutExitSignals.TotalReturn), "TotalReturn 一致")
+	})
+
+	t.Run("シグナルイグジットで TP/SL 到達前に手仕舞い", func(t *testing.T) {
+		// day1でエントリー、day3で exitSignal が立つ（TP/SL未到達）
+		prices := pricesFromCloses(100, 100, 101, 102, 103, 110)
+		entrySignals := boolsAt(6, 1)
+		exitSignals := boolsAt(6, 3) // day3で手仕舞い
+
+		res := RunBacktest(prices, entrySignals, exitSignals, params)
+
+		assert.Equal(t, 1, res.Trades)
+		assert.Equal(t, "signal_exit", res.TradeList[0].Reason)
+		assert.Equal(t, 2, res.TradeList[0].HoldDays) // day1→day3 = 2日
+		// リターン = 102/100 - 1 = 0.02
+		assert.InDelta(t, 0.02, f64FromDec(res.TradeList[0].Return), 1e-9)
+	})
+
+	t.Run("同日に TP とシグナルが重なったら TP 優先", func(t *testing.T) {
+		// day1でエントリー、day2で TP 到達（+50%）、同日に exitSignal も true
+		params2 := ExitParams{TakeProfit: decimal.NewFromFloat(0.49), StopLoss: decimal.NewFromFloat(0.50), MaxHoldDays: 30}
+		prices := pricesFromCloses(100, 100, 150, 200) // day2で +50%
+		entrySignals := boolsAt(4, 1)
+		exitSignals := boolsAt(4, 2) // day2が TP 到達日と同日
+
+		res := RunBacktest(prices, entrySignals, exitSignals, params2)
+
+		assert.Equal(t, 1, res.Trades)
+		// TP が優先されるべき
+		assert.Equal(t, "take_profit", res.TradeList[0].Reason)
+	})
+
+	t.Run("exitSignals が entrySignals より短い場合もパニックしない", func(t *testing.T) {
+		prices := pricesFromCloses(100, 100, 101, 102, 103)
+		entrySignals := boolsAt(5, 1)
+		exitSignals := boolsAt(3, 2) // 長さが prices より短い
+
+		assert.NotPanics(t, func() {
+			RunBacktest(prices, entrySignals, exitSignals, params)
+		})
 	})
 }

--- a/domain_service/strategy_signals.go
+++ b/domain_service/strategy_signals.go
@@ -54,6 +54,127 @@ func EntrySignalsByStrategy(strategy string, prices []*models.StockBrandDailyPri
 	}
 }
 
+// ExitSignalsByStrategy 指定戦略の反転（手仕舞い）シグナルを日次の []bool で返す純粋関数。
+// 返り値の長さは len(prices) と一致し、true はその日の終値時点でイグジット条件成立を表す。
+// 未知の strategy は全 false を返す。
+func ExitSignalsByStrategy(strategy string, prices []*models.StockBrandDailyPrice) []bool {
+	switch strategy {
+	case StrategyMACDBullish:
+		return MACDBullishExitSignals(prices)
+	case StrategyBollingerBreakout:
+		return BollingerBreakoutExitSignals(prices)
+	case StrategyTriangleFormation:
+		return GenericTrendBreakExitSignals(prices)
+	case StrategyMovingAverageCross:
+		return MovingAverageCrossExitSignals(prices)
+	case StrategyMultipleSignals:
+		return GenericTrendBreakExitSignals(prices)
+	default:
+		return make([]bool, len(prices))
+	}
+}
+
+// MACDBullishExitSignals MACDデッドクロス（前日 MACD >= Signal かつ当日 MACD < Signal）で手仕舞い。
+// MACDBullishEntrySignals（ゴールデンクロス）の反転シグナル。
+func MACDBullishExitSignals(prices []*models.StockBrandDailyPrice) []bool {
+	n := len(prices)
+	signals := make([]bool, n)
+	closes := ExtractClosePrices(prices)
+
+	macd := CalculateMACD(closes, 12, 26, 9)
+	if macd == nil {
+		return signals
+	}
+	// MACD/Signal が有効になる十分なウォームアップ後から評価（エントリーと同じ閾値）
+	const minIdx = 35
+	for i := minIdx; i < n; i++ {
+		cur := macd[i]
+		prev := macd[i-1]
+		// デッドクロス: 前日 MACD >= Signal かつ当日 MACD < Signal
+		deadCross := cur.MACD.LessThan(cur.Signal) &&
+			!prev.MACD.LessThan(prev.Signal)
+		if deadCross {
+			signals[i] = true
+		}
+	}
+	return signals
+}
+
+// BollingerBreakoutExitSignals 終値がボリンジャーミドルバンド（20SMA）を下抜け。
+// 前日 close >= middle かつ当日 close < middle の成立を手仕舞いシグナルとする。
+// BollingerBreakoutEntrySignals（アッパー上抜け）の反転シグナル。
+func BollingerBreakoutExitSignals(prices []*models.StockBrandDailyPrice) []bool {
+	n := len(prices)
+	signals := make([]bool, n)
+	closes := ExtractClosePrices(prices)
+
+	const bbPeriod = 20
+	bb := CalculateBollingerBands(closes, bbPeriod, decimal.NewFromInt(2))
+	if bb == nil {
+		return signals
+	}
+
+	// ミドルバンドが有効になる bbPeriod-1 日目以降から評価
+	for i := bbPeriod; i < n; i++ {
+		// 終値がミドルバンド（20SMA）を下抜け
+		belowMiddle := closes[i].LessThan(bb[i].Middle) &&
+			!closes[i-1].LessThan(bb[i-1].Middle)
+		if belowMiddle {
+			signals[i] = true
+		}
+	}
+	return signals
+}
+
+// MovingAverageCrossExitSignals 5日SMAが25日SMAを下抜け（前日 5SMA >= 25SMA かつ当日 5SMA < 25SMA）。
+// MovingAverageCrossEntrySignals（5/25/75全上抜け）の反転シグナル。
+func MovingAverageCrossExitSignals(prices []*models.StockBrandDailyPrice) []bool {
+	n := len(prices)
+	signals := make([]bool, n)
+	closes := ExtractClosePrices(prices)
+
+	sma5 := smaSeries(closes, 5)
+	sma25 := smaSeries(closes, 25)
+
+	// sma25 が有効になる index=24 以降、かつ前日も有効な index=25 以降から評価
+	for i := 25; i < n; i++ {
+		if sma5[i].IsZero() || sma25[i].IsZero() || sma5[i-1].IsZero() || sma25[i-1].IsZero() {
+			continue
+		}
+		// 5SMA が 25SMA を下抜け
+		crossUnder := sma5[i].LessThan(sma25[i]) &&
+			!sma5[i-1].LessThan(sma25[i-1])
+		if crossUnder {
+			signals[i] = true
+		}
+	}
+	return signals
+}
+
+// GenericTrendBreakExitSignals 汎用トレンド破れルール: 終値が25日SMAを下抜け。
+// TriangleFormation・MultipleSignals など固有の反転シグナルが定義しにくい戦略に使用する。
+func GenericTrendBreakExitSignals(prices []*models.StockBrandDailyPrice) []bool {
+	n := len(prices)
+	signals := make([]bool, n)
+	closes := ExtractClosePrices(prices)
+
+	sma25 := smaSeries(closes, 25)
+
+	// sma25 が有効になる index=24 以降、かつ前日も有効な index=25 以降から評価
+	for i := 25; i < n; i++ {
+		if sma25[i].IsZero() || sma25[i-1].IsZero() {
+			continue
+		}
+		// 終値が 25SMA を下抜け
+		belowSMA25 := closes[i].LessThan(sma25[i]) &&
+			!closes[i-1].LessThan(sma25[i-1])
+		if belowSMA25 {
+			signals[i] = true
+		}
+	}
+	return signals
+}
+
 // MACDBullishEntrySignals MACDゴールデンクロス(Signal≥0) + RSI<70 + 出来高>5日平均。
 func MACDBullishEntrySignals(prices []*models.StockBrandDailyPrice) []bool {
 	n := len(prices)

--- a/domain_service/strategy_signals_test.go
+++ b/domain_service/strategy_signals_test.go
@@ -90,3 +90,134 @@ func TestMovingAverageCrossEntrySignals(t *testing.T) {
 	}
 	assert.Equal(t, 1, count)
 }
+
+// TestExitSignalsByStrategy_LengthAndDefault ExitSignalsByStrategy の基本動作を確認。
+func TestExitSignalsByStrategy_LengthAndDefault(t *testing.T) {
+	prices := pricesFromCloses(make([]float64, 90)...)
+	for _, s := range StrategyOrder {
+		got := ExitSignalsByStrategy(s, prices)
+		assert.Len(t, got, len(prices), "strategy %s", s)
+	}
+	// 未知の戦略は全 false
+	got := ExitSignalsByStrategy("unknown", prices)
+	assert.Len(t, got, len(prices))
+	for _, v := range got {
+		assert.False(t, v)
+	}
+}
+
+// TestMACDBullishExitSignals MACD デッドクロスを検出することを確認。
+func TestMACDBullishExitSignals(t *testing.T) {
+	t.Run("短データ（ウォームアップ不足）は全 false", func(t *testing.T) {
+		prices := pricesFromCloses(make([]float64, 30)...)
+		sigs := MACDBullishExitSignals(prices)
+		for _, v := range sigs {
+			assert.False(t, v)
+		}
+	})
+
+	t.Run("急騰後に急落するデータではデッドクロスが発生する", func(t *testing.T) {
+		// 100日データ: 10日フラット + 50日急上昇 + 40日急落
+		// このパターンだと minIdx=35 以降でデッドクロスが発生する
+		closes := make([]float64, 100)
+		for i := 0; i < 10; i++ {
+			closes[i] = 100 // フラット
+		}
+		for i := 10; i < 60; i++ {
+			closes[i] = float64(100 + (i-10)*3) // 急上昇
+		}
+		peak := 100 + 50*3 // 250
+		for i := 60; i < 100; i++ {
+			closes[i] = float64(peak - (i-60)*5) // 急落
+		}
+		prices := pricesFromCloses(closes...)
+		sigs := MACDBullishExitSignals(prices)
+		// 急落フェーズでデッドクロスが1回以上発生するはず
+		count := 0
+		for _, v := range sigs {
+			if v {
+				count++
+			}
+		}
+		assert.Greater(t, count, 0, "急落フェーズでデッドクロスが発生するはず")
+	})
+}
+
+// TestBollingerBreakoutExitSignals ミドルバンド下抜けを検出することを確認。
+func TestBollingerBreakoutExitSignals(t *testing.T) {
+	t.Run("短データ（ウォームアップ不足）は全 false", func(t *testing.T) {
+		prices := pricesFromCloses(make([]float64, 15)...)
+		sigs := BollingerBreakoutExitSignals(prices)
+		for _, v := range sigs {
+			assert.False(t, v)
+		}
+	})
+
+	t.Run("ミドルバンドを下抜けた日が検出される", func(t *testing.T) {
+		// 25日フラット(100)の後、1日だけ80に急落し翌日100に戻す
+		closes := make([]float64, 25)
+		for i := range closes {
+			closes[i] = 100
+		}
+		closes = append(closes, 80) // index 25: 100→80（ミドルバンド≒100を下抜け）
+		closes = append(closes, 100)
+		prices := pricesFromCloses(closes...)
+		sigs := BollingerBreakoutExitSignals(prices)
+		assert.True(t, sigs[25], "index25 でミドルバンド下抜けシグナルが立つべき")
+	})
+}
+
+// TestMovingAverageCrossExitSignals 5SMAが25SMAを下抜けを検出することを確認。
+func TestMovingAverageCrossExitSignals(t *testing.T) {
+	t.Run("短データは全 false", func(t *testing.T) {
+		prices := pricesFromCloses(make([]float64, 10)...)
+		sigs := MovingAverageCrossExitSignals(prices)
+		for _, v := range sigs {
+			assert.False(t, v)
+		}
+	})
+
+	t.Run("5SMAが25SMAを下抜けた日が検出される", func(t *testing.T) {
+		// 30日フラット(100)の後、5日連続で急落（5SMAが25SMAを下抜け）
+		closes := make([]float64, 30)
+		for i := range closes {
+			closes[i] = 100
+		}
+		for i := 0; i < 5; i++ {
+			closes = append(closes, 50) // 急落（5SMA≒50 < 25SMA≒100近辺）
+		}
+		prices := pricesFromCloses(closes...)
+		sigs := MovingAverageCrossExitSignals(prices)
+		// 急落フェーズで少なくとも1回下抜けが検出されるはず
+		count := 0
+		for _, v := range sigs {
+			if v {
+				count++
+			}
+		}
+		assert.Greater(t, count, 0, "急落後に5SMA < 25SMAの下抜けが検出されるはず")
+	})
+}
+
+// TestGenericTrendBreakExitSignals 終値が25SMAを下抜けを検出することを確認。
+func TestGenericTrendBreakExitSignals(t *testing.T) {
+	t.Run("短データは全 false", func(t *testing.T) {
+		prices := pricesFromCloses(make([]float64, 10)...)
+		sigs := GenericTrendBreakExitSignals(prices)
+		for _, v := range sigs {
+			assert.False(t, v)
+		}
+	})
+
+	t.Run("終値が25SMAを下抜けた日が検出される", func(t *testing.T) {
+		// 30日フラット(100)の後1日だけ50に急落（25SMA≒100を下抜け）
+		closes := make([]float64, 30)
+		for i := range closes {
+			closes[i] = 100
+		}
+		closes = append(closes, 50) // index 30: 25SMAより大幅に下
+		prices := pricesFromCloses(closes...)
+		sigs := GenericTrendBreakExitSignals(prices)
+		assert.True(t, sigs[30], "index30 で25SMA下抜けシグナルが立つべき")
+	})
+}

--- a/entrypoint/api/handler/backtest_handler.go
+++ b/entrypoint/api/handler/backtest_handler.go
@@ -66,6 +66,18 @@ func parseNonNegativeRate(raw string) (decimal.Decimal, bool) {
 	return decimal.NewFromFloat(f), true
 }
 
+// parseExitMode "common"（デフォルト）/ "signal" をパースする。空なら "common"（デフォルト）。
+// それ以外の値は false を返す。
+func parseExitMode(raw string) (string, bool) {
+	if raw == "" {
+		return models.ExitModeCommon, true
+	}
+	if raw == models.ExitModeCommon || raw == models.ExitModeSignal {
+		return raw, true
+	}
+	return "", false
+}
+
 func (h *BacktestHandler) validateGetBacktestParams(r *http.Request) (*getBacktestParams, error) {
 	p := &getBacktestParams{}
 
@@ -119,12 +131,18 @@ func (h *BacktestHandler) validateGetBacktestParams(r *http.Request) (*getBackte
 		return nil, &validationError{message: "slippageは0以上0.05以下である必要があります"}
 	}
 
+	exitMode, ok := parseExitMode(h.httpServer.GetQueryParam(r, "exitMode"))
+	if !ok {
+		return nil, &validationError{message: "exitModeはcommonまたはsignalである必要があります"}
+	}
+
 	p.params = models.BacktestParams{
 		TakeProfit:     takeProfit,
 		StopLoss:       stopLoss,
 		MaxHoldDays:    maxHoldDays,
 		CommissionRate: commissionRate,
 		SlippageRate:   slippageRate,
+		ExitMode:       exitMode,
 	}
 	return p, nil
 }

--- a/entrypoint/api/handler/backtest_handler_test.go
+++ b/entrypoint/api/handler/backtest_handler_test.go
@@ -26,6 +26,7 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 		MaxHoldDays:    20,
 		CommissionRate: decimal.Zero,
 		SlippageRate:   decimal.Zero,
+		ExitMode:       models.ExitModeCommon,
 	}
 
 	type fields struct {
@@ -66,6 +67,7 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "exitMode").Return("")
 					return m
 				},
 			},
@@ -156,6 +158,7 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "exitMode").Return("")
 					return m
 				},
 			},
@@ -325,6 +328,144 @@ func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
 
 			assert.Equal(t, tt.wantStatusCode, w.Code)
 			assert.Equal(t, tt.wantBody, w.Body.String())
+		})
+	}
+}
+
+func TestBacktestHandler_GetBacktest_ExitMode(t *testing.T) {
+	date, _ := time.Parse(util.DateLayout, "2021-01-04")
+	type fields struct {
+		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor
+		httpServer func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		req            *http.Request
+		wantStatusCode int
+		wantBody       string
+	}{
+		{
+			name: "異常系: exitMode が不正値",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					return mock_usecase.NewMockBacktestInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "exitMode").Return("invalid")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&exitMode=invalid", nil),
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "exitModeはcommonまたはsignalである必要があります\n",
+
+		},
+		{
+			name: "正常系: exitMode=signal でバックテスト取得",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					m := mock_usecase.NewMockBacktestInteractor(ctrl)
+					signalParams := models.BacktestParams{
+						TakeProfit:     decimal.NewFromFloat(0.10),
+						StopLoss:       decimal.NewFromFloat(0.05),
+						MaxHoldDays:    20,
+						CommissionRate: decimal.Zero,
+						SlippageRate:   decimal.Zero,
+						ExitMode:       models.ExitModeSignal,
+					}
+					m.EXPECT().
+						GetBacktestComparison(gomock.Any(), "7203", &date, &date, signalParams).
+						Return(&models.BacktestComparison{
+							Symbol:     "7203",
+							TradingDays: 1,
+							Params:     signalParams,
+							Strategies: []models.StrategyBacktest{},
+						}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "exitMode").Return("signal")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&from=2021-01-04&to=2021-01-04&exitMode=signal", nil),
+			wantStatusCode: http.StatusOK,
+		},
+		{
+			name: "正常系: exitMode=common でバックテスト取得",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor {
+					m := mock_usecase.NewMockBacktestInteractor(ctrl)
+					commonParams := models.BacktestParams{
+						TakeProfit:     decimal.NewFromFloat(0.10),
+						StopLoss:       decimal.NewFromFloat(0.05),
+						MaxHoldDays:    20,
+						CommissionRate: decimal.Zero,
+						SlippageRate:   decimal.Zero,
+						ExitMode:       models.ExitModeCommon,
+					}
+					m.EXPECT().
+						GetBacktestComparison(gomock.Any(), "7203", &date, &date, commonParams).
+						Return(&models.BacktestComparison{
+							Symbol:     "7203",
+							TradingDays: 1,
+							Params:     commonParams,
+							Strategies: []models.StrategyBacktest{},
+						}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
+					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "commission").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "slippage").Return("")
+					m.EXPECT().GetQueryParam(gomock.Any(), "exitMode").Return("common")
+					return m
+				},
+			},
+			req:            httptest.NewRequest(http.MethodGet, "/backtest?symbol=7203&from=2021-01-04&to=2021-01-04&exitMode=common", nil),
+			wantStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			h := NewBacktestHandler(tt.fields.usecase(ctrl), tt.fields.httpServer(ctrl), zap.NewNop())
+
+			w := httptest.NewRecorder()
+			h.GetBacktest(w, tt.req)
+
+			assert.Equal(t, tt.wantStatusCode, w.Code)
+			if tt.wantBody != "" {
+				assert.Equal(t, tt.wantBody, w.Body.String())
+			}
 		})
 	}
 }

--- a/models/backtest.go
+++ b/models/backtest.go
@@ -9,7 +9,17 @@ type BacktestParams struct {
 	MaxHoldDays    int             `json:"maxHoldDays"`    // 最大保有営業日数
 	CommissionRate decimal.Decimal `json:"commissionRate"` // 片道手数料率（例: 0.0005）。ゼロ値 = コストなし
 	SlippageRate   decimal.Decimal `json:"slippageRate"`   // 片道スリッページ率（例: 0.001）。ゼロ値 = コストなし
+	// ExitMode イグジットモード: "common"（デフォルト・従来動作）/ "signal"（戦略固有シグナルで手仕舞い）。
+	// "common" はリクエスト省略時のデフォルト。
+	ExitMode string `json:"exitMode"`
 }
+
+// ExitModeCommon 共通ルール（TakeProfit/StopLoss/MaxHoldDays）のみで手仕舞い。デフォルト動作。
+const ExitModeCommon = "common"
+
+// ExitModeSignal 戦略固有の反転シグナル（ExitSignalsByStrategy）で手仕舞い。
+// 共通ルールが同日に成立した場合は共通ルールが優先される。
+const ExitModeSignal = "signal"
 
 // BacktestEquityPoint エクイティカーブの1点（初期資金=1.0 を起点とした倍率）。
 type BacktestEquityPoint struct {

--- a/usecase/backtest_interactor.go
+++ b/usecase/backtest_interactor.go
@@ -70,7 +70,12 @@ func (b *backtestInteractorImpl) GetBacktestComparison(ctx context.Context, symb
 		var result models.BacktestResult
 		if len(prices) >= minBacktestDays {
 			signals := domain_service.EntrySignalsByStrategy(strategy, prices)
-			result = domain_service.RunBacktest(prices, signals, exitParams)
+			// exitMode=signal のとき戦略固有の反転シグナルを渡す。それ以外は nil（従来動作）。
+			var exitSignals []bool
+			if params.ExitMode == models.ExitModeSignal {
+				exitSignals = domain_service.ExitSignalsByStrategy(strategy, prices)
+			}
+			result = domain_service.RunBacktest(prices, signals, exitSignals, exitParams)
 		} else {
 			// データ不足時は空結果（取引0件）
 			result = models.BacktestResult{Equity: []models.BacktestEquityPoint{}, TradeList: []models.BacktestTrade{}}

--- a/usecase/strategy_ranking_interactor.go
+++ b/usecase/strategy_ranking_interactor.go
@@ -73,7 +73,8 @@ func accumulateResults(brand *models.StockBrand, prices []*models.StockBrandDail
 	results := make(map[string]models.BacktestResult, len(domain_service.StrategyOrder))
 	for _, s := range domain_service.StrategyOrder {
 		signals := domain_service.EntrySignalsByStrategy(s, prices)
-		results[s] = domain_service.RunBacktestMetrics(prices, signals, exitParams)
+		// exitSignals は nil を渡して共通ルールのみ使用（ランキングバッチは挙動不変を優先）
+		results[s] = domain_service.RunBacktestMetrics(prices, signals, nil, exitParams)
 	}
 	for _, s := range domain_service.StrategyOrder {
 		res := results[s]


### PR DESCRIPTION
## 概要

バックテスト（`GET /backtest`）に「エントリーした戦略自身の反転シグナルで手仕舞う」モードを追加しました。
`exitMode` クエリパラメータで切り替えます。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `domain_service/strategy_signals.go` | `ExitSignalsByStrategy()` と各戦略の反転シグナル関数を追加 |
| `domain_service/backtest.go` | `RunBacktest/RunBacktestMetrics` に `exitSignals []bool` 引数を追加 |
| `models/backtest.go` | `BacktestParams.ExitMode` フィールドと定数を追加 |
| `entrypoint/api/handler/backtest_handler.go` | `exitMode` クエリパラメータのパース・バリデーションを追加 |
| `usecase/backtest_interactor.go` | `exitMode=signal` 時に `ExitSignalsByStrategy` を呼び出すよう修正 |
| `usecase/strategy_ranking_interactor.go` | `nil` を渡して挙動不変を担保 |
| 各 `_test.go` | 既存テストを新シグネチャに追従 + 新規テスト追加 |

## API 仕様変更（フロント向け）

### リクエスト

```
GET /backtest?symbol=7203&exitMode=signal
```

| パラメータ | 値 | 説明 |
|---|---|---|
| `exitMode` | `common`（デフォルト・省略可）| 共通ルール（TP/SL/MaxHold）のみ。従来動作 |
| `exitMode` | `signal` | 戦略固有の反転シグナルで手仕舞い（共通ルールと両立、優先は共通ルール） |
| `exitMode` | その他 | 400 Bad Request |

### レスポンス変化

`params` フィールドに `exitMode` が追加されます:

```json
{
  "params": {
    "takeProfit": "0.1",
    "stopLoss": "0.05",
    "maxHoldDays": 20,
    "commissionRate": "0",
    "slippageRate": "0",
    "exitMode": "signal"
  }
}
```

`tradeList` の `reason` に新しい値 `"signal_exit"` が追加されます:

- `take_profit` / `stop_loss` / `max_hold` / `end_of_data`（従来）
- `signal_exit`（追加: 戦略シグナルによる手仕舞い）

## イグジット定義

| 戦略 | イグジット条件 |
|---|---|
| `macd_bullish` | MACD デッドクロス（前日 MACD ≥ Signal かつ当日 MACD < Signal） |
| `ma_cross` | 5日SMA が 25日SMA を下抜け（前日 5SMA ≥ 25SMA かつ当日 5SMA < 25SMA） |
| `bollinger_breakout` | 終値がミドルバンド（20SMA）を下抜け |
| `triangle_formation` | 汎用トレンド破れ（終値が25SMAを下抜け）|
| `multiple_signals` | 汎用トレンド破れ（終値が25SMAを下抜け）|

## 後方互換

- `exitMode` 省略時は `"common"` として動作（従来と完全一致）
- `RunBacktest(prices, signals, nil, params)` で `nil` を渡せば従来動作
- 戦略ランキングバッチ（`accumulateResults`）は `nil` を渡して挙動不変

## テスト

- `ENVCODE=unit go test ./...` — 全 PASS
- `make lint` — 0 issues

## Test plan

- [ ] `GET /backtest?symbol=7203&exitMode=signal` でレスポンスに `exitMode: "signal"` が含まれる
- [ ] `tradeList` の `reason` に `"signal_exit"` が現れる
- [ ] `exitMode=invalid` で 400 が返る
- [ ] `exitMode` 省略時は既存と同じ結果

🤖 Generated with [Claude Code](https://claude.com/claude-code)