### PR TITLE
fix: クイズ成績の日付軸を出題基準日(quiz_date)に変更

### DIFF
--- a/infrastructure/database/quiz_answer.go
+++ b/infrastructure/database/quiz_answer.go
@@ -65,30 +65,6 @@ func (qi *QuizAnswerRepositoryImpl) ListByQuizDate(ctx context.Context, quizDate
 	return answers, nil
 }
 
-func (qi *QuizAnswerRepositoryImpl) ListByAnsweredDate(ctx context.Context, date time.Time) ([]*models.QuizAnswer, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
-
-	from := dateOnlyOf(date)
-	to := from.AddDate(0, 0, 1)
-
-	rows, err := tx.QuizAnswer.WithContext(ctx).
-		Where(tx.QuizAnswer.AnsweredAt.Gte(from)).
-		Where(tx.QuizAnswer.AnsweredAt.Lt(to)).
-		Find()
-	if err != nil {
-		return nil, pkgerrors.Wrap(err, "QuizAnswerRepositoryImpl.ListByAnsweredDate error")
-	}
-
-	answers := make([]*models.QuizAnswer, 0, len(rows))
-	for _, r := range rows {
-		answers = append(answers, qi.convertToDomainModel(r))
-	}
-	return answers, nil
-}
-
 func (qi *QuizAnswerRepositoryImpl) ListUngraded(ctx context.Context) ([]*models.QuizAnswer, error) {
 	tx, ok := GetTxQuery(ctx)
 	if !ok {

--- a/mock/repositories/quiz_answer.go
+++ b/mock/repositories/quiz_answer.go
@@ -86,21 +86,6 @@ func (mr *MockQuizAnswerRepositoryMockRecorder) ListAllGraded(ctx any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllGraded", reflect.TypeOf((*MockQuizAnswerRepository)(nil).ListAllGraded), ctx)
 }
 
-// ListByAnsweredDate mocks base method.
-func (m *MockQuizAnswerRepository) ListByAnsweredDate(ctx context.Context, date time.Time) ([]*models.QuizAnswer, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListByAnsweredDate", ctx, date)
-	ret0, _ := ret[0].([]*models.QuizAnswer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListByAnsweredDate indicates an expected call of ListByAnsweredDate.
-func (mr *MockQuizAnswerRepositoryMockRecorder) ListByAnsweredDate(ctx, date any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListByAnsweredDate", reflect.TypeOf((*MockQuizAnswerRepository)(nil).ListByAnsweredDate), ctx, date)
-}
-
 // ListByQuizDate mocks base method.
 func (m *MockQuizAnswerRepository) ListByQuizDate(ctx context.Context, quizDate time.Time) ([]*models.QuizAnswer, error) {
 	m.ctrl.T.Helper()

--- a/mock/usecase/quiz_interactor.go
+++ b/mock/usecase/quiz_interactor.go
@@ -73,18 +73,18 @@ func (mr *MockQuizInteractorMockRecorder) GetQuestions(ctx, date any) *gomock.Ca
 }
 
 // GetResults mocks base method.
-func (m *MockQuizInteractor) GetResults(ctx context.Context, answeredDate time.Time) (*models.QuizResults, error) {
+func (m *MockQuizInteractor) GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResults", ctx, answeredDate)
+	ret := m.ctrl.Call(m, "GetResults", ctx, quizDate)
 	ret0, _ := ret[0].(*models.QuizResults)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetResults indicates an expected call of GetResults.
-func (mr *MockQuizInteractorMockRecorder) GetResults(ctx, answeredDate any) *gomock.Call {
+func (mr *MockQuizInteractorMockRecorder) GetResults(ctx, quizDate any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResults", reflect.TypeOf((*MockQuizInteractor)(nil).GetResults), ctx, answeredDate)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResults", reflect.TypeOf((*MockQuizInteractor)(nil).GetResults), ctx, quizDate)
 }
 
 // GetStats mocks base method.

--- a/models/quiz.go
+++ b/models/quiz.go
@@ -136,8 +136,7 @@ type QuizResultsSummary struct {
 	Score     int `json:"score"`
 }
 
-// QuizResults GET /quiz/results のレスポンス。
-// QuizDate は互換のため JSON タグを維持しているが、中身は「回答日」（DATE(answered_at)、JST）。1回答日に複数の quiz_date（出題基準日）の設問が混在しうる。
+// QuizResults GET /quiz/results のレスポンス。QuizDate は出題基準日（quiz_date）。
 type QuizResults struct {
 	QuizDate string             `json:"quizDate"`
 	Graded   bool               `json:"graded"`
@@ -152,8 +151,7 @@ type QuizConfidenceStats struct {
 	Accuracy decimal.Decimal `json:"accuracy"`
 }
 
-// QuizDailyScore 日別スコア推移の1点。
-// QuizDate は互換のため JSON タグを維持しているが、中身は「回答日」（DATE(answered_at)、JST）であり quiz_date（採点基準日）ではない。
+// QuizDailyScore 日別スコア推移の1点。QuizDate は出題基準日（quiz_date）。
 type QuizDailyScore struct {
 	QuizDate string `json:"quizDate"`
 	Answered int    `json:"answered"`

--- a/repositories/quiz_answer.go
+++ b/repositories/quiz_answer.go
@@ -18,8 +18,6 @@ type QuizAnswerRepository interface {
 	Create(ctx context.Context, answer *models.QuizAnswer) error
 	// ListByQuizDate 指定日の回答一覧を取得する。
 	ListByQuizDate(ctx context.Context, quizDate time.Time) ([]*models.QuizAnswer, error)
-	// ListByAnsweredDate 指定した回答日（answered_at の日付、JST）の回答一覧を取得する。
-	ListByAnsweredDate(ctx context.Context, date time.Time) ([]*models.QuizAnswer, error)
 	// ListUngraded 未採点（outcome IS NULL）の回答を全て取得する。
 	ListUngraded(ctx context.Context) ([]*models.QuizAnswer, error)
 	// UpdateGrading 採点結果（NextClosePrice/ActualReturn/Outcome/Score/GradedAt）を一括反映する。

--- a/usecase/quiz_interactor.go
+++ b/usecase/quiz_interactor.go
@@ -40,9 +40,8 @@ type QuizInteractor interface {
 	// SubmitAnswer 回答を1件登録する。既に回答済みの場合は repositories.ErrQuizAnswerAlreadyExists を返す。
 	// 登録成功時は回答直後に公開する銘柄情報（コード・名称）を返す。
 	SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) (*models.QuizAnswerReveal, error)
-	// GetResults 指定した回答日（answered_at の日付、JST）の採点結果を返す（銘柄名を公開）。
-	// 1回答日には複数の quiz_date（出題基準日）の設問が混在しうる。
-	GetResults(ctx context.Context, answeredDate time.Time) (*models.QuizResults, error)
+	// GetResults 指定した出題基準日（quiz_date）の採点結果を返す（銘柄名を公開）。
+	GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error)
 	// GetStats 累計統計（スコア・的中率・確信度別的中率・日次推移）を返す。
 	GetStats(ctx context.Context) (*models.QuizStats, error)
 }
@@ -180,42 +179,25 @@ func (qi *quizInteractorImpl) SubmitAnswer(ctx context.Context, quizDate time.Ti
 	}, nil
 }
 
-func (qi *quizInteractorImpl) GetResults(ctx context.Context, answeredDate time.Time) (*models.QuizResults, error) {
-	answers, err := qi.quizAnswerRepository.ListByAnsweredDate(ctx, answeredDate)
+func (qi *quizInteractorImpl) GetResults(ctx context.Context, quizDate time.Time) (*models.QuizResults, error) {
+	universe, err := qi.quizDailyUniverseRepository.ListByQuizDate(ctx, quizDate)
 	if err != nil {
-		return nil, pkgerrors.Wrap(err, "ListByAnsweredDate error")
+		return nil, pkgerrors.Wrap(err, "ListByQuizDate error")
+	}
+	answers, err := qi.quizAnswerRepository.ListByQuizDate(ctx, quizDate)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "ListByQuizDate(answers) error")
 	}
 
-	// 回答日には複数の quiz_date（出題基準日）が混在しうるため、distinct な quiz_date ごとに
-	// universe（question_order/base_close_price）を引いてマージする。
-	quizDateSeen := make(map[string]struct{}, len(answers))
-	orderByKey := make(map[string]int)
-	baseCloseByKey := make(map[string]decimal.Decimal)
-	for _, a := range answers {
-		quizDateKey := a.QuizDate.Format(util.DateLayout)
-		if _, ok := quizDateSeen[quizDateKey]; ok {
-			continue
-		}
-		quizDateSeen[quizDateKey] = struct{}{}
-
-		universe, err := qi.quizDailyUniverseRepository.ListByQuizDate(ctx, a.QuizDate)
-		if err != nil {
-			return nil, pkgerrors.Wrap(err, "ListByQuizDate error")
-		}
-		for _, u := range universe {
-			key := quizResultKey(u.QuizDate, u.StockBrandID)
-			orderByKey[key] = u.QuestionOrder
-			baseCloseByKey[key] = u.BaseClosePrice
-		}
+	orderByBrand := make(map[string]int, len(universe))
+	baseCloseByBrand := make(map[string]decimal.Decimal, len(universe))
+	for _, u := range universe {
+		orderByBrand[u.StockBrandID] = u.QuestionOrder
+		baseCloseByBrand[u.StockBrandID] = u.BaseClosePrice
 	}
 
 	sort.Slice(answers, func(i, j int) bool {
-		oi := orderByKey[quizResultKey(answers[i].QuizDate, answers[i].StockBrandID)]
-		oj := orderByKey[quizResultKey(answers[j].QuizDate, answers[j].StockBrandID)]
-		if oi != oj {
-			return oi < oj
-		}
-		return answers[i].QuizDate.Before(answers[j].QuizDate)
+		return orderByBrand[answers[i].StockBrandID] < orderByBrand[answers[j].StockBrandID]
 	})
 
 	brandIDs := make([]string, 0, len(answers))
@@ -239,23 +221,16 @@ func (qi *quizInteractorImpl) GetResults(ctx context.Context, answeredDate time.
 		if !a.Graded() {
 			graded = false
 		}
-		key := quizResultKey(a.QuizDate, a.StockBrandID)
-		items = append(items, buildQuizResultItem(a, orderByKey[key], nameByBrand[a.StockBrandID], baseCloseByKey[key]))
+		items = append(items, buildQuizResultItem(a, orderByBrand[a.StockBrandID], nameByBrand[a.StockBrandID], baseCloseByBrand[a.StockBrandID]))
 		tallyQuizResultSummary(&summary, a)
 	}
 
 	return &models.QuizResults{
-		QuizDate: answeredDate.Format(util.DateLayout),
+		QuizDate: quizDate.Format(util.DateLayout),
 		Graded:   graded,
 		Summary:  summary,
 		Items:    items,
 	}, nil
-}
-
-// quizResultKey quiz_date と stock_brand_id の複合キー。同一銘柄が複数の quiz_date の
-// universe に登場しうるため、question_order/base_close_price の引き当てをこのキーで行う。
-func quizResultKey(quizDate time.Time, stockBrandID string) string {
-	return quizDate.Format(util.DateLayout) + "|" + stockBrandID
 }
 
 func buildQuizResultItem(a *models.QuizAnswer, questionOrder int, name string, baseClosePrice decimal.Decimal) *models.QuizResultItem {
@@ -310,8 +285,8 @@ func (qi *quizInteractorImpl) GetStats(ctx context.Context) (*models.QuizStats, 
 	var dailyOrder []string
 
 	for _, a := range all {
-		// 日次集計キーは回答日（DATE(answered_at)、JST）。quiz_date（出題基準日）ではない。
-		dateStr := a.AnsweredAt.Format(util.DateLayout)
+		// 日次集計キーは出題基準日（quiz_date）。
+		dateStr := a.QuizDate.Format(util.DateLayout)
 		acc, ok := dailyByDate[dateStr]
 		if !ok {
 			acc = &dailyAccumulator{}
@@ -355,6 +330,10 @@ func (qi *quizInteractorImpl) GetStats(ctx context.Context) (*models.QuizStats, 
 		Normal: normalAcc.toStats(),
 		Strong: strongAcc.toStats(),
 	}
+
+	// dailyOrder は ListAll の並び（answered_at 昇順）に由来するため、後から古いクイズに
+	// 回答した場合などに quiz_date の昇順と一致しなくなる。ここで明示的に日付昇順へ並べ直す。
+	sort.Strings(dailyOrder)
 
 	stats.Daily = make([]*models.QuizDailyScore, 0, len(dailyOrder))
 	for _, d := range dailyOrder {

--- a/usecase/quiz_interactor_test.go
+++ b/usecase/quiz_interactor_test.go
@@ -142,7 +142,6 @@ func TestQuizInteractorImpl_GetQuestions(t *testing.T) {
 }
 
 func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
-	answeredDate := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
 	quizDate := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
 
 	ctrl := gomock.NewController(t)
@@ -150,15 +149,15 @@ func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
 
 	universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
 	universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizUniverseEntry{
-		{QuizDate: quizDate, StockBrandID: "brand-a", QuestionOrder: 1, BaseClosePrice: decimal.NewFromInt(100)},
-		{QuizDate: quizDate, StockBrandID: "brand-b", QuestionOrder: 2, BaseClosePrice: decimal.NewFromInt(200)},
+		{StockBrandID: "brand-a", QuestionOrder: 1, BaseClosePrice: decimal.NewFromInt(100)},
+		{StockBrandID: "brand-b", QuestionOrder: 2, BaseClosePrice: decimal.NewFromInt(200)},
 	}, nil)
 
 	// リポジトリからは question_order と無関係な順で返ってくる想定
 	answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
-	answerRepo.EXPECT().ListByAnsweredDate(gomock.Any(), answeredDate).Return([]*models.QuizAnswer{
-		{QuizDate: quizDate, StockBrandID: "brand-b", TickerSymbol: "B001", Prediction: models.QuizPredictionUp},
-		{QuizDate: quizDate, StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionDown},
+	answerRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizAnswer{
+		{StockBrandID: "brand-b", TickerSymbol: "B001", Prediction: models.QuizPredictionUp},
+		{StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionDown},
 	}, nil)
 
 	stockBrandRepo := mock_repositories.NewMockStockBrandRepository(ctrl)
@@ -174,9 +173,9 @@ func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
 		stockBrandRepo,
 	)
 
-	got, err := interactor.GetResults(context.Background(), answeredDate)
+	got, err := interactor.GetResults(context.Background(), quizDate)
 	assert.NoError(t, err)
-	assert.Equal(t, "2026-07-03", got.QuizDate)
+	assert.Equal(t, "2026-07-02", got.QuizDate)
 	assert.Len(t, got.Items, 2)
 	assert.Equal(t, 1, got.Items[0].QuestionOrder)
 	assert.Equal(t, "A001", got.Items[0].TickerSymbol)
@@ -184,59 +183,14 @@ func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
 	assert.Equal(t, "B001", got.Items[1].TickerSymbol)
 }
 
-func TestQuizInteractorImpl_GetResults_MergesMultipleQuizDates(t *testing.T) {
-	// 1回答日（07/04）に複数の quiz_date（07/02出題分・07/03出題分）の回答が混在するケース。
-	answeredDate := time.Date(2026, 7, 4, 0, 0, 0, 0, time.UTC)
-	quizDate1 := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
-	quizDate2 := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
-	// 同一銘柄(brand-a)が異なるquiz_dateのユニバースに別のquestion_order/base_close_priceで登場する。
-	universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate1).Return([]*models.QuizUniverseEntry{
-		{QuizDate: quizDate1, StockBrandID: "brand-a", QuestionOrder: 1, BaseClosePrice: decimal.NewFromInt(100)},
-	}, nil)
-	universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate2).Return([]*models.QuizUniverseEntry{
-		{QuizDate: quizDate2, StockBrandID: "brand-a", QuestionOrder: 5, BaseClosePrice: decimal.NewFromInt(999)},
-	}, nil)
-
-	answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
-	answerRepo.EXPECT().ListByAnsweredDate(gomock.Any(), answeredDate).Return([]*models.QuizAnswer{
-		{QuizDate: quizDate2, StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionUp},
-		{QuizDate: quizDate1, StockBrandID: "brand-a", TickerSymbol: "A001", Prediction: models.QuizPredictionDown},
-	}, nil)
-
-	stockBrandRepo := mock_repositories.NewMockStockBrandRepository(ctrl)
-	stockBrandRepo.EXPECT().FindByIDs(gomock.Any(), gomock.Any()).Return([]*models.StockBrand{
-		{ID: "brand-a", Name: "銘柄A"},
-	}, nil)
-
-	interactor := NewQuizInteractor(
-		universeRepo,
-		answerRepo,
-		mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
-		stockBrandRepo,
-	)
-
-	got, err := interactor.GetResults(context.Background(), answeredDate)
-	assert.NoError(t, err)
-	assert.Equal(t, "2026-07-04", got.QuizDate)
-	assert.Len(t, got.Items, 2)
-	// quizDate1由来の回答はquestion_order=1・base_close=100を、quizDate2由来はorder=5・base_close=999を
-	// それぞれ正しく引き当てる（quiz_date+stock_brand_idの複合キーでの引き当てを検証）。
-	assert.Equal(t, 1, got.Items[0].QuestionOrder)
-	assert.True(t, decimal.NewFromInt(100).Equal(got.Items[0].BaseClosePrice))
-	assert.Equal(t, 5, got.Items[1].QuestionOrder)
-	assert.True(t, decimal.NewFromInt(999).Equal(got.Items[1].BaseClosePrice))
-}
-
 func TestQuizInteractorImpl_GetStats(t *testing.T) {
-	// 日次集計キーは回答日（DATE(answered_at)）。quiz_dateは使わない。
-	answeredAt1 := time.Date(2026, 7, 1, 9, 0, 0, 0, time.UTC)
-	answeredAt2 := time.Date(2026, 7, 2, 9, 0, 0, 0, time.UTC)
-	answeredAt3 := time.Date(2026, 7, 3, 9, 0, 0, 0, time.UTC)
+	// 日次集計キーはquiz_date（出題基準日）。ListAllはanswered_at昇順で返るため、
+	// 過去のクイズに後から回答した場合はencounter順とquiz_date順がずれうる。
+	// ここでは意図的にquiz_date順と異なる順でモックを返し、最終的にQuizDate昇順へ
+	// 並び替えられることを検証する。
+	quizDate1 := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	quizDate2 := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	quizDate3 := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
 
 	correct := models.QuizOutcomeCorrect
 	incorrect := models.QuizOutcomeIncorrect
@@ -248,12 +202,13 @@ func TestQuizInteractorImpl_GetStats(t *testing.T) {
 
 	answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
 	answerRepo.EXPECT().ListAll(gomock.Any()).Return([]*models.QuizAnswer{
-		{AnsweredAt: answeredAt1, Prediction: models.QuizPredictionUp, Outcome: &correct, Score: &score1},
-		{AnsweredAt: answeredAt1, Prediction: models.QuizPredictionStrongUp, Outcome: &correct, Score: &score2},
-		{AnsweredAt: answeredAt2, Prediction: models.QuizPredictionDown, Outcome: &incorrect, Score: &scoreMinus1},
-		{AnsweredAt: answeredAt2, Prediction: models.QuizPredictionUp, Outcome: &voidOutcome, Score: &score0},
-		// 未採点（採点バッチ未実行）。的中率・スコアの分母には含まれず、日次のPendingにのみ計上される。
-		{AnsweredAt: answeredAt3, Prediction: models.QuizPredictionUp},
+		// quizDate3（未採点・出題基準日としては最も新しい）が最初に回答されたケース
+		// （encounter順とquiz_date順が逆転する状況を再現）。
+		{QuizDate: quizDate3, Prediction: models.QuizPredictionUp},
+		{QuizDate: quizDate1, Prediction: models.QuizPredictionUp, Outcome: &correct, Score: &score1},
+		{QuizDate: quizDate1, Prediction: models.QuizPredictionStrongUp, Outcome: &correct, Score: &score2},
+		{QuizDate: quizDate2, Prediction: models.QuizPredictionDown, Outcome: &incorrect, Score: &scoreMinus1},
+		{QuizDate: quizDate2, Prediction: models.QuizPredictionUp, Outcome: &voidOutcome, Score: &score0},
 	}, nil)
 
 	interactor := NewQuizInteractor(
@@ -275,6 +230,7 @@ func TestQuizInteractorImpl_GetStats(t *testing.T) {
 	assert.Equal(t, 1, stats.ByConfidence.Strong.Answered)
 	assert.Equal(t, 1, stats.ByConfidence.Strong.Correct)
 
+	// encounter順（quizDate3→1→2）ではなく quiz_date 昇順（1→2→3）にソートされていること。
 	assert.Len(t, stats.Daily, 3)
 	assert.Equal(t, "2026-07-01", stats.Daily[0].QuizDate)
 	assert.Equal(t, 2, stats.Daily[0].Answered)


### PR DESCRIPTION
## 背景

直前のPR #111 でクイズ成績（GET /quiz/results, GET /quiz/stats）の日付軸を「回答日（DATE(answered_at)）」に変更したが、ユーザー要望は**「◯月◯日分のクイズ」単位（=出題基準日 quiz_date）**での成績確認だった。本PRは日付軸をquiz_dateに戻す。

## 変更内容

- `usecase/quiz_interactor.go`
  - `GetResults`: `ListByAnsweredDate` + 複合キー(quiz_date, stock_brand_id)マージの実装をやめ、指定された`quizDate`で`quizDailyUniverseRepository.ListByQuizDate` / `quizAnswerRepository.ListByQuizDate`を呼ぶ元の単純な形に戻した。不要になった`quizResultKey`は削除
  - `GetStats`: `ListAll`による未採点込み集計とPending表示は維持。日次集計キーを`a.AnsweredAt`から`a.QuizDate`に変更。`ListAll`はanswered_at昇順で返るため、過去のクイズに後から回答した場合にencounter順とquiz_date順がずれる問題があり、最後に`QuizDate`文字列で昇順ソートしてから返すようにした
- `repositories/quiz_answer.go` / `infrastructure/database/quiz_answer.go`: 未使用になった`ListByAnsweredDate`を削除（`ListAll`はGetStatsで使用継続）
- `models/quiz.go`: `QuizResults.QuizDate` / `QuizDailyScore.QuizDate`のコメントを「出題基準日（quiz_date）」に戻す
- handlerは変更なし（dateパラメータの意味がquiz_dateに戻るだけ）

PR #111 で入れた改善（`ListAll`による未採点込み集計・`QuizDailyScore.Pending`・ETF除外・MySQL TZデフォルト）はすべて維持する。

## テスト

- `usecase/quiz_interactor_test.go`: `GetResults`をquiz_dateベースの単純なテストに戻し、`GetStats`はquiz_dateキー集計・Pending・encounter順とquiz_date順が異なるケースでのソートを検証するテストに更新
- `make test-unit`: 全パッケージPASS
- `make lint`: 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)