### PR TITLE
feat: シグナル精度トラッキングにrank帯別・score四分位別の成績集計を追加

### DIFF
--- a/domain_service/signal_band_test.go
+++ b/domain_service/signal_band_test.go
@@ -1,0 +1,188 @@
+package domain_service
+
+import (
+	"testing"
+
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- テストヘルパー ----
+
+func intPtr(v int) *int { return &v }
+
+func decPtr(f float64) *decimal.Decimal {
+	d := decimal.NewFromFloat(f)
+	return &d
+}
+
+func signalWithRank(rank *int) *models.EvaluatedSignal {
+	r5 := decimal.NewFromFloat(0.05)
+	return &models.EvaluatedSignal{
+		Method:     "test",
+		SignalRank: rank,
+		Returns:    map[int]*decimal.Decimal{5: &r5},
+	}
+}
+
+func signalWithScore(score *decimal.Decimal, ret float64) *models.EvaluatedSignal {
+	r5 := decimal.NewFromFloat(ret)
+	return &models.EvaluatedSignal{
+		Method:  "test",
+		Score:   score,
+		Returns: map[int]*decimal.Decimal{5: &r5},
+	}
+}
+
+// ---- AggregateByRankBand テスト ----
+
+func TestAggregateByRankBand_BandNames(t *testing.T) {
+	// 帯名と順序の確認（シグナル0件でも3帯返る）
+	result := AggregateByRankBand([]*models.EvaluatedSignal{}, []int{5})
+	require.Len(t, result, 3)
+	assert.Equal(t, "1-3", result[0].Band)
+	assert.Equal(t, "4-10", result[1].Band)
+	assert.Equal(t, "11+", result[2].Band)
+}
+
+func TestAggregateByRankBand_EmptyBands(t *testing.T) {
+	// シグナル0件でも SignalCount=0 で3帯返る
+	result := AggregateByRankBand([]*models.EvaluatedSignal{}, []int{5})
+	for _, b := range result {
+		assert.Equal(t, 0, b.SignalCount)
+	}
+}
+
+func TestAggregateByRankBand_BoundaryRank3to4(t *testing.T) {
+	// 境界: rank=3 は "1-3"、rank=4 は "4-10"
+	signals := []*models.EvaluatedSignal{
+		signalWithRank(intPtr(3)),
+		signalWithRank(intPtr(4)),
+	}
+	result := AggregateByRankBand(signals, []int{5})
+	require.Len(t, result, 3)
+	assert.Equal(t, 1, result[0].SignalCount, "rank=3 は 1-3 帯")
+	assert.Equal(t, 1, result[1].SignalCount, "rank=4 は 4-10 帯")
+	assert.Equal(t, 0, result[2].SignalCount, "11+ 帯は空")
+}
+
+func TestAggregateByRankBand_BoundaryRank10to11(t *testing.T) {
+	// 境界: rank=10 は "4-10"、rank=11 は "11+"
+	signals := []*models.EvaluatedSignal{
+		signalWithRank(intPtr(10)),
+		signalWithRank(intPtr(11)),
+	}
+	result := AggregateByRankBand(signals, []int{5})
+	require.Len(t, result, 3)
+	assert.Equal(t, 0, result[0].SignalCount, "1-3 帯は空")
+	assert.Equal(t, 1, result[1].SignalCount, "rank=10 は 4-10 帯")
+	assert.Equal(t, 1, result[2].SignalCount, "rank=11 は 11+ 帯")
+}
+
+func TestAggregateByRankBand_NilRankExcluded(t *testing.T) {
+	// SignalRank=nil のシグナルは除外
+	signals := []*models.EvaluatedSignal{
+		signalWithRank(intPtr(1)),
+		signalWithRank(nil), // 除外
+	}
+	result := AggregateByRankBand(signals, []int{5})
+	total := 0
+	for _, b := range result {
+		total += b.SignalCount
+	}
+	assert.Equal(t, 1, total, "nil rank は除外されること")
+}
+
+func TestAggregateByRankBand_ReturnsNilSkipped(t *testing.T) {
+	// Returns=nil（skip）のシグナルは SignalCount に含まれるが stats の evaluatedCount には入らない
+	signals := []*models.EvaluatedSignal{
+		{Method: "test", SignalRank: intPtr(1), Returns: nil}, // skip
+		signalWithRank(intPtr(2)),
+	}
+	result := AggregateByRankBand(signals, []int{5})
+	assert.Equal(t, 2, result[0].SignalCount, "skip を含む SignalCount")
+	assert.Equal(t, 1, result[0].Stats[5].EvaluatedCount, "skip は evaluatedCount に含まれない")
+}
+
+// ---- AggregateByScoreQuartile テスト ----
+
+func TestAggregateByScoreQuartile_NLessThan4_ReturnsEmpty(t *testing.T) {
+	// n<4 のとき空を返す
+	signals := []*models.EvaluatedSignal{
+		signalWithScore(decPtr(0.5), 0.1),
+		signalWithScore(decPtr(0.6), 0.2),
+		signalWithScore(decPtr(0.7), 0.3),
+	}
+	result := AggregateByScoreQuartile(signals, []int{5})
+	assert.Empty(t, result)
+}
+
+func TestAggregateByScoreQuartile_NilScoreExcluded(t *testing.T) {
+	// Score=nil のシグナルは除外（全部 nil なら空）
+	signals := []*models.EvaluatedSignal{
+		signalWithScore(nil, 0.1),
+		signalWithScore(nil, 0.2),
+		signalWithScore(nil, 0.3),
+		signalWithScore(nil, 0.4),
+	}
+	result := AggregateByScoreQuartile(signals, []int{5})
+	assert.Empty(t, result)
+}
+
+func TestAggregateByScoreQuartile_N8_2PerQuartile(t *testing.T) {
+	// n=8 で各四分位 2件ずつ
+	signals := make([]*models.EvaluatedSignal, 8)
+	for i := 0; i < 8; i++ {
+		signals[i] = signalWithScore(decPtr(float64(i+1)*0.1), 0.01*float64(i+1))
+	}
+	result := AggregateByScoreQuartile(signals, []int{5})
+	require.Len(t, result, 4)
+	for i, b := range result {
+		assert.Equal(t, "Q"+string(rune('1'+i)), b.Band)
+		assert.Equal(t, 2, b.SignalCount, "各四分位は2件")
+	}
+}
+
+func TestAggregateByScoreQuartile_Q1LowQ4High(t *testing.T) {
+	// Q1=低スコア、Q4=高スコア の順序確認
+	// score: 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8
+	// Q1=[0.1,0.2], Q4=[0.7,0.8]
+	signals := []*models.EvaluatedSignal{
+		signalWithScore(decPtr(0.8), 0.08), // 高スコア
+		signalWithScore(decPtr(0.1), 0.01), // 低スコア
+		signalWithScore(decPtr(0.5), 0.05),
+		signalWithScore(decPtr(0.2), 0.02),
+		signalWithScore(decPtr(0.6), 0.06),
+		signalWithScore(decPtr(0.3), 0.03),
+		signalWithScore(decPtr(0.7), 0.07),
+		signalWithScore(decPtr(0.4), 0.04),
+	}
+	result := AggregateByScoreQuartile(signals, []int{5})
+	require.Len(t, result, 4)
+	assert.Equal(t, "Q1", result[0].Band)
+	assert.Equal(t, "Q4", result[3].Band)
+
+	// Q1 の 2シグナルは score=0.1, 0.2 → returns = 0.01, 0.02 → avg 低い
+	// Q4 の 2シグナルは score=0.7, 0.8 → returns = 0.07, 0.08 → avg 高い
+	q1Avg := result[0].Stats[5].AvgReturn
+	q4Avg := result[3].Stats[5].AvgReturn
+	assert.True(t, q1Avg.LessThan(q4Avg), "Q1 avg < Q4 avg (Q4は高スコア)")
+}
+
+func TestAggregateByScoreQuartile_BandNames(t *testing.T) {
+	// n=4 で各四分位 1件ずつ、Band名確認
+	signals := []*models.EvaluatedSignal{
+		signalWithScore(decPtr(0.1), 0.1),
+		signalWithScore(decPtr(0.2), 0.2),
+		signalWithScore(decPtr(0.3), 0.3),
+		signalWithScore(decPtr(0.4), 0.4),
+	}
+	result := AggregateByScoreQuartile(signals, []int{5})
+	require.Len(t, result, 4)
+	assert.Equal(t, "Q1", result[0].Band)
+	assert.Equal(t, "Q2", result[1].Band)
+	assert.Equal(t, "Q3", result[2].Band)
+	assert.Equal(t, "Q4", result[3].Band)
+}

--- a/domain_service/signal_performance.go
+++ b/domain_service/signal_performance.go
@@ -140,3 +140,112 @@ func calcHorizonStats(returns []decimal.Decimal) *models.HorizonStats {
 		WorstReturn:    worst.Round(6),
 	}
 }
+
+// rankBandDefs はランク帯の定義（帯名、min/max でシグナルを仕分け）
+type rankBandDef struct {
+	band string
+	min  int
+	max  int // -1 = 上限なし
+}
+
+var rankBandDefs = []rankBandDef{
+	{"1-3", 1, 3},
+	{"4-10", 4, 10},
+	{"11+", 11, -1},
+}
+
+// AggregateByRankBand SignalRank 非nilのシグナルをランク帯別に集計する。
+// 帯の順序は固定（1-3 / 4-10 / 11+）。対象0件の帯も SignalCount=0 で返す。
+func AggregateByRankBand(signals []*models.EvaluatedSignal, horizons []int) []*models.BandSummary {
+	type bucket struct {
+		signals []*models.EvaluatedSignal
+	}
+	buckets := make([]bucket, len(rankBandDefs))
+
+	for _, sig := range signals {
+		if sig.SignalRank == nil {
+			continue
+		}
+		rank := *sig.SignalRank
+		for i, def := range rankBandDefs {
+			if rank >= def.min && (def.max == -1 || rank <= def.max) {
+				buckets[i].signals = append(buckets[i].signals, sig)
+				break
+			}
+		}
+	}
+
+	result := make([]*models.BandSummary, len(rankBandDefs))
+	for i, def := range rankBandDefs {
+		sigs := buckets[i].signals
+		stats := calcBandStats(sigs, horizons)
+		result[i] = &models.BandSummary{
+			Band:        def.band,
+			SignalCount: len(sigs),
+			Stats:       stats,
+		}
+	}
+	return result
+}
+
+// AggregateByScoreQuartile Score 非nilのシグナルをスコア四分位別に集計する。
+// score 昇順で四分位に分割（Q1=下位〜Q4=上位、境界は件数ベースの等分割）。
+// n<4 のときは空スライスを返す。
+func AggregateByScoreQuartile(signals []*models.EvaluatedSignal, horizons []int) []*models.BandSummary {
+	// Score 非nilのみ抽出
+	scored := make([]*models.EvaluatedSignal, 0, len(signals))
+	for _, sig := range signals {
+		if sig.Score != nil {
+			scored = append(scored, sig)
+		}
+	}
+
+	if len(scored) < 4 {
+		return []*models.BandSummary{}
+	}
+
+	// score 昇順ソート
+	sort.Slice(scored, func(i, j int) bool {
+		return scored[i].Score.LessThan(*scored[j].Score)
+	})
+
+	n := len(scored)
+	result := make([]*models.BandSummary, 4)
+	for q := 0; q < 4; q++ {
+		// 件数ベースの等分割: [q*n/4, (q+1)*n/4)
+		lo := q * n / 4
+		hi := (q + 1) * n / 4
+		if q == 3 {
+			hi = n // 最後の四分位は端数を全て含む
+		}
+		qSigs := scored[lo:hi]
+		stats := calcBandStats(qSigs, horizons)
+		result[q] = &models.BandSummary{
+			Band:        "Q" + string(rune('1'+q)),
+			SignalCount: len(qSigs),
+			Stats:       stats,
+		}
+	}
+	return result
+}
+
+// calcBandStats シグナル群から horizon 別統計を生成する（Returns nil = skip）
+func calcBandStats(signals []*models.EvaluatedSignal, horizons []int) map[int]*models.HorizonStats {
+	returns := make(map[int][]decimal.Decimal, len(horizons))
+	for _, sig := range signals {
+		if sig.Returns == nil {
+			continue
+		}
+		for _, h := range horizons {
+			if v := sig.Returns[h]; v != nil {
+				returns[h] = append(returns[h], *v)
+			}
+		}
+	}
+
+	stats := make(map[int]*models.HorizonStats, len(horizons))
+	for _, h := range horizons {
+		stats[h] = calcHorizonStats(returns[h])
+	}
+	return stats
+}

--- a/models/signal_performance.go
+++ b/models/signal_performance.go
@@ -47,11 +47,20 @@ type EvaluatedSignal struct {
 	Returns      map[int]*decimal.Decimal `json:"returns"` // key: 5/10/20, nil=未到来
 }
 
+// BandSummary rank帯・score四分位など、シグナルの帯別集計
+type BandSummary struct {
+	Band        string                `json:"band"`        // 例: "1-3", "4-10", "11+", "Q1".."Q4"
+	SignalCount int                   `json:"signalCount"` // 帯に属するシグナル数（skip含む）
+	Stats       map[int]*HorizonStats `json:"stats"`
+}
+
 // SignalPerformance API レスポンス全体
 type SignalPerformance struct {
-	From      time.Time                  `json:"from"`
-	To        time.Time                  `json:"to"`
-	Horizons  []int                      `json:"horizons"`
-	Summaries []*SignalPerformanceSummary `json:"summaries"`
-	Signals   []*EvaluatedSignal         `json:"signals"` // method 指定時のみ、非 nil
+	From           time.Time                  `json:"from"`
+	To             time.Time                  `json:"to"`
+	Horizons       []int                      `json:"horizons"`
+	Summaries      []*SignalPerformanceSummary `json:"summaries"`
+	Signals        []*EvaluatedSignal         `json:"signals"`        // method 指定時のみ、非 nil
+	RankBands      []*BandSummary             `json:"rankBands"`      // method 指定時のみ非nil
+	ScoreQuartiles []*BandSummary             `json:"scoreQuartiles"` // method 指定時のみ非nil
 }

--- a/usecase/signal_performance_interactor.go
+++ b/usecase/signal_performance_interactor.go
@@ -114,20 +114,27 @@ func (s *signalPerformanceInteractorImpl) GetSignalPerformance(ctx context.Conte
 
 	summaries := domain_service.AggregateSignalPerformance(evaluated, signalPerformanceHorizons)
 
-	// method 指定時のみ明細を返す
+	// method 指定時のみ明細と帯別集計を返す
 	var detail []*models.EvaluatedSignal
+	var rankBands []*models.BandSummary
+	var scoreQuartiles []*models.BandSummary
+
 	if filter.Method != "" {
 		detail = evaluated
+		rankBands = domain_service.AggregateByRankBand(evaluated, signalPerformanceHorizons)
+		scoreQuartiles = domain_service.AggregateByScoreQuartile(evaluated, signalPerformanceHorizons)
 	} else {
 		detail = []*models.EvaluatedSignal{}
 	}
 
 	return &models.SignalPerformance{
-		From:      filter.From,
-		To:        filter.To,
-		Horizons:  signalPerformanceHorizons,
-		Summaries: summaries,
-		Signals:   detail,
+		From:           filter.From,
+		To:             filter.To,
+		Horizons:       signalPerformanceHorizons,
+		Summaries:      summaries,
+		Signals:        detail,
+		RankBands:      rankBands,
+		ScoreQuartiles: scoreQuartiles,
 	}, nil
 }
 

--- a/usecase/signal_performance_interactor_test.go
+++ b/usecase/signal_performance_interactor_test.go
@@ -367,3 +367,173 @@ func TestFilterPricesFrom(t *testing.T) {
 		})
 	}
 }
+
+// --- rankBands / scoreQuartiles テスト ---
+
+func TestSignalPerformanceInteractor_BandAggregation(t *testing.T) {
+	from := spDate(2024, 1, 4)
+	to := spDate(2024, 3, 31)
+	signalDate := spDate(2024, 1, 10)
+	method1 := models.AnalyzeStockBrandPriceHistoryMethodFindMACDBullishV1
+
+	rank1 := 1
+	rank5 := 5
+	score1 := decimal.NewFromFloat(0.8)
+	score2 := decimal.NewFromFloat(0.3)
+
+	// SignalRank / Score 付きシグナルを返すヘルパー
+	spSignalWithBands := func(symbol string, rank *int, score *decimal.Decimal) *models.AnalyzeStockBrandPriceHistory {
+		sig := spSignal(symbol, method1, models.AnalyzeStockBrandPriceHistoryActionBuy, signalDate)
+		sig.SignalRank = rank
+		sig.Score = score
+		return sig
+	}
+
+	makePrices := func(symbol string) []*models.StockBrandDailyPrice {
+		prices := make([]*models.StockBrandDailyPrice, 30)
+		for i := 0; i < 30; i++ {
+			prices[i] = spPrice(symbol, signalDate.AddDate(0, 0, i), 1000+float64(i))
+		}
+		return prices
+	}
+
+	type fields struct {
+		analyzeRepo func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository
+		priceRepo   func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository
+	}
+
+	tests := []struct {
+		name   string
+		filter *models.SignalPerformanceFilter
+		fields fields
+		check  func(t *testing.T, got *models.SignalPerformance)
+	}{
+		{
+			name: "method 指定時は rankBands と scoreQuartiles が非nil",
+			filter: &models.SignalPerformanceFilter{
+				From:   from,
+				To:     to,
+				Method: method1,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return([]*models.AnalyzeStockBrandPriceHistory{
+						spSignalWithBands("7203", &rank1, &score1),
+						spSignalWithBands("6758", &rank5, &score2),
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).Return(
+						append(makePrices("7203"), makePrices("6758")...), nil,
+					)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				// method 指定時は rankBands が3帯固定で返る
+				assert.NotNil(t, got.RankBands)
+				assert.Len(t, got.RankBands, 3, "ランク帯は常に3帯")
+				assert.Equal(t, "1-3", got.RankBands[0].Band)
+				assert.Equal(t, "4-10", got.RankBands[1].Band)
+				assert.Equal(t, "11+", got.RankBands[2].Band)
+				// rank=1 は 1-3 帯, rank=5 は 4-10 帯
+				assert.Equal(t, 1, got.RankBands[0].SignalCount)
+				assert.Equal(t, 1, got.RankBands[1].SignalCount)
+				assert.Equal(t, 0, got.RankBands[2].SignalCount)
+
+				// score が2件のため n<4 → scoreQuartiles は空スライス
+				assert.NotNil(t, got.ScoreQuartiles)
+				assert.Empty(t, got.ScoreQuartiles, "n<4 のとき空スライス")
+			},
+		},
+		{
+			name: "method 未指定時は rankBands と scoreQuartiles が nil",
+			filter: &models.SignalPerformanceFilter{
+				From: from,
+				To:   to,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return([]*models.AnalyzeStockBrandPriceHistory{
+						spSignalWithBands("7203", &rank1, &score1),
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).Return(
+						makePrices("7203"), nil,
+					)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				// method 未指定時は rankBands/scoreQuartiles は nil
+				assert.Nil(t, got.RankBands)
+				assert.Nil(t, got.ScoreQuartiles)
+			},
+		},
+		{
+			name: "score 4件以上の場合 scoreQuartiles が4帯返る",
+			filter: &models.SignalPerformanceFilter{
+				From:   from,
+				To:     to,
+				Method: method1,
+			},
+			fields: fields{
+				analyzeRepo: func(ctrl *gomock.Controller) *mock_repositories.MockAnalyzeStockBrandPriceHistoryRepository {
+					m := mock_repositories.NewMockAnalyzeStockBrandPriceHistoryRepository(ctrl)
+					s1 := decimal.NewFromFloat(0.1)
+					s2 := decimal.NewFromFloat(0.3)
+					s3 := decimal.NewFromFloat(0.6)
+					s4 := decimal.NewFromFloat(0.9)
+					m.EXPECT().FindByCreatedAtRange(gomock.Any(), gomock.Any()).Return([]*models.AnalyzeStockBrandPriceHistory{
+						{ID: "1", TickerSymbol: "7203", Method: method1, Action: "Buy", CreatedAt: signalDate, Score: &s1},
+						{ID: "2", TickerSymbol: "6758", Method: method1, Action: "Buy", CreatedAt: signalDate, Score: &s2},
+						{ID: "3", TickerSymbol: "9984", Method: method1, Action: "Buy", CreatedAt: signalDate, Score: &s3},
+						{ID: "4", TickerSymbol: "3382", Method: method1, Action: "Buy", CreatedAt: signalDate, Score: &s4},
+					}, nil)
+					return m
+				},
+				priceRepo: func(ctrl *gomock.Controller) *mock_repositories.MockStockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					var prices []*models.StockBrandDailyPrice
+					for _, sym := range []string{"7203", "6758", "9984", "3382"} {
+						prices = append(prices, makePrices(sym)...)
+					}
+					m.EXPECT().ListRangePricesBySymbols(gomock.Any(), gomock.Any()).Return(prices, nil)
+					return m
+				},
+			},
+			check: func(t *testing.T, got *models.SignalPerformance) {
+				assert.NotNil(t, got.ScoreQuartiles)
+				assert.Len(t, got.ScoreQuartiles, 4, "n=4 のとき4帯返る")
+				assert.Equal(t, "Q1", got.ScoreQuartiles[0].Band)
+				assert.Equal(t, "Q2", got.ScoreQuartiles[1].Band)
+				assert.Equal(t, "Q3", got.ScoreQuartiles[2].Band)
+				assert.Equal(t, "Q4", got.ScoreQuartiles[3].Band)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			interactor := NewSignalPerformanceInteractor(
+				tt.fields.analyzeRepo(ctrl),
+				tt.fields.priceRepo(ctrl),
+			)
+			got, err := interactor.GetSignalPerformance(context.Background(), tt.filter)
+			assert.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

`GET /signal-performance?method=...` のレスポンスに `rankBands`（ランク帯別集計）と `scoreQuartiles`（スコア四分位別集計）を追加しました。

ランクが高い／スコアが高いシグナルほど当たるのかを検証できます。

## 変更内容

### models/signal_performance.go
- `BandSummary` 型を新規追加（`band`, `signalCount`, `stats`）
- `SignalPerformance` に `rankBands` / `scoreQuartiles` フィールドを追加（method指定時のみ非nil）

### domain_service/signal_performance.go
- `AggregateByRankBand(signals, horizons)` を追加：SignalRank非nilのみ対象、帯: 1-3 / 4-10 / 11+（固定）
- `AggregateByScoreQuartile(signals, horizons)` を追加：Score非nilのみ対象、score昇順でQ1〜Q4に等分割、n<4は空スライス
- 既存の `calcHorizonStats` を再利用する `calcBandStats` を内部関数として追加

### domain_service/signal_band_test.go（新規）
- ランク帯の境界テスト（rank=3/4, 10/11）
- nil除外、Returns nil(skip)の扱い
- score四分位のn<4→空、nil除外、Q1/Q4の大小関係

### usecase/signal_performance_interactor.go
- `filter.Method != ""` のとき帯別集計を実行してレスポンスに格納

### usecase/signal_performance_interactor_test.go
- method指定時にrankBands/scoreQuartilesが非nilになること
- method未指定時にnil
- score4件以上でscoreQuartilesが4帯返ること

## レスポンスの新フィールド（JSON例）

```json
{
  "rankBands": [
    {
      "band": "1-3",
      "signalCount": 12,
      "stats": {
        "5":  { "evaluatedCount": 10, "winCount": 7, "winRate": "0.7000", "avgReturn": "0.031200", ... },
        "10": { ... },
        "20": { ... }
      }
    },
    { "band": "4-10", "signalCount": 20, "stats": { ... } },
    { "band": "11+",  "signalCount": 8,  "stats": { ... } }
  ],
  "scoreQuartiles": [
    { "band": "Q1", "signalCount": 10, "stats": { ... } },
    { "band": "Q2", "signalCount": 10, "stats": { ... } },
    { "band": "Q3", "signalCount": 10, "stats": { ... } },
    { "band": "Q4", "signalCount": 10, "stats": { ... } }
  ]
}
```

**method未指定の場合**: `rankBands: null, scoreQuartiles: null`
**scoreが4件未満の場合**: `scoreQuartiles: []`（空配列）

## 帯仕様

| 帯 | 対象 rank | 備考 |
|---|---|---|
| 1-3 | 1, 2, 3 | 最上位 |
| 4-10 | 4〜10 | |
| 11+ | 11以上 | 上限なし |

- SignalRank=nilのシグナルは全帯から除外
- Returns=nil（P0未到来でskip）は SignalCount にカウントされるが `evaluatedCount` には含まれない
- 0件の帯も `signalCount: 0` で固定3帯として返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)