### PR TITLE
日足チャート取得API(GET /daily-prices/chart)を追加

### DIFF
--- a/domain_service/chart_series.go
+++ b/domain_service/chart_series.go
@@ -1,0 +1,59 @@
+package domain_service
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/Code0716/stock-price-repository/util"
+)
+
+// BuildDailyChartSeries 日足チャート表示用データを組み立てる。
+// prices は移動平均のウォームアップのため visibleFrom より十分前（目安75日以上）から渡すこと。
+// MA5/25/75 は prices 全体で計算し、visibleFrom 以降の点のみレスポンスに含める。
+// visibleFrom がゼロ値の場合は全点を含める。
+func BuildDailyChartSeries(prices []*models.StockBrandDailyPrice, visibleFrom time.Time) *models.DailyPriceChart {
+	closes := make([]decimal.Decimal, len(prices))
+	for i, p := range prices {
+		closes[i] = p.Close
+	}
+
+	ma5 := smaSeries(closes, 5)
+	ma25 := smaSeries(closes, 25)
+	ma75 := smaSeries(closes, 75)
+
+	chart := &models.DailyPriceChart{
+		Candles: make([]*models.ChartCandle, 0, len(prices)),
+		MA5:     make([]*models.ChartMAPoint, 0, len(prices)),
+		MA25:    make([]*models.ChartMAPoint, 0, len(prices)),
+		MA75:    make([]*models.ChartMAPoint, 0, len(prices)),
+	}
+
+	for i, p := range prices {
+		if p.Date.Before(visibleFrom) {
+			continue
+		}
+		dateStr := p.Date.Format(util.DateLayout)
+
+		chart.Candles = append(chart.Candles, &models.ChartCandle{
+			Date:   dateStr,
+			Open:   p.Open,
+			High:   p.High,
+			Low:    p.Low,
+			Close:  p.Close,
+			Volume: p.Volume,
+		})
+		if !ma5[i].IsZero() {
+			chart.MA5 = append(chart.MA5, &models.ChartMAPoint{Date: dateStr, Value: ma5[i]})
+		}
+		if !ma25[i].IsZero() {
+			chart.MA25 = append(chart.MA25, &models.ChartMAPoint{Date: dateStr, Value: ma25[i]})
+		}
+		if !ma75[i].IsZero() {
+			chart.MA75 = append(chart.MA75, &models.ChartMAPoint{Date: dateStr, Value: ma75[i]})
+		}
+	}
+
+	return chart
+}

--- a/domain_service/chart_series_test.go
+++ b/domain_service/chart_series_test.go
@@ -1,0 +1,96 @@
+package domain_service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Code0716/stock-price-repository/models"
+)
+
+// buildDailyPrices baseDate から days 日分の連続する日足データを生成する（Close は 100+i）。
+func buildDailyPrices(baseDate time.Time, days int) []*models.StockBrandDailyPrice {
+	prices := make([]*models.StockBrandDailyPrice, days)
+	for i := 0; i < days; i++ {
+		prices[i] = &models.StockBrandDailyPrice{
+			Date:   baseDate.AddDate(0, 0, i),
+			Open:   decimal.NewFromInt(int64(100 + i)),
+			High:   decimal.NewFromInt(int64(110 + i)),
+			Low:    decimal.NewFromInt(int64(90 + i)),
+			Close:  decimal.NewFromInt(int64(100 + i)),
+			Volume: 1000,
+		}
+	}
+	return prices
+}
+
+func TestBuildDailyChartSeries(t *testing.T) {
+	baseDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	type args struct {
+		prices      []*models.StockBrandDailyPrice
+		visibleFrom time.Time
+	}
+	tests := []struct {
+		name          string
+		args          args
+		wantCandles   int
+		wantMA5Count  int
+		wantMA25Count int
+		wantMA75Count int
+	}{
+		{
+			name: "正常系: visibleFromより前のデータは除外される",
+			args: args{
+				// 100日分のうち、後半10日だけを可視範囲とする
+				prices:      buildDailyPrices(baseDate, 100),
+				visibleFrom: baseDate.AddDate(0, 0, 90),
+			},
+			wantCandles:   10,
+			wantMA5Count:  10, // 可視範囲は十分に後方のためMA5もすべて非ゼロ
+			wantMA25Count: 10,
+			wantMA75Count: 10,
+		},
+		{
+			name: "正常系: visibleFromがゼロ値の場合は全点を含む",
+			args: args{
+				prices:      buildDailyPrices(baseDate, 5),
+				visibleFrom: time.Time{},
+			},
+			wantCandles:   5,
+			wantMA5Count:  1, // 5日目のみMA5が計算可能
+			wantMA25Count: 0,
+			wantMA75Count: 0,
+		},
+		{
+			name: "正常系: pricesが空の場合は空のチャートを返す",
+			args: args{
+				prices:      []*models.StockBrandDailyPrice{},
+				visibleFrom: time.Time{},
+			},
+			wantCandles:   0,
+			wantMA5Count:  0,
+			wantMA25Count: 0,
+			wantMA75Count: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildDailyChartSeries(tt.args.prices, tt.args.visibleFrom)
+
+			assert.Len(t, got.Candles, tt.wantCandles)
+			assert.Len(t, got.MA5, tt.wantMA5Count)
+			assert.Len(t, got.MA25, tt.wantMA25Count)
+			assert.Len(t, got.MA75, tt.wantMA75Count)
+
+			if tt.wantCandles > 0 {
+				firstVisible := tt.args.prices[len(tt.args.prices)-tt.wantCandles]
+				assert.Equal(t, firstVisible.Date.Format("2006-01-02"), got.Candles[0].Date)
+				assert.True(t, got.Candles[0].Close.Equal(firstVisible.Close))
+			}
+		})
+	}
+}

--- a/domain_service/quiz_chart.go
+++ b/domain_service/quiz_chart.go
@@ -3,8 +3,6 @@ package domain_service
 import (
 	"time"
 
-	"github.com/shopspring/decimal"
-
 	"github.com/Code0716/stock-price-repository/models"
 	"github.com/Code0716/stock-price-repository/util"
 )
@@ -13,45 +11,13 @@ import (
 // prices は移動平均のウォームアップのため visibleFrom より十分前（目安75日以上）から渡すこと。
 // MA5/25/75 は prices 全体で計算し、visibleFrom 以降の点のみレスポンスに含める。
 func BuildQuizChartSeries(prices []*models.StockBrandDailyPrice, visibleFrom time.Time) *models.QuizChart {
-	closes := make([]decimal.Decimal, len(prices))
-	for i, p := range prices {
-		closes[i] = p.Close
-	}
-
-	ma5 := smaSeries(closes, 5)
-	ma25 := smaSeries(closes, 25)
-	ma75 := smaSeries(closes, 75)
+	dailyChart := BuildDailyChartSeries(prices, visibleFrom)
 
 	chart := &models.QuizChart{
-		Candles: make([]*models.QuizChartCandle, 0, len(prices)),
-		MA5:     make([]*models.QuizChartMAPoint, 0, len(prices)),
-		MA25:    make([]*models.QuizChartMAPoint, 0, len(prices)),
-		MA75:    make([]*models.QuizChartMAPoint, 0, len(prices)),
-	}
-
-	for i, p := range prices {
-		if p.Date.Before(visibleFrom) {
-			continue
-		}
-		dateStr := p.Date.Format(util.DateLayout)
-
-		chart.Candles = append(chart.Candles, &models.QuizChartCandle{
-			Date:   dateStr,
-			Open:   p.Open,
-			High:   p.High,
-			Low:    p.Low,
-			Close:  p.Close,
-			Volume: p.Volume,
-		})
-		if !ma5[i].IsZero() {
-			chart.MA5 = append(chart.MA5, &models.QuizChartMAPoint{Date: dateStr, Value: ma5[i]})
-		}
-		if !ma25[i].IsZero() {
-			chart.MA25 = append(chart.MA25, &models.QuizChartMAPoint{Date: dateStr, Value: ma25[i]})
-		}
-		if !ma75[i].IsZero() {
-			chart.MA75 = append(chart.MA75, &models.QuizChartMAPoint{Date: dateStr, Value: ma75[i]})
-		}
+		Candles: dailyChart.Candles,
+		MA5:     dailyChart.MA5,
+		MA25:    dailyChart.MA25,
+		MA75:    dailyChart.MA75,
 	}
 
 	if len(prices) > 0 {

--- a/domain_service/quiz_chart_test.go
+++ b/domain_service/quiz_chart_test.go
@@ -1,0 +1,53 @@
+package domain_service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/Code0716/stock-price-repository/models"
+)
+
+func TestBuildQuizChartSeries(t *testing.T) {
+	baseDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	type args struct {
+		prices      []*models.StockBrandDailyPrice
+		visibleFrom time.Time
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantQuizDate string
+		wantCandles  int
+	}{
+		{
+			name: "正常系: QuizDateはpricesの最終日になる",
+			args: args{
+				prices:      buildDailyPrices(baseDate, 10),
+				visibleFrom: baseDate,
+			},
+			wantQuizDate: baseDate.AddDate(0, 0, 9).Format("2006-01-02"),
+			wantCandles:  10,
+		},
+		{
+			name: "正常系: pricesが空の場合はQuizDateが空文字になる",
+			args: args{
+				prices:      []*models.StockBrandDailyPrice{},
+				visibleFrom: time.Time{},
+			},
+			wantQuizDate: "",
+			wantCandles:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildQuizChartSeries(tt.args.prices, tt.args.visibleFrom)
+
+			assert.Equal(t, tt.wantQuizDate, got.QuizDate)
+			assert.Len(t, got.Candles, tt.wantCandles)
+		})
+	}
+}

--- a/entrypoint/api/handler/stock_price_handler.go
+++ b/entrypoint/api/handler/stock_price_handler.go
@@ -19,6 +19,13 @@ type getDailyPricesParams struct {
 	sortOrder *models.SortOrder
 }
 
+// getDailyPriceChartParams GetDailyPriceChartのリクエストパラメータ
+type getDailyPriceChartParams struct {
+	symbol string
+	from   *time.Time
+	to     *time.Time
+}
+
 type StockPriceHandler struct {
 	usecase    usecase.StockBrandsDailyPriceInteractor
 	httpServer driver.HTTPServer
@@ -99,4 +106,63 @@ func (h *StockPriceHandler) GetDailyPrices(w http.ResponseWriter, r *http.Reques
 	}
 
 	respondJSON(w, h.logger, prices)
+}
+
+// validateGetDailyPriceChartParams GetDailyPriceChartのリクエストパラメータをバリデーションする
+func (h *StockPriceHandler) validateGetDailyPriceChartParams(r *http.Request) (*getDailyPriceChartParams, error) {
+	params := &getDailyPriceChartParams{}
+
+	// symbol パラメータの取得とバリデーション
+	params.symbol = h.httpServer.GetQueryParam(r, "symbol")
+	if params.symbol == "" {
+		return nil, &validationError{message: "シンボルは必須です"}
+	}
+
+	if len(params.symbol) > 10 {
+		return nil, &validationError{message: "シンボルが長すぎます"}
+	}
+
+	if !alphanumericRequiredRegex.MatchString(params.symbol) {
+		return nil, &validationError{message: "シンボルは英数字である必要があります"}
+	}
+
+	// from パラメータの取得とバリデーション
+	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	if err != nil {
+		return nil, &validationError{message: "fromの日付形式が不正です"}
+	}
+	params.from = from
+
+	// to パラメータの取得とバリデーション
+	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
+	if err != nil {
+		return nil, &validationError{message: "toの日付形式が不正です"}
+	}
+	params.to = to
+
+	return params, nil
+}
+
+// GetDailyPriceChart 日足ローソク足+MA5/25/75のチャートデータを取得する
+func (h *StockPriceHandler) GetDailyPriceChart(w http.ResponseWriter, r *http.Request) {
+	// パラメータのバリデーション
+	params, err := h.validateGetDailyPriceChartParams(r)
+	if err != nil {
+		if verr, ok := err.(*validationError); ok {
+			http.Error(w, verr.message, http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+
+	// ユースケース呼び出し
+	chart, err := h.usecase.GetDailyStockPriceChart(r.Context(), params.symbol, params.from, params.to)
+	if err != nil {
+		h.logger.Error("failed to get daily stock price chart", zap.Error(err))
+		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		return
+	}
+
+	respondJSON(w, h.logger, chart)
 }

--- a/entrypoint/api/handler/stock_price_handler_test.go
+++ b/entrypoint/api/handler/stock_price_handler_test.go
@@ -293,3 +293,219 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 		})
 	}
 }
+
+func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
+	// テスト用の日付
+	dateStr := "2023-10-01"
+	date, _ := time.Parse(util.DateLayout, dateStr)
+
+	type fields struct {
+		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor
+		httpServer func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer
+	}
+	type args struct {
+		req *http.Request
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		args           args
+		wantStatusCode int
+		wantBody       interface{}
+	}{
+		{
+			name: "正常系: チャートデータを取得できる",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor {
+					m := mock_usecase.NewMockStockBrandsDailyPriceInteractor(ctrl)
+					m.EXPECT().
+						GetDailyStockPriceChart(gomock.Any(), "1234", &date, &date).
+						Return(&models.DailyPriceChart{
+							Candles: []*models.ChartCandle{
+								{
+									Date:   dateStr,
+									Open:   decimal.NewFromInt(100),
+									High:   decimal.NewFromInt(110),
+									Low:    decimal.NewFromInt(90),
+									Close:  decimal.NewFromInt(105),
+									Volume: 1000,
+								},
+							},
+							MA5:  []*models.ChartMAPoint{},
+							MA25: []*models.ChartMAPoint{},
+							MA75: []*models.ChartMAPoint{},
+						}, nil)
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=1234&from=2023-10-01&to=2023-10-01", nil),
+			},
+			wantStatusCode: http.StatusOK,
+			wantBody: &models.DailyPriceChart{
+				Candles: []*models.ChartCandle{
+					{
+						Date:   dateStr,
+						Open:   decimal.NewFromInt(100),
+						High:   decimal.NewFromInt(110),
+						Low:    decimal.NewFromInt(90),
+						Close:  decimal.NewFromInt(105),
+						Volume: 1000,
+					},
+				},
+				MA5:  []*models.ChartMAPoint{},
+				MA25: []*models.ChartMAPoint{},
+				MA75: []*models.ChartMAPoint{},
+			},
+		},
+		{
+			name: "異常系: symbolが指定されていない",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor {
+					return mock_usecase.NewMockStockBrandsDailyPriceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("")
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart", nil),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "シンボルは必須です\n",
+		},
+		{
+			name: "異常系: symbolが長すぎる",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor {
+					return mock_usecase.NewMockStockBrandsDailyPriceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("12345678901")
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=12345678901", nil),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "シンボルが長すぎます\n",
+		},
+		{
+			name: "異常系: symbolに不正な文字が含まれる",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor {
+					return mock_usecase.NewMockStockBrandsDailyPriceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234@")
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=1234@", nil),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "シンボルは英数字である必要があります\n",
+		},
+		{
+			name: "異常系: fromの日付フォーマットが不正",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor {
+					return mock_usecase.NewMockStockBrandsDailyPriceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, errors.New("invalid date"))
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=1234&from=invalid", nil),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "fromの日付形式が不正です\n",
+		},
+		{
+			name: "異常系: toの日付フォーマットが不正",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor {
+					return mock_usecase.NewMockStockBrandsDailyPriceInteractor(ctrl)
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, errors.New("invalid date"))
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=1234&from=2023-10-01&to=invalid", nil),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "toの日付形式が不正です\n",
+		},
+		{
+			name: "異常系: UseCaseがエラーを返す",
+			fields: fields{
+				usecase: func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor {
+					m := mock_usecase.NewMockStockBrandsDailyPriceInteractor(ctrl)
+					m.EXPECT().
+						GetDailyStockPriceChart(gomock.Any(), "1234", &date, &date).
+						Return(nil, errors.New("db error"))
+					return m
+				},
+				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
+					m := mock_driver.NewMockHTTPServer(ctrl)
+					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
+					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
+					return m
+				},
+			},
+			args: args{
+				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=1234&from=2023-10-01&to=2023-10-01", nil),
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			wantBody:       "内部サーバーエラー\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			u := tt.fields.usecase(ctrl)
+			h := tt.fields.httpServer(ctrl)
+
+			handler := NewStockPriceHandler(u, h, zap.NewNop())
+
+			w := httptest.NewRecorder()
+			handler.GetDailyPriceChart(w, tt.args.req)
+
+			assert.Equal(t, tt.wantStatusCode, w.Code)
+
+			if tt.wantStatusCode == http.StatusOK {
+				wantJSON, err := json.Marshal(tt.wantBody)
+				assert.NoError(t, err)
+				assert.JSONEq(t, string(wantJSON), w.Body.String())
+			} else {
+				assert.Equal(t, tt.wantBody, w.Body.String())
+			}
+		})
+	}
+}

--- a/entrypoint/api/router/router.go
+++ b/entrypoint/api/router/router.go
@@ -26,6 +26,7 @@ func NewRouter(
 	mux := http.NewServeMux()
 	if stockPriceHandler != nil {
 		mux.HandleFunc("/daily-prices", stockPriceHandler.GetDailyPrices)
+		mux.HandleFunc("/daily-prices/chart", stockPriceHandler.GetDailyPriceChart)
 	}
 	if returnAnalysisHandler != nil {
 		mux.HandleFunc("/return-analysis", returnAnalysisHandler.GetReturnAnalysis)

--- a/mock/usecase/stock_brands_daily_stock_price_interactor.go
+++ b/mock/usecase/stock_brands_daily_stock_price_interactor.go
@@ -85,6 +85,21 @@ func (mr *MockStockBrandsDailyPriceInteractorMockRecorder) CreateHistoricalDaily
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateHistoricalDailyStockPrices", reflect.TypeOf((*MockStockBrandsDailyPriceInteractor)(nil).CreateHistoricalDailyStockPrices), ctx, now)
 }
 
+// GetDailyStockPriceChart mocks base method.
+func (m *MockStockBrandsDailyPriceInteractor) GetDailyStockPriceChart(ctx context.Context, symbol string, from, to *time.Time) (*models.DailyPriceChart, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDailyStockPriceChart", ctx, symbol, from, to)
+	ret0, _ := ret[0].(*models.DailyPriceChart)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDailyStockPriceChart indicates an expected call of GetDailyStockPriceChart.
+func (mr *MockStockBrandsDailyPriceInteractorMockRecorder) GetDailyStockPriceChart(ctx, symbol, from, to any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDailyStockPriceChart", reflect.TypeOf((*MockStockBrandsDailyPriceInteractor)(nil).GetDailyStockPriceChart), ctx, symbol, from, to)
+}
+
 // GetDailyStockPrices mocks base method.
 func (m *MockStockBrandsDailyPriceInteractor) GetDailyStockPrices(ctx context.Context, symbol string, from, to *time.Time) ([]*models.StockBrandDailyPrice, error) {
 	m.ctrl.T.Helper()

--- a/models/chart.go
+++ b/models/chart.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"github.com/shopspring/decimal"
+)
+
+// ChartCandle チャート用の1本の日足。
+type ChartCandle struct {
+	Date   string          `json:"date"`
+	Open   decimal.Decimal `json:"open"`
+	High   decimal.Decimal `json:"high"`
+	Low    decimal.Decimal `json:"low"`
+	Close  decimal.Decimal `json:"close"`
+	Volume int64           `json:"volume"`
+}
+
+// ChartMAPoint 移動平均線の1点。
+type ChartMAPoint struct {
+	Date  string          `json:"date"`
+	Value decimal.Decimal `json:"value"`
+}
+
+// DailyPriceChart GET /daily-prices/chart のレスポンス。
+type DailyPriceChart struct {
+	Candles []*ChartCandle  `json:"candles"`
+	MA5     []*ChartMAPoint `json:"ma5"`
+	MA25    []*ChartMAPoint `json:"ma25"`
+	MA75    []*ChartMAPoint `json:"ma75"`
+}

--- a/models/quiz.go
+++ b/models/quiz.go
@@ -98,29 +98,13 @@ type QuizQuestionSet struct {
 	Questions     []*QuizQuestion `json:"questions"`
 }
 
-// QuizChartCandle チャート用の1本の日足。
-type QuizChartCandle struct {
-	Date   string          `json:"date"`
-	Open   decimal.Decimal `json:"open"`
-	High   decimal.Decimal `json:"high"`
-	Low    decimal.Decimal `json:"low"`
-	Close  decimal.Decimal `json:"close"`
-	Volume int64           `json:"volume"`
-}
-
-// QuizChartMAPoint 移動平均線の1点。
-type QuizChartMAPoint struct {
-	Date  string          `json:"date"`
-	Value decimal.Decimal `json:"value"`
-}
-
 // QuizChart GET /quiz/chart のレスポンス（銘柄名・コードは含まない）。
 type QuizChart struct {
-	QuizDate string              `json:"quizDate"`
-	Candles  []*QuizChartCandle  `json:"candles"`
-	MA5      []*QuizChartMAPoint `json:"ma5"`
-	MA25     []*QuizChartMAPoint `json:"ma25"`
-	MA75     []*QuizChartMAPoint `json:"ma75"`
+	QuizDate string          `json:"quizDate"`
+	Candles  []*ChartCandle  `json:"candles"`
+	MA5      []*ChartMAPoint `json:"ma5"`
+	MA25     []*ChartMAPoint `json:"ma25"`
+	MA75     []*ChartMAPoint `json:"ma75"`
 }
 
 // QuizAnswerReveal 回答直後に公開する銘柄情報（POST /quiz/answers のレスポンス）。

--- a/readme.md
+++ b/readme.md
@@ -326,6 +326,22 @@ curl "http://localhost:8080/stock-brands?symbol_from=9900&limit=100"
 curl "http://localhost:8080/daily-prices?symbol=1301&from=2023-01-01&to=2023-01-31"
 ```
 
+#### 日足チャート取得
+
+指定した銘柄の日足ローソク足と移動平均線（MA5/25/75）を取得します。`from` を指定した場合、MA75計算のウォームアップとして内部的に5ヶ月前から日足を取得し、`from`より前の点はレスポンスから除外されます。`from`未指定時は全期間を返します。
+
+- **URL**: `/daily-prices/chart`
+- **Method**: `GET`
+- **Query Parameters**:
+  - `symbol` (必須): 銘柄コード (例: `1301`)
+  - `from` (任意): 表示開始日 (YYYY-MM-DD)
+  - `to` (任意): 終了日 (YYYY-MM-DD)
+- **Response**: `{ "candles": [...], "ma5": [...], "ma25": [...], "ma75": [...] }`
+
+```bash
+curl "http://localhost:8080/daily-prices/chart?symbol=1301&from=2023-01-01&to=2023-01-31"
+```
+
 #### 決算発表予定一覧取得
 
 近日の決算発表予定を取得します。

--- a/usecase/get_daily_stock_price_chart.go
+++ b/usecase/get_daily_stock_price_chart.go
@@ -1,0 +1,40 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/Code0716/stock-price-repository/domain_service"
+	"github.com/Code0716/stock-price-repository/models"
+)
+
+// dailyChartWarmupMonths MA75のウォームアップに十分な過去データを取得する月数。
+// 75営業日 ≒ 約3.7ヶ月 + 休場バッファ。
+const dailyChartWarmupMonths = 5
+
+// GetDailyStockPriceChart 指定された銘柄コードと日付範囲に基づいて、日足ローソク足+MA5/25/75のチャートデータを取得します。
+func (u *stockBrandsDailyStockPriceInteractorImpl) GetDailyStockPriceChart(ctx context.Context, symbol string, from, to *time.Time) (*models.DailyPriceChart, error) {
+	var fetchFrom *time.Time
+	var visibleFrom time.Time
+	if from != nil {
+		warmupFrom := from.AddDate(0, -dailyChartWarmupMonths, 0)
+		fetchFrom = &warmupFrom
+		visibleFrom = *from
+	}
+
+	order := models.SortOrderAsc
+	filter := models.ListDailyPricesBySymbolFilter{
+		TickerSymbol: symbol,
+		DateFrom:     fetchFrom,
+		DateTo:       to,
+		DateOrder:    &order,
+	}
+	prices, err := u.stockBrandsDailyStockPriceRepository.ListDailyPricesBySymbol(ctx, filter)
+	if err != nil {
+		return nil, errors.Wrap(err, "ListDailyPricesBySymbol error")
+	}
+
+	return domain_service.BuildDailyChartSeries(prices, visibleFrom), nil
+}

--- a/usecase/get_daily_stock_price_chart_test.go
+++ b/usecase/get_daily_stock_price_chart_test.go
@@ -1,0 +1,152 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	mock_repositories "github.com/Code0716/stock-price-repository/mock/repositories"
+	"github.com/Code0716/stock-price-repository/models"
+	"github.com/Code0716/stock-price-repository/repositories"
+	"github.com/shopspring/decimal"
+)
+
+// buildDailyPricesForChartTest baseDate から days 日分の連続する日足データを生成する（Close は 100+i）。
+func buildDailyPricesForChartTest(baseDate time.Time, days int) []*models.StockBrandDailyPrice {
+	prices := make([]*models.StockBrandDailyPrice, days)
+	for i := 0; i < days; i++ {
+		prices[i] = &models.StockBrandDailyPrice{
+			Date:   baseDate.AddDate(0, 0, i),
+			Open:   decimal.NewFromInt(int64(100 + i)),
+			High:   decimal.NewFromInt(int64(110 + i)),
+			Low:    decimal.NewFromInt(int64(90 + i)),
+			Close:  decimal.NewFromInt(int64(100 + i)),
+			Volume: 1000,
+		}
+	}
+	return prices
+}
+
+func TestStockBrandsDailyStockPriceInteractorImpl_GetDailyStockPriceChart(t *testing.T) {
+	// from を指定した場合、リポジトリへの取得開始日は from の5ヶ月前になる
+	from := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 6, 10, 0, 0, 0, 0, time.UTC)
+	expectedFetchFrom := from.AddDate(0, -5, 0) // 2024-01-01
+
+	// expectedFetchFrom から to までの連続する日足（161日分）。可視範囲（from以降）は10日分。
+	daysFromFetchFromToTo := int(to.Sub(expectedFetchFrom).Hours()/24) + 1
+	prices := buildDailyPricesForChartTest(expectedFetchFrom, daysFromFetchFromToTo)
+	ascOrder := models.SortOrderAsc
+
+	type fields struct {
+		stockBrandsDailyStockPriceRepository func(ctrl *gomock.Controller) repositories.StockBrandsDailyPriceRepository
+	}
+	type args struct {
+		ctx    context.Context
+		symbol string
+		from   *time.Time
+		to     *time.Time
+	}
+
+	tests := []struct {
+		name        string
+		fields      fields
+		args        args
+		wantCandles int
+		wantErr     bool
+	}{
+		{
+			name: "正常系: fromを指定した場合、5ヶ月前からウォームアップ取得しvisibleFrom以前は除外される",
+			fields: fields{
+				stockBrandsDailyStockPriceRepository: func(ctrl *gomock.Controller) repositories.StockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListDailyPricesBySymbol(gomock.Any(), models.ListDailyPricesBySymbolFilter{
+						TickerSymbol: "1234",
+						DateFrom:     &expectedFetchFrom,
+						DateTo:       &to,
+						DateOrder:    &ascOrder,
+					}).Return(prices, nil)
+					return m
+				},
+			},
+			args: args{
+				ctx:    context.Background(),
+				symbol: "1234",
+				from:   &from,
+				to:     &to,
+			},
+			wantCandles: 10, // from(2024-06-01)からto(2024-06-10)までの10日分のみ可視
+			wantErr:     false,
+		},
+		{
+			name: "正常系: fromがnilの場合は全期間取得しすべての点を可視とする",
+			fields: fields{
+				stockBrandsDailyStockPriceRepository: func(ctrl *gomock.Controller) repositories.StockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListDailyPricesBySymbol(gomock.Any(), models.ListDailyPricesBySymbolFilter{
+						TickerSymbol: "1234",
+						DateFrom:     nil,
+						DateTo:       nil,
+						DateOrder:    &ascOrder,
+					}).Return(buildDailyPricesForChartTest(from, 5), nil)
+					return m
+				},
+			},
+			args: args{
+				ctx:    context.Background(),
+				symbol: "1234",
+				from:   nil,
+				to:     nil,
+			},
+			wantCandles: 5,
+			wantErr:     false,
+		},
+		{
+			name: "異常系: リポジトリがエラーを返す場合はエラーを伝播する",
+			fields: fields{
+				stockBrandsDailyStockPriceRepository: func(ctrl *gomock.Controller) repositories.StockBrandsDailyPriceRepository {
+					m := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					m.EXPECT().ListDailyPricesBySymbol(gomock.Any(), gomock.Any()).Return(nil, errors.New("db error"))
+					return m
+				},
+			},
+			args: args{
+				ctx:    context.Background(),
+				symbol: "1234",
+				from:   &from,
+				to:     &to,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			r := tt.fields.stockBrandsDailyStockPriceRepository(ctrl)
+			u := NewStockBrandsDailyPriceInteractor(nil, nil, r, nil, nil, nil, nil)
+
+			got, err := u.GetDailyStockPriceChart(tt.args.ctx, tt.args.symbol, tt.args.from, tt.args.to)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetDailyStockPriceChart() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				assert.Nil(t, got)
+				return
+			}
+
+			assert.Len(t, got.Candles, tt.wantCandles)
+			// MA75まで計算できるだけのウォームアップ期間があること
+			if tt.name == "正常系: fromを指定した場合、5ヶ月前からウォームアップ取得しvisibleFrom以前は除外される" {
+				assert.Len(t, got.MA75, tt.wantCandles)
+			}
+		})
+	}
+}

--- a/usecase/stock_brands_daily_stock_price_interactor.go
+++ b/usecase/stock_brands_daily_stock_price_interactor.go
@@ -32,6 +32,7 @@ type StockBrandsDailyPriceInteractor interface {
 	AdjustHistoricalDataForStockSplit(ctx context.Context, symbol string, splitRatio decimal.Decimal, effectiveDate time.Time, dryRun bool) error
 	GetDailyStockPrices(ctx context.Context, symbol string, from, to *time.Time) ([]*models.StockBrandDailyPrice, error)
 	GetDailyStockPricesWithOrder(ctx context.Context, symbol string, from, to *time.Time, order *models.SortOrder) ([]*models.StockBrandDailyPrice, error)
+	GetDailyStockPriceChart(ctx context.Context, symbol string, from, to *time.Time) (*models.DailyPriceChart, error)
 }
 
 func NewStockBrandsDailyPriceInteractor(


### PR DESCRIPTION
## 概要

- 新エンドポイント `GET /daily-prices/chart?symbol=&from=&to=` を追加。指定銘柄の日足ローソク足 + MA5/25/75 を返す
- レスポンス形は既存 `GET /quiz/chart` と同形（`quizDate` なし）: `{ "candles": [...], "ma5": [...], "ma25": [...], "ma75": [...] }`
- `models/quiz.go` の `QuizChartCandle` / `QuizChartMAPoint` を中立名 `ChartCandle` / `ChartMAPoint` にリネームして新規 `models/chart.go` へ移動（JSONタグは不変のためAPIレスポンス互換）
- `domain_service/quiz_chart.go` の `BuildQuizChartSeries` のコアロジックを汎用化し、新規 `domain_service/chart_series.go` の `BuildDailyChartSeries` に切り出し（`BuildQuizChartSeries` はこれを呼ぶ薄いラッパーに変更）
- `from` 指定時はMA75計算のウォームアップとして内部的に5ヶ月前から日足を取得し、`from`以降のみ可視範囲としてレスポンスする。`from`未指定時は全期間を返す

## 変更ファイル

- `models/chart.go`（新規）: `ChartCandle` / `ChartMAPoint` / `DailyPriceChart`
- `models/quiz.go`: `QuizChart` のフィールド型を中立名に差し替え
- `domain_service/chart_series.go`（新規）: `BuildDailyChartSeries`
- `domain_service/quiz_chart.go`: `BuildQuizChartSeries` をラッパー化
- `usecase/stock_brands_daily_stock_price_interactor.go`: インターフェースに `GetDailyStockPriceChart` を追加
- `usecase/get_daily_stock_price_chart.go`（新規）: usecase実装
- `entrypoint/api/handler/stock_price_handler.go`: `GetDailyPriceChart` ハンドラを追加
- `entrypoint/api/router/router.go`: `/daily-prices/chart` ルートを追加
- `mock/usecase/stock_brands_daily_stock_price_interactor.go`: `make mock` で再生成
- `readme.md`: API一覧に追記
- テスト: `domain_service/chart_series_test.go`, `domain_service/quiz_chart_test.go`, `usecase/get_daily_stock_price_chart_test.go`, `entrypoint/api/handler/stock_price_handler_test.go`

## レスポンス例

```json
{
  "candles": [
    { "date": "2023-10-01", "open": "100", "high": "110", "low": "90", "close": "105", "volume": 1000 }
  ],
  "ma5": [{ "date": "2023-10-01", "value": "102.5" }],
  "ma25": [],
  "ma75": []
}
```

## 検証

- `go build ./...` グリーン
- `make lint` グリーン（0 issues）
- `make test-unit` グリーン（全パッケージ ok）

## Test plan

- [x] `go build ./...`
- [x] `make lint`
- [x] `make test-unit`
- [ ] CI（`gh pr checks --watch`）通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)