### PR TITLE
feat: クイズ回答直後に銘柄コード・名称を公開する

### DIFF
--- a/entrypoint/api/handler/quiz_handler.go
+++ b/entrypoint/api/handler/quiz_handler.go
@@ -99,7 +99,8 @@ func (h *QuizHandler) SubmitAnswer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.usecase.SubmitAnswer(r.Context(), quizDate, req.StockBrandID, prediction); err != nil {
+	reveal, err := h.usecase.SubmitAnswer(r.Context(), quizDate, req.StockBrandID, prediction)
+	if err != nil {
 		if errors.Is(err, usecase.ErrQuizQuestionNotFound) {
 			http.Error(w, "指定された設問が見つかりません", http.StatusNotFound)
 			return
@@ -112,7 +113,7 @@ func (h *QuizHandler) SubmitAnswer(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
+	respondJSONStatus(w, h.logger, http.StatusCreated, reveal)
 }
 
 func (h *QuizHandler) GetResults(w http.ResponseWriter, r *http.Request) {

--- a/entrypoint/api/handler/response.go
+++ b/entrypoint/api/handler/response.go
@@ -7,9 +7,15 @@ import (
 	"go.uber.org/zap"
 )
 
-// respondJSON JSON レスポンスを返却する共通メソッド
+// respondJSON JSON レスポンスを返却する共通メソッド（ステータスコードは200固定）
 func respondJSON(w http.ResponseWriter, logger *zap.Logger, data interface{}) {
+	respondJSONStatus(w, logger, http.StatusOK, data)
+}
+
+// respondJSONStatus 指定したステータスコードでJSONレスポンスを返却する共通メソッド
+func respondJSONStatus(w http.ResponseWriter, logger *zap.Logger, status int, data interface{}) {
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		logger.Error("failed to encode response", zap.Error(err))
 		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)

--- a/mock/usecase/quiz_interactor.go
+++ b/mock/usecase/quiz_interactor.go
@@ -103,11 +103,12 @@ func (mr *MockQuizInteractorMockRecorder) GetStats(ctx any) *gomock.Call {
 }
 
 // SubmitAnswer mocks base method.
-func (m *MockQuizInteractor) SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) error {
+func (m *MockQuizInteractor) SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) (*models.QuizAnswerReveal, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubmitAnswer", ctx, quizDate, stockBrandID, prediction)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*models.QuizAnswerReveal)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // SubmitAnswer indicates an expected call of SubmitAnswer.

--- a/models/quiz.go
+++ b/models/quiz.go
@@ -123,6 +123,12 @@ type QuizChart struct {
 	MA75     []*QuizChartMAPoint `json:"ma75"`
 }
 
+// QuizAnswerReveal 回答直後に公開する銘柄情報（POST /quiz/answers のレスポンス）。
+type QuizAnswerReveal struct {
+	TickerSymbol string `json:"tickerSymbol"`
+	Name         string `json:"name"`
+}
+
 // QuizResultItem 採点済み1件の結果（銘柄名を公開）。
 type QuizResultItem struct {
 	QuestionOrder  int              `json:"questionOrder"`

--- a/readme.md
+++ b/readme.md
@@ -586,13 +586,17 @@ curl "http://localhost:8080/quiz/chart?quiz_date=2026-07-03&stock_brand_id=..."
 
 翌営業日終値の予想を1件送信します。同一設問への重複回答は `409` を返します。
 
+出題中は銘柄名・コードとも非公開ですが、回答直後のレスポンスでのみその設問の銘柄コード・名称を公開します（出題中の常時表示はしません）。
+
 - **URL**: `/quiz/answers`
 - **Method**: `POST`
 - **Body**: `{"quizDate": "2026-07-03", "stockBrandId": "...", "prediction": "strong_up"}` （`prediction`: `strong_down`/`down`/`up`/`strong_up`）
+- **Response** (`201`): `{"tickerSymbol": "...", "name": "..."}`
 
 ```bash
 curl -X POST "http://localhost:8080/quiz/answers" \
   -d '{"quizDate":"2026-07-03","stockBrandId":"...","prediction":"up"}'
+# => {"tickerSymbol":"1234","name":"サンプル株式会社"}
 ```
 
 #### クイズ結果取得

--- a/usecase/quiz_interactor.go
+++ b/usecase/quiz_interactor.go
@@ -38,7 +38,8 @@ type QuizInteractor interface {
 	// GetChart 指定設問の匿名チャート（ローソク足+MA5/25/75+出来高）を返す。
 	GetChart(ctx context.Context, quizDate time.Time, stockBrandID string) (*models.QuizChart, error)
 	// SubmitAnswer 回答を1件登録する。既に回答済みの場合は repositories.ErrQuizAnswerAlreadyExists を返す。
-	SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) error
+	// 登録成功時は回答直後に公開する銘柄情報（コード・名称）を返す。
+	SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) (*models.QuizAnswerReveal, error)
 	// GetResults 指定日の採点結果を返す（銘柄名を公開）。
 	GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error)
 	// GetStats 累計統計（スコア・的中率・確信度別的中率・日次推移）を返す。
@@ -136,17 +137,26 @@ func (qi *quizInteractorImpl) GetChart(ctx context.Context, quizDate time.Time, 
 	return domain_service.BuildQuizChartSeries(prices, visibleFrom), nil
 }
 
-func (qi *quizInteractorImpl) SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) error {
+func (qi *quizInteractorImpl) SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) (*models.QuizAnswerReveal, error) {
 	if !prediction.Valid() {
-		return pkgerrors.New("invalid prediction")
+		return nil, pkgerrors.New("invalid prediction")
 	}
 
 	entry, err := qi.quizDailyUniverseRepository.FindByQuizDateAndStockBrandID(ctx, quizDate, stockBrandID)
 	if err != nil {
-		return pkgerrors.Wrap(err, "FindByQuizDateAndStockBrandID error")
+		return nil, pkgerrors.Wrap(err, "FindByQuizDateAndStockBrandID error")
 	}
 	if entry == nil {
-		return ErrQuizQuestionNotFound
+		return nil, ErrQuizQuestionNotFound
+	}
+
+	name := ""
+	brands, err := qi.stockBrandRepository.FindByIDs(ctx, []string{stockBrandID})
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "FindByIDs error")
+	}
+	if len(brands) > 0 {
+		name = brands[0].Name
 	}
 
 	answer := &models.QuizAnswer{
@@ -158,11 +168,15 @@ func (qi *quizInteractorImpl) SubmitAnswer(ctx context.Context, quizDate time.Ti
 	}
 	if err := qi.quizAnswerRepository.Create(ctx, answer); err != nil {
 		if errors.Is(err, repositories.ErrQuizAnswerAlreadyExists) {
-			return repositories.ErrQuizAnswerAlreadyExists
+			return nil, repositories.ErrQuizAnswerAlreadyExists
 		}
-		return pkgerrors.Wrap(err, "Create error")
+		return nil, pkgerrors.Wrap(err, "Create error")
 	}
-	return nil
+
+	return &models.QuizAnswerReveal{
+		TickerSymbol: entry.TickerSymbol,
+		Name:         name,
+	}, nil
 }
 
 func (qi *quizInteractorImpl) GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error) {

--- a/usecase/quiz_interactor_test.go
+++ b/usecase/quiz_interactor_test.go
@@ -28,7 +28,7 @@ func TestQuizInteractorImpl_SubmitAnswer(t *testing.T) {
 			mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
 			mock_repositories.NewMockStockBrandRepository(ctrl),
 		)
-		err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPrediction("invalid"))
+		_, err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPrediction("invalid"))
 		assert.Error(t, err)
 	})
 
@@ -45,7 +45,7 @@ func TestQuizInteractorImpl_SubmitAnswer(t *testing.T) {
 			mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
 			mock_repositories.NewMockStockBrandRepository(ctrl),
 		)
-		err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPredictionUp)
+		_, err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPredictionUp)
 		assert.ErrorIs(t, err, ErrQuizQuestionNotFound)
 	})
 
@@ -57,6 +57,10 @@ func TestQuizInteractorImpl_SubmitAnswer(t *testing.T) {
 		universeRepo.EXPECT().FindByQuizDateAndStockBrandID(gomock.Any(), quizDate, "brand-a").Return(
 			&models.QuizUniverseEntry{StockBrandID: "brand-a", TickerSymbol: "A001"}, nil)
 
+		stockBrandRepo := mock_repositories.NewMockStockBrandRepository(ctrl)
+		stockBrandRepo.EXPECT().FindByIDs(gomock.Any(), []string{"brand-a"}).Return(
+			[]*models.StockBrand{{ID: "brand-a", Name: "銘柄A"}}, nil)
+
 		answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
 		answerRepo.EXPECT().Create(gomock.Any(), gomock.Any()).Return(repositories.ErrQuizAnswerAlreadyExists)
 
@@ -64,9 +68,9 @@ func TestQuizInteractorImpl_SubmitAnswer(t *testing.T) {
 			universeRepo,
 			answerRepo,
 			mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
-			mock_repositories.NewMockStockBrandRepository(ctrl),
+			stockBrandRepo,
 		)
-		err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPredictionUp)
+		_, err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPredictionUp)
 		assert.True(t, errors.Is(err, repositories.ErrQuizAnswerAlreadyExists))
 	})
 
@@ -77,6 +81,10 @@ func TestQuizInteractorImpl_SubmitAnswer(t *testing.T) {
 		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
 		universeRepo.EXPECT().FindByQuizDateAndStockBrandID(gomock.Any(), quizDate, "brand-a").Return(
 			&models.QuizUniverseEntry{StockBrandID: "brand-a", TickerSymbol: "A001"}, nil)
+
+		stockBrandRepo := mock_repositories.NewMockStockBrandRepository(ctrl)
+		stockBrandRepo.EXPECT().FindByIDs(gomock.Any(), []string{"brand-a"}).Return(
+			[]*models.StockBrand{{ID: "brand-a", Name: "銘柄A"}}, nil)
 
 		answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
 		answerRepo.EXPECT().Create(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -90,10 +98,12 @@ func TestQuizInteractorImpl_SubmitAnswer(t *testing.T) {
 			universeRepo,
 			answerRepo,
 			mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
-			mock_repositories.NewMockStockBrandRepository(ctrl),
+			stockBrandRepo,
 		)
-		err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPredictionStrongUp)
+		reveal, err := interactor.SubmitAnswer(context.Background(), quizDate, "brand-a", models.QuizPredictionStrongUp)
 		assert.NoError(t, err)
+		assert.Equal(t, "A001", reveal.TickerSymbol)
+		assert.Equal(t, "銘柄A", reveal.Name)
 	})
 }
 


### PR DESCRIPTION
## 概要

株価クイズ機能で、現状は出題中・回答後とも銘柄名が非公開（翌日の結果画面でのみ公開）。本PRでは回答直後の `POST /quiz/answers` レスポンスでのみ、その設問の銘柄コード・名称を公開する。出題中の常時表示は行わずブラインド性を維持する。

## 変更内容

- `models/quiz.go`: `QuizAnswerReveal`（`tickerSymbol` / `name`）を追加
- `usecase/quiz_interactor.go`: `SubmitAnswer` の戻り値を `(*models.QuizAnswerReveal, error)` に変更。処理順は validate → universe entry 取得 → `stockBrandRepository.FindByIDs` で銘柄名解決 → answer Create → reveal 返却（Create前に名前解決することで、失敗時に回答が書き込まれないようにしている）
- `entrypoint/api/handler/quiz_handler.go`: `SubmitAnswer` が 201 + reveal をJSONで返すよう変更。共通の `respondJSONStatus`（ステータス指定可能な `respondJSON`）を `entrypoint/api/handler/response.go` に追加
- `usecase/quiz_interactor_test.go`: 既存回答済み・正常系ケースに `FindByIDs` のモック追加、正常系で reveal の `TickerSymbol`/`Name` をassert
- `readme.md`: `POST /quiz/answers` のレスポンス例を追記
- `mock/usecase/quiz_interactor.go`: `make mock` で再生成

## 検証

- `make lint` — 0 issues
- `make test-unit` — 全パス（`db-migrations` submoduleをworktreeで `git submodule update --init` してから実行）

## 補足

front側 (`stock-price-repository-front`) の対応PRは本PRのレスポンス形式に依存するため、マージ順は **spr → front** を想定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)