### PR TITLE
fix: クイズの成績を回答日ベースに変更し出題を主要市場銘柄に限定

### DIFF
--- a/config/db.go
+++ b/config/db.go
@@ -14,7 +14,7 @@ type Database struct {
 	Port             string `envconfig:"stock_price_repository_mysql_port" default:""`
 	User             string `envconfig:"stock_price_repository_mysql_user" default:""`
 	Charset          string `envconfig:"stock_price_repository_mysql_charset" default:""`
-	Timezone         string `envconfig:"stock_price_repository_mysql_timezone" default:""`
+	Timezone         string `envconfig:"stock_price_repository_mysql_timezone" default:"Asia/Tokyo"`
 	RootUser         string `envconfig:"stock_price_repository_mysql_root_user" default:""`
 	RootPassword     string `envconfig:"stock_price_repository_mysql_root_password" default:""`
 	ExportBackupPath string `envconfig:"stock_price_repository_mysql_backup_path" default:""`

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -74,7 +74,7 @@ func InitializeCli(ctx context.Context) (*cli.Runner, func(), error) {
 	quizDailyUniverseRepository := database.NewQuizDailyUniverseRepositoryImpl(gormDB)
 	gradeQuizAnswersInteractor := usecase.NewGradeQuizAnswersInteractor(transaction, quizAnswerRepository, quizDailyUniverseRepository, stockBrandsDailyPriceRepository, appliedStockSplitsHistoryRepository, appliedStockConsolidationsHistoryRepository)
 	gradeQuizAnswersV1Command := commands.NewGradeQuizAnswersV1Command(gradeQuizAnswersInteractor)
-	createQuizDailyUniverseInteractor := usecase.NewCreateQuizDailyUniverseInteractor(stockBrandsDailyPriceRepository, quizDailyUniverseRepository)
+	createQuizDailyUniverseInteractor := usecase.NewCreateQuizDailyUniverseInteractor(stockBrandsDailyPriceRepository, quizDailyUniverseRepository, stockBrandRepository)
 	createQuizDailyUniverseV1Command := commands.NewCreateQuizDailyUniverseV1Command(createQuizDailyUniverseInteractor)
 	runner := cli.NewRunner(healthCheckCommand, updateStockBrandsV1Command, createHistoricalDailyStockPricesV1Command, createDailyStockPriceV1Command, createNikkeiAndDjiHistoricalDataV1Command, adjustHistoricalDataForStockSplitCommand, adjustHistoricalDataForStockConsolidationCommand, exportYearlyDataCommand, exportMasterDataCommand, syncFinAnnouncementsCommand, syncFinStatementsCommand, backtestAllStocksCommand, syncFinStatementsAllStocksCommand, gradeQuizAnswersV1Command, createQuizDailyUniverseV1Command, indexInteractor, slackAPIClient)
 	return runner, func() {

--- a/infrastructure/database/quiz_answer.go
+++ b/infrastructure/database/quiz_answer.go
@@ -65,6 +65,30 @@ func (qi *QuizAnswerRepositoryImpl) ListByQuizDate(ctx context.Context, quizDate
 	return answers, nil
 }
 
+func (qi *QuizAnswerRepositoryImpl) ListByAnsweredDate(ctx context.Context, date time.Time) ([]*models.QuizAnswer, error) {
+	tx, ok := GetTxQuery(ctx)
+	if !ok {
+		tx = qi.query
+	}
+
+	from := dateOnlyOf(date)
+	to := from.AddDate(0, 0, 1)
+
+	rows, err := tx.QuizAnswer.WithContext(ctx).
+		Where(tx.QuizAnswer.AnsweredAt.Gte(from)).
+		Where(tx.QuizAnswer.AnsweredAt.Lt(to)).
+		Find()
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "QuizAnswerRepositoryImpl.ListByAnsweredDate error")
+	}
+
+	answers := make([]*models.QuizAnswer, 0, len(rows))
+	for _, r := range rows {
+		answers = append(answers, qi.convertToDomainModel(r))
+	}
+	return answers, nil
+}
+
 func (qi *QuizAnswerRepositoryImpl) ListUngraded(ctx context.Context) ([]*models.QuizAnswer, error) {
 	tx, ok := GetTxQuery(ctx)
 	if !ok {
@@ -113,6 +137,26 @@ func (qi *QuizAnswerRepositoryImpl) ListAllGraded(ctx context.Context) ([]*model
 		Find()
 	if err != nil {
 		return nil, pkgerrors.Wrap(err, "QuizAnswerRepositoryImpl.ListAllGraded error")
+	}
+
+	answers := make([]*models.QuizAnswer, 0, len(rows))
+	for _, r := range rows {
+		answers = append(answers, qi.convertToDomainModel(r))
+	}
+	return answers, nil
+}
+
+func (qi *QuizAnswerRepositoryImpl) ListAll(ctx context.Context) ([]*models.QuizAnswer, error) {
+	tx, ok := GetTxQuery(ctx)
+	if !ok {
+		tx = qi.query
+	}
+
+	rows, err := tx.QuizAnswer.WithContext(ctx).
+		Order(tx.QuizAnswer.AnsweredAt).
+		Find()
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "QuizAnswerRepositoryImpl.ListAll error")
 	}
 
 	answers := make([]*models.QuizAnswer, 0, len(rows))

--- a/mock/repositories/quiz_answer.go
+++ b/mock/repositories/quiz_answer.go
@@ -56,6 +56,21 @@ func (mr *MockQuizAnswerRepositoryMockRecorder) Create(ctx, answer any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockQuizAnswerRepository)(nil).Create), ctx, answer)
 }
 
+// ListAll mocks base method.
+func (m *MockQuizAnswerRepository) ListAll(ctx context.Context) ([]*models.QuizAnswer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAll", ctx)
+	ret0, _ := ret[0].([]*models.QuizAnswer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAll indicates an expected call of ListAll.
+func (mr *MockQuizAnswerRepositoryMockRecorder) ListAll(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAll", reflect.TypeOf((*MockQuizAnswerRepository)(nil).ListAll), ctx)
+}
+
 // ListAllGraded mocks base method.
 func (m *MockQuizAnswerRepository) ListAllGraded(ctx context.Context) ([]*models.QuizAnswer, error) {
 	m.ctrl.T.Helper()
@@ -69,6 +84,21 @@ func (m *MockQuizAnswerRepository) ListAllGraded(ctx context.Context) ([]*models
 func (mr *MockQuizAnswerRepositoryMockRecorder) ListAllGraded(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllGraded", reflect.TypeOf((*MockQuizAnswerRepository)(nil).ListAllGraded), ctx)
+}
+
+// ListByAnsweredDate mocks base method.
+func (m *MockQuizAnswerRepository) ListByAnsweredDate(ctx context.Context, date time.Time) ([]*models.QuizAnswer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListByAnsweredDate", ctx, date)
+	ret0, _ := ret[0].([]*models.QuizAnswer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListByAnsweredDate indicates an expected call of ListByAnsweredDate.
+func (mr *MockQuizAnswerRepositoryMockRecorder) ListByAnsweredDate(ctx, date any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAnsweredDate", reflect.TypeOf((*MockQuizAnswerRepository)(nil).ListByAnsweredDate), ctx, date)
 }
 
 // ListByQuizDate mocks base method.

--- a/mock/usecase/quiz_interactor.go
+++ b/mock/usecase/quiz_interactor.go
@@ -73,18 +73,18 @@ func (mr *MockQuizInteractorMockRecorder) GetQuestions(ctx, date any) *gomock.Ca
 }
 
 // GetResults mocks base method.
-func (m *MockQuizInteractor) GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error) {
+func (m *MockQuizInteractor) GetResults(ctx context.Context, answeredDate time.Time) (*models.QuizResults, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResults", ctx, quizDate)
+	ret := m.ctrl.Call(m, "GetResults", ctx, answeredDate)
 	ret0, _ := ret[0].(*models.QuizResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetResults indicates an expected call of GetResults.
-func (mr *MockQuizInteractorMockRecorder) GetResults(ctx, quizDate any) *gomock.Call {
+func (mr *MockQuizInteractorMockRecorder) GetResults(ctx, answeredDate any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResults", reflect.TypeOf((*MockQuizInteractor)(nil).GetResults), ctx, quizDate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResults", reflect.TypeOf((*MockQuizInteractor)(nil).GetResults), ctx, answeredDate)
 }
 
 // GetStats mocks base method.

--- a/models/quiz.go
+++ b/models/quiz.go
@@ -137,6 +137,7 @@ type QuizResultsSummary struct {
 }
 
 // QuizResults GET /quiz/results のレスポンス。
+// QuizDate は互換のため JSON タグを維持しているが、中身は「回答日」（DATE(answered_at)、JST）。1回答日に複数の quiz_date（出題基準日）の設問が混在しうる。
 type QuizResults struct {
 	QuizDate string             `json:"quizDate"`
 	Graded   bool               `json:"graded"`
@@ -152,11 +153,14 @@ type QuizConfidenceStats struct {
 }
 
 // QuizDailyScore 日別スコア推移の1点。
+// QuizDate は互換のため JSON タグを維持しているが、中身は「回答日」（DATE(answered_at)、JST）であり quiz_date（採点基準日）ではない。
 type QuizDailyScore struct {
 	QuizDate string `json:"quizDate"`
 	Answered int    `json:"answered"`
 	Correct  int    `json:"correct"`
 	Score    int    `json:"score"`
+	// Pending 当該回答日のうち未採点（Outcome未確定）の件数。Answered/Score/Correctの分母には含まない。
+	Pending int `json:"pending"`
 }
 
 // QuizStats GET /quiz/stats のレスポンス。

--- a/repositories/quiz_answer.go
+++ b/repositories/quiz_answer.go
@@ -18,10 +18,14 @@ type QuizAnswerRepository interface {
 	Create(ctx context.Context, answer *models.QuizAnswer) error
 	// ListByQuizDate 指定日の回答一覧を取得する。
 	ListByQuizDate(ctx context.Context, quizDate time.Time) ([]*models.QuizAnswer, error)
+	// ListByAnsweredDate 指定した回答日（answered_at の日付、JST）の回答一覧を取得する。
+	ListByAnsweredDate(ctx context.Context, date time.Time) ([]*models.QuizAnswer, error)
 	// ListUngraded 未採点（outcome IS NULL）の回答を全て取得する。
 	ListUngraded(ctx context.Context) ([]*models.QuizAnswer, error)
 	// UpdateGrading 採点結果（NextClosePrice/ActualReturn/Outcome/Score/GradedAt）を一括反映する。
 	UpdateGrading(ctx context.Context, answers []*models.QuizAnswer) error
 	// ListAllGraded 統計算出用に採点済みの回答を全て取得する。
 	ListAllGraded(ctx context.Context) ([]*models.QuizAnswer, error)
+	// ListAll 統計算出用に未採点分を含む全ての回答を answered_at 昇順で取得する。
+	ListAll(ctx context.Context) ([]*models.QuizAnswer, error)
 }

--- a/usecase/create_quiz_daily_universe.go
+++ b/usecase/create_quiz_daily_universe.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Code0716/stock-price-repository/domain_service"
+	"github.com/Code0716/stock-price-repository/models"
 	"github.com/Code0716/stock-price-repository/repositories"
 )
 
@@ -17,10 +18,11 @@ const quizUniverseWindowDays = 20
 type createQuizDailyUniverseInteractorImpl struct {
 	stockBrandsDailyStockPriceRepository repositories.StockBrandsDailyPriceRepository
 	quizDailyUniverseRepository          repositories.QuizDailyUniverseRepository
+	stockBrandRepository                 repositories.StockBrandRepository
 }
 
 type CreateQuizDailyUniverseInteractor interface {
-	// CreateQuizDailyUniverse 直近営業日を基準に出来高がありよく動く300銘柄を選定し、当日分の出題ユニバースを作成する。
+	// CreateQuizDailyUniverse 直近営業日を基準に出来高がありよく動く300銘柄（プライム/スタンダード/グロースの主要市場銘柄のみ）を選定し、当日分の出題ユニバースを作成する。
 	// 既に作成済み・データ不足の場合は何もせず正常終了する（冪等）。
 	CreateQuizDailyUniverse(ctx context.Context, now time.Time) error
 }
@@ -28,10 +30,12 @@ type CreateQuizDailyUniverseInteractor interface {
 func NewCreateQuizDailyUniverseInteractor(
 	stockBrandsDailyStockPriceRepository repositories.StockBrandsDailyPriceRepository,
 	quizDailyUniverseRepository repositories.QuizDailyUniverseRepository,
+	stockBrandRepository repositories.StockBrandRepository,
 ) CreateQuizDailyUniverseInteractor {
 	return &createQuizDailyUniverseInteractorImpl{
 		stockBrandsDailyStockPriceRepository: stockBrandsDailyStockPriceRepository,
 		quizDailyUniverseRepository:          quizDailyUniverseRepository,
+		stockBrandRepository:                 stockBrandRepository,
 	}
 }
 
@@ -61,6 +65,16 @@ func (ci *createQuizDailyUniverseInteractorImpl) CreateQuizDailyUniverse(ctx con
 		return errors.Wrap(err, "ListPricesByDateRange error")
 	}
 
+	mainMarketBrands, err := ci.stockBrandRepository.FindAllMainMarkets(ctx)
+	if err != nil {
+		return errors.Wrap(err, "FindAllMainMarkets error")
+	}
+	mainMarketIDs := make(map[string]struct{}, len(mainMarketBrands))
+	for _, b := range mainMarketBrands {
+		mainMarketIDs[b.ID] = struct{}{}
+	}
+	prices = filterPricesByStockBrandIDs(prices, mainMarketIDs)
+
 	entries := domain_service.SelectQuizUniverse(prices, domain_service.QuizUniverseValueTopN, domain_service.QuizUniverseRangeTopN)
 	if len(entries) == 0 {
 		return nil
@@ -70,4 +84,15 @@ func (ci *createQuizDailyUniverseInteractorImpl) CreateQuizDailyUniverse(ctx con
 		return errors.Wrap(err, "BulkCreate error")
 	}
 	return nil
+}
+
+// filterPricesByStockBrandIDs 許可された StockBrandID のみを残す（主要市場以外＝ETF等の除外用）。
+func filterPricesByStockBrandIDs(prices []*models.StockBrandDailyPrice, allowed map[string]struct{}) []*models.StockBrandDailyPrice {
+	filtered := make([]*models.StockBrandDailyPrice, 0, len(prices))
+	for _, p := range prices {
+		if _, ok := allowed[p.StockBrandID]; ok {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
 }

--- a/usecase/create_quiz_daily_universe_test.go
+++ b/usecase/create_quiz_daily_universe_test.go
@@ -18,8 +18,9 @@ func TestCreateQuizDailyUniverseInteractorImpl_CreateQuizDailyUniverse(t *testin
 	now := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
 
 	type fields struct {
-		priceRepo    func(ctrl *gomock.Controller) repositories.StockBrandsDailyPriceRepository
-		universeRepo func(ctrl *gomock.Controller) repositories.QuizDailyUniverseRepository
+		priceRepo      func(ctrl *gomock.Controller) repositories.StockBrandsDailyPriceRepository
+		universeRepo   func(ctrl *gomock.Controller) repositories.QuizDailyUniverseRepository
+		stockBrandRepo func(ctrl *gomock.Controller) repositories.StockBrandRepository
 	}
 	tests := []struct {
 		name   string
@@ -37,6 +38,10 @@ func TestCreateQuizDailyUniverseInteractorImpl_CreateQuizDailyUniverse(t *testin
 				universeRepo: func(ctrl *gomock.Controller) repositories.QuizDailyUniverseRepository {
 					// ExistsByQuizDate/BulkCreate は呼ばれない
 					return mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+				},
+				stockBrandRepo: func(ctrl *gomock.Controller) repositories.StockBrandRepository {
+					// FindAllMainMarkets は呼ばれない
+					return mock_repositories.NewMockStockBrandRepository(ctrl)
 				},
 			},
 		},
@@ -56,6 +61,10 @@ func TestCreateQuizDailyUniverseInteractorImpl_CreateQuizDailyUniverse(t *testin
 					mock := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
 					mock.EXPECT().ExistsByQuizDate(gomock.Any(), now).Return(true, nil)
 					return mock
+				},
+				stockBrandRepo: func(ctrl *gomock.Controller) repositories.StockBrandRepository {
+					// FindAllMainMarkets は呼ばれない
+					return mock_repositories.NewMockStockBrandRepository(ctrl)
 				},
 			},
 		},
@@ -93,6 +102,67 @@ func TestCreateQuizDailyUniverseInteractorImpl_CreateQuizDailyUniverse(t *testin
 						})
 					return mock
 				},
+				stockBrandRepo: func(ctrl *gomock.Controller) repositories.StockBrandRepository {
+					mock := mock_repositories.NewMockStockBrandRepository(ctrl)
+					mock.EXPECT().FindAllMainMarkets(gomock.Any()).Return([]*models.StockBrand{
+						{ID: "brand-a"},
+					}, nil)
+					return mock
+				},
+			},
+		},
+		{
+			name: "主要市場外（ETF等）の銘柄は選定候補から除外される",
+			fields: fields{
+				priceRepo: func(ctrl *gomock.Controller) repositories.StockBrandsDailyPriceRepository {
+					mock := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+					dates := make([]time.Time, quizUniverseWindowDays)
+					for i := range dates {
+						dates[i] = now.AddDate(0, 0, -i)
+					}
+					mock.EXPECT().ListRecentTradingDates(gomock.Any(), now, quizUniverseWindowDays).Return(dates, nil)
+					mock.EXPECT().ListPricesByDateRange(gomock.Any(), dates[len(dates)-1], now).Return([]*models.StockBrandDailyPrice{
+						{
+							StockBrandID: "brand-a",
+							TickerSymbol: "A001",
+							Date:         now,
+							Close:        decimal.NewFromInt(100),
+							High:         decimal.NewFromInt(105),
+							Low:          decimal.NewFromInt(95),
+							Volume:       1000,
+						},
+						{
+							// ETF等（主要市場外）はFindAllMainMarketsに含まれないため除外される想定。
+							StockBrandID: "brand-etf",
+							TickerSymbol: "E001",
+							Date:         now,
+							Close:        decimal.NewFromInt(100),
+							High:         decimal.NewFromInt(200),
+							Low:          decimal.NewFromInt(50),
+							Volume:       1000,
+						},
+					}, nil)
+					return mock
+				},
+				universeRepo: func(ctrl *gomock.Controller) repositories.QuizDailyUniverseRepository {
+					mock := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+					mock.EXPECT().ExistsByQuizDate(gomock.Any(), now).Return(false, nil)
+					mock.EXPECT().BulkCreate(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(ctx context.Context, entries []*models.QuizUniverseEntry) error {
+							assert.Len(t, entries, 1)
+							assert.Equal(t, "brand-a", entries[0].StockBrandID)
+							return nil
+						})
+					return mock
+				},
+				stockBrandRepo: func(ctrl *gomock.Controller) repositories.StockBrandRepository {
+					mock := mock_repositories.NewMockStockBrandRepository(ctrl)
+					// brand-etf は主要市場銘柄として返さない。
+					mock.EXPECT().FindAllMainMarkets(gomock.Any()).Return([]*models.StockBrand{
+						{ID: "brand-a"},
+					}, nil)
+					return mock
+				},
 			},
 		},
 	}
@@ -102,7 +172,7 @@ func TestCreateQuizDailyUniverseInteractorImpl_CreateQuizDailyUniverse(t *testin
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			interactor := NewCreateQuizDailyUniverseInteractor(tt.fields.priceRepo(ctrl), tt.fields.universeRepo(ctrl))
+			interactor := NewCreateQuizDailyUniverseInteractor(tt.fields.priceRepo(ctrl), tt.fields.universeRepo(ctrl), tt.fields.stockBrandRepo(ctrl))
 			err := interactor.CreateQuizDailyUniverse(context.Background(), now)
 			assert.NoError(t, err)
 		})

--- a/usecase/quiz_interactor.go
+++ b/usecase/quiz_interactor.go
@@ -40,8 +40,9 @@ type QuizInteractor interface {
 	// SubmitAnswer 回答を1件登録する。既に回答済みの場合は repositories.ErrQuizAnswerAlreadyExists を返す。
 	// 登録成功時は回答直後に公開する銘柄情報（コード・名称）を返す。
 	SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) (*models.QuizAnswerReveal, error)
-	// GetResults 指定日の採点結果を返す（銘柄名を公開）。
-	GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error)
+	// GetResults 指定した回答日（answered_at の日付、JST）の採点結果を返す（銘柄名を公開）。
+	// 1回答日には複数の quiz_date（出題基準日）の設問が混在しうる。
+	GetResults(ctx context.Context, answeredDate time.Time) (*models.QuizResults, error)
 	// GetStats 累計統計（スコア・的中率・確信度別的中率・日次推移）を返す。
 	GetStats(ctx context.Context) (*models.QuizStats, error)
 }
@@ -179,25 +180,42 @@ func (qi *quizInteractorImpl) SubmitAnswer(ctx context.Context, quizDate time.Ti
 	}, nil
 }
 
-func (qi *quizInteractorImpl) GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error) {
-	universe, err := qi.quizDailyUniverseRepository.ListByQuizDate(ctx, quizDate)
+func (qi *quizInteractorImpl) GetResults(ctx context.Context, answeredDate time.Time) (*models.QuizResults, error) {
+	answers, err := qi.quizAnswerRepository.ListByAnsweredDate(ctx, answeredDate)
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "ListByQuizDate error")
-	}
-	answers, err := qi.quizAnswerRepository.ListByQuizDate(ctx, quizDate)
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "ListByQuizDate(answers) error")
+		return nil, pkgerrors.Wrap(err, "ListByAnsweredDate error")
 	}
 
-	orderByBrand := make(map[string]int, len(universe))
-	baseCloseByBrand := make(map[string]decimal.Decimal, len(universe))
-	for _, u := range universe {
-		orderByBrand[u.StockBrandID] = u.QuestionOrder
-		baseCloseByBrand[u.StockBrandID] = u.BaseClosePrice
+	// 回答日には複数の quiz_date（出題基準日）が混在しうるため、distinct な quiz_date ごとに
+	// universe（question_order/base_close_price）を引いてマージする。
+	quizDateSeen := make(map[string]struct{}, len(answers))
+	orderByKey := make(map[string]int)
+	baseCloseByKey := make(map[string]decimal.Decimal)
+	for _, a := range answers {
+		quizDateKey := a.QuizDate.Format(util.DateLayout)
+		if _, ok := quizDateSeen[quizDateKey]; ok {
+			continue
+		}
+		quizDateSeen[quizDateKey] = struct{}{}
+
+		universe, err := qi.quizDailyUniverseRepository.ListByQuizDate(ctx, a.QuizDate)
+		if err != nil {
+			return nil, pkgerrors.Wrap(err, "ListByQuizDate error")
+		}
+		for _, u := range universe {
+			key := quizResultKey(u.QuizDate, u.StockBrandID)
+			orderByKey[key] = u.QuestionOrder
+			baseCloseByKey[key] = u.BaseClosePrice
+		}
 	}
 
 	sort.Slice(answers, func(i, j int) bool {
-		return orderByBrand[answers[i].StockBrandID] < orderByBrand[answers[j].StockBrandID]
+		oi := orderByKey[quizResultKey(answers[i].QuizDate, answers[i].StockBrandID)]
+		oj := orderByKey[quizResultKey(answers[j].QuizDate, answers[j].StockBrandID)]
+		if oi != oj {
+			return oi < oj
+		}
+		return answers[i].QuizDate.Before(answers[j].QuizDate)
 	})
 
 	brandIDs := make([]string, 0, len(answers))
@@ -221,16 +239,23 @@ func (qi *quizInteractorImpl) GetResults(ctx context.Context, quizDate time.Time
 		if !a.Graded() {
 			graded = false
 		}
-		items = append(items, buildQuizResultItem(a, orderByBrand[a.StockBrandID], nameByBrand[a.StockBrandID], baseCloseByBrand[a.StockBrandID]))
+		key := quizResultKey(a.QuizDate, a.StockBrandID)
+		items = append(items, buildQuizResultItem(a, orderByKey[key], nameByBrand[a.StockBrandID], baseCloseByKey[key]))
 		tallyQuizResultSummary(&summary, a)
 	}
 
 	return &models.QuizResults{
-		QuizDate: quizDate.Format(util.DateLayout),
+		QuizDate: answeredDate.Format(util.DateLayout),
 		Graded:   graded,
 		Summary:  summary,
 		Items:    items,
 	}, nil
+}
+
+// quizResultKey quiz_date と stock_brand_id の複合キー。同一銘柄が複数の quiz_date の
+// universe に登場しうるため、question_order/base_close_price の引き当てをこのキーで行う。
+func quizResultKey(quizDate time.Time, stockBrandID string) string {
+	return quizDate.Format(util.DateLayout) + "|" + stockBrandID
 }
 
 func buildQuizResultItem(a *models.QuizAnswer, questionOrder int, name string, baseClosePrice decimal.Decimal) *models.QuizResultItem {
@@ -268,9 +293,9 @@ func tallyQuizResultSummary(summary *models.QuizResultsSummary, a *models.QuizAn
 }
 
 func (qi *quizInteractorImpl) GetStats(ctx context.Context) (*models.QuizStats, error) {
-	graded, err := qi.quizAnswerRepository.ListAllGraded(ctx)
+	all, err := qi.quizAnswerRepository.ListAll(ctx)
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "ListAllGraded error")
+		return nil, pkgerrors.Wrap(err, "ListAll error")
 	}
 
 	stats := &models.QuizStats{}
@@ -279,18 +304,14 @@ func (qi *quizInteractorImpl) GetStats(ctx context.Context) (*models.QuizStats, 
 	strongAcc := &confidenceAccumulator{}
 
 	type dailyAccumulator struct {
-		answered, correct, score int
+		answered, correct, score, pending int
 	}
 	dailyByDate := make(map[string]*dailyAccumulator)
 	var dailyOrder []string
 
-	for _, a := range graded {
-		if a.Score != nil {
-			stats.TotalScore += *a.Score
-		}
-		stats.TotalAnswered++
-
-		dateStr := a.QuizDate.Format(util.DateLayout)
+	for _, a := range all {
+		// 日次集計キーは回答日（DATE(answered_at)、JST）。quiz_date（出題基準日）ではない。
+		dateStr := a.AnsweredAt.Format(util.DateLayout)
 		acc, ok := dailyByDate[dateStr]
 		if !ok {
 			acc = &dailyAccumulator{}
@@ -298,13 +319,17 @@ func (qi *quizInteractorImpl) GetStats(ctx context.Context) (*models.QuizStats, 
 			dailyOrder = append(dailyOrder, dateStr)
 		}
 		acc.answered++
+		stats.TotalAnswered++
 		if a.Score != nil {
+			stats.TotalScore += *a.Score
 			acc.score += *a.Score
 		}
 
-		if a.Outcome == nil {
+		if !a.Graded() {
+			acc.pending++
 			continue
 		}
+
 		switch *a.Outcome {
 		case models.QuizOutcomeCorrect:
 			stats.TotalCorrect++
@@ -339,6 +364,7 @@ func (qi *quizInteractorImpl) GetStats(ctx context.Context) (*models.QuizStats, 
 			Answered: acc.answered,
 			Correct:  acc.correct,
 			Score:    acc.score,
+			Pending:  acc.pending,
 		})
 	}
 

--- a/usecase/quiz_interactor_test.go
+++ b/usecase/quiz_interactor_test.go
@@ -142,6 +142,7 @@ func TestQuizInteractorImpl_GetQuestions(t *testing.T) {
 }
 
 func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
+	answeredDate := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
 	quizDate := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
 
 	ctrl := gomock.NewController(t)
@@ -149,15 +150,15 @@ func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
 
 	universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
 	universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizUniverseEntry{
-		{StockBrandID: "brand-a", QuestionOrder: 1, BaseClosePrice: decimal.NewFromInt(100)},
-		{StockBrandID: "brand-b", QuestionOrder: 2, BaseClosePrice: decimal.NewFromInt(200)},
+		{QuizDate: quizDate, StockBrandID: "brand-a", QuestionOrder: 1, BaseClosePrice: decimal.NewFromInt(100)},
+		{QuizDate: quizDate, StockBrandID: "brand-b", QuestionOrder: 2, BaseClosePrice: decimal.NewFromInt(200)},
 	}, nil)
 
 	// リポジトリからは question_order と無関係な順で返ってくる想定
 	answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
-	answerRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizAnswer{
-		{StockBrandID: "brand-b", TickerSymbol: "B001", Prediction: models.QuizPredictionUp},
-		{StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionDown},
+	answerRepo.EXPECT().ListByAnsweredDate(gomock.Any(), answeredDate).Return([]*models.QuizAnswer{
+		{QuizDate: quizDate, StockBrandID: "brand-b", TickerSymbol: "B001", Prediction: models.QuizPredictionUp},
+		{QuizDate: quizDate, StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionDown},
 	}, nil)
 
 	stockBrandRepo := mock_repositories.NewMockStockBrandRepository(ctrl)
@@ -173,8 +174,9 @@ func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
 		stockBrandRepo,
 	)
 
-	got, err := interactor.GetResults(context.Background(), quizDate)
+	got, err := interactor.GetResults(context.Background(), answeredDate)
 	assert.NoError(t, err)
+	assert.Equal(t, "2026-07-03", got.QuizDate)
 	assert.Len(t, got.Items, 2)
 	assert.Equal(t, 1, got.Items[0].QuestionOrder)
 	assert.Equal(t, "A001", got.Items[0].TickerSymbol)
@@ -182,9 +184,59 @@ func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
 	assert.Equal(t, "B001", got.Items[1].TickerSymbol)
 }
 
+func TestQuizInteractorImpl_GetResults_MergesMultipleQuizDates(t *testing.T) {
+	// 1回答日（07/04）に複数の quiz_date（07/02出題分・07/03出題分）の回答が混在するケース。
+	answeredDate := time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
+	quizDate1 := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	quizDate2 := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+	// 同一銘柄(brand-a)が異なるquiz_dateのユニバースに別のquestion_order/base_close_priceで登場する。
+	universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate1).Return([]*models.QuizUniverseEntry{
+		{QuizDate: quizDate1, StockBrandID: "brand-a", QuestionOrder: 1, BaseClosePrice: decimal.NewFromInt(100)},
+	}, nil)
+	universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate2).Return([]*models.QuizUniverseEntry{
+		{QuizDate: quizDate2, StockBrandID: "brand-a", QuestionOrder: 5, BaseClosePrice: decimal.NewFromInt(999)},
+	}, nil)
+
+	answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
+	answerRepo.EXPECT().ListByAnsweredDate(gomock.Any(), answeredDate).Return([]*models.QuizAnswer{
+		{QuizDate: quizDate2, StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionUp},
+		{QuizDate: quizDate1, StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionDown},
+	}, nil)
+
+	stockBrandRepo := mock_repositories.NewMockStockBrandRepository(ctrl)
+	stockBrandRepo.EXPECT().FindByIDs(gomock.Any(), gomock.Any()).Return([]*models.StockBrand{
+		{ID: "brand-a", Name: "銘柄A"},
+	}, nil)
+
+	interactor := NewQuizInteractor(
+		universeRepo,
+		answerRepo,
+		mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
+		stockBrandRepo,
+	)
+
+	got, err := interactor.GetResults(context.Background(), answeredDate)
+	assert.NoError(t, err)
+	assert.Equal(t, "2026-07-04", got.QuizDate)
+	assert.Len(t, got.Items, 2)
+	// quizDate1由来の回答はquestion_order=1・base_close=100を、quizDate2由来はorder=5・base_close=999を
+	// それぞれ正しく引き当てる（quiz_date+stock_brand_idの複合キーでの引き当てを検証）。
+	assert.Equal(t, 1, got.Items[0].QuestionOrder)
+	assert.True(t, decimal.NewFromInt(100).Equal(got.Items[0].BaseClosePrice))
+	assert.Equal(t, 5, got.Items[1].QuestionOrder)
+	assert.True(t, decimal.NewFromInt(999).Equal(got.Items[1].BaseClosePrice))
+}
+
 func TestQuizInteractorImpl_GetStats(t *testing.T) {
-	quizDate1 := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
-	quizDate2 := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	// 日次集計キーは回答日（DATE(answered_at)）。quiz_dateは使わない。
+	answeredAt1 := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
+	answeredAt2 := time.Date(2026, 7, 2, 9, 0, 0, 0, time.UTC)
+	answeredAt3 := time.Date(2026, 7, 3, 9, 0, 0, 0, time.UTC)
 
 	correct := models.QuizOutcomeCorrect
 	incorrect := models.QuizOutcomeIncorrect
@@ -195,11 +247,13 @@ func TestQuizInteractorImpl_GetStats(t *testing.T) {
 	defer ctrl.Finish()
 
 	answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
-	answerRepo.EXPECT().ListAllGraded(gomock.Any()).Return([]*models.QuizAnswer{
-		{QuizDate: quizDate1, Prediction: models.QuizPredictionUp, Outcome: &correct, Score: &score1},
-		{QuizDate: quizDate1, Prediction: models.QuizPredictionStrongUp, Outcome: &correct, Score: &score2},
-		{QuizDate: quizDate2, Prediction: models.QuizPredictionDown, Outcome: &incorrect, Score: &scoreMinus1},
-		{QuizDate: quizDate2, Prediction: models.QuizPredictionUp, Outcome: &voidOutcome, Score: &score0},
+	answerRepo.EXPECT().ListAll(gomock.Any()).Return([]*models.QuizAnswer{
+		{AnsweredAt: answeredAt1, Prediction: models.QuizPredictionUp, Outcome: &correct, Score: &score1},
+		{AnsweredAt: answeredAt1, Prediction: models.QuizPredictionStrongUp, Outcome: &correct, Score: &score2},
+		{AnsweredAt: answeredAt2, Prediction: models.QuizPredictionDown, Outcome: &incorrect, Score: &scoreMinus1},
+		{AnsweredAt: answeredAt2, Prediction: models.QuizPredictionUp, Outcome: &voidOutcome, Score: &score0},
+		// 未採点（採点バッチ未実行）。的中率・スコアの分母には含まれず、日次のPendingにのみ計上される。
+		{AnsweredAt: answeredAt3, Prediction: models.QuizPredictionUp},
 	}, nil)
 
 	interactor := NewQuizInteractor(
@@ -211,19 +265,29 @@ func TestQuizInteractorImpl_GetStats(t *testing.T) {
 
 	stats, err := interactor.GetStats(context.Background())
 	assert.NoError(t, err)
-	assert.Equal(t, 2, stats.TotalScore) // 1+2-1+0
-	assert.Equal(t, 4, stats.TotalAnswered)
+	assert.Equal(t, 2, stats.TotalScore) // 1+2-1+0（未採点分はScoreがnilのため加算されない）
+	assert.Equal(t, 5, stats.TotalAnswered)
 	assert.Equal(t, 2, stats.TotalCorrect)
-	assert.True(t, stats.Accuracy.Equal(decimal.NewFromInt(2).Div(decimal.NewFromInt(3))), "voidを除いた correct+incorrect=3件中2件的中")
+	assert.True(t, stats.Accuracy.Equal(decimal.NewFromInt(2).Div(decimal.NewFromInt(3))), "voidと未採点を除いた correct+incorrect=3件中2件的中")
 
-	assert.Equal(t, 2, stats.ByConfidence.Normal.Answered) // up(correct)とdown(incorrect)。voidは除外
+	assert.Equal(t, 2, stats.ByConfidence.Normal.Answered) // up(correct)とdown(incorrect)。voidと未採点は除外
 	assert.Equal(t, 1, stats.ByConfidence.Normal.Correct)
 	assert.Equal(t, 1, stats.ByConfidence.Strong.Answered)
 	assert.Equal(t, 1, stats.ByConfidence.Strong.Correct)
 
-	assert.Len(t, stats.Daily, 2)
+	assert.Len(t, stats.Daily, 3)
 	assert.Equal(t, "2026-07-01", stats.Daily[0].QuizDate)
+	assert.Equal(t, 2, stats.Daily[0].Answered)
 	assert.Equal(t, 3, stats.Daily[0].Score) // 1+2
+	assert.Equal(t, 0, stats.Daily[0].Pending)
+
 	assert.Equal(t, "2026-07-02", stats.Daily[1].QuizDate)
+	assert.Equal(t, 2, stats.Daily[1].Answered)
 	assert.Equal(t, -1, stats.Daily[1].Score) // -1+0
+	assert.Equal(t, 0, stats.Daily[1].Pending)
+
+	assert.Equal(t, "2026-07-03", stats.Daily[2].QuizDate)
+	assert.Equal(t, 1, stats.Daily[2].Answered)
+	assert.Equal(t, 0, stats.Daily[2].Score)
+	assert.Equal(t, 1, stats.Daily[2].Pending)
 }


### PR DESCRIPTION
## 背景

ユーザー報告のうち以下3件のバックエンド対応（プラン`parsed-swimming-orbit.md`セクションA）:

1. **日付ズレ**: 07/03の回答が07/02分として記録される
3. **日毎成績が出ない**: 累積のみで日毎の成績が見えない
4. **ETF混入**: 出題にETFが含まれる

### 根本原因と方針

- 課題1は`quiz_date`（採点基準日＝チャートの基準営業日）が翌日回答でも変わらない設計に起因し、採点基準として`quiz_date`自体は変更不可。そこで**ユーザー向けの日付軸を「回答日 = DATE(answered_at)（JST）」に統一**した。
- 課題3は日次集計キーが`quiz_date`だったため複数回答日が1行に潰れ、かつ`ListAllGraded`（採点済みのみ）ベースで当日の未採点分が表示されなかった。
- 課題4はユニバース選定が売買代金・値幅率のみで市場区分を見ておらず、ETF等（market_code=109等）が混入していた。既存の`StockBrandRepository.FindAllMainMarkets()`（111/112/113のみ）で除外した。

## 変更内容

- `repositories/quiz_answer.go` / `infrastructure/database/quiz_answer.go`: `ListByAnsweredDate`（answered_atの日付範囲）・`ListAll`（未採点含む全件、answered_at昇順）を追加
- `usecase/quiz_interactor.go`
  - `GetResults`: `ListByQuizDate`→`ListByAnsweredDate`に変更。回答日に混在しうる複数の`quiz_date`ごとにuniverseを引き、`quiz_date + stock_brand_id`の複合キーでquestion_order/base_close_priceをマージ
  - `GetStats`: `ListAllGraded`→`ListAll`に変更。日次集計キーを`DATE(answered_at)`に変更し、未採点件数を日次行の`Pending`として集計（的中率・スコアの分母は従来どおり採点確定分のみ）
- `models/quiz.go`: `QuizDailyScore`に`Pending`を追加。JSONタグ互換維持（`quizDate`のまま中身は回答日であることをコメントで明記）
- `usecase/create_quiz_daily_universe.go`: `StockBrandRepository`を依存追加し、`FindAllMainMarkets`で許可銘柄を絞り込んでから`SelectQuizUniverse`に渡すよう変更（domain_serviceのシグネチャ変更なし。適用は次回バッチ作成分から）
- `config/db.go`: `STOCK_PRICE_REPOSITORY_MYSQL_TIMEZONE`のdefaultを空文字（UTC相当）→`Asia/Tokyo`に変更（防御的修正。DATE(answered_at)の日付境界をJSTで一貫させる）
- `make mock` → `make di` を実行し`mock/`・`di/wire_gen.go`を再生成

## テスト

- `usecase/quiz_interactor_test.go`: GetResults/GetStatsを回答日ベースに更新。複数quiz_date混在時のマージ検証・Pending集計のテストケースを追加
- `usecase/create_quiz_daily_universe_test.go`: 主要市場外（ETF等）銘柄が除外されるケースを追加
- `make test-unit` / `make lint` ともにパス確認済み

## Test plan

- [x] `make test-unit`
- [x] `make lint`
- [ ] CI green（`gh pr checks --watch`）