### PR TITLE
feat: クイズチャートに答え表示用の reveal オプションと結果への stockBrandId を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Install dependencies
         run: go mod download
@@ -51,7 +51,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.26.4'
+          go-version: '1.26.5'
 
       - name: Install dependencies
         run: go mod download

--- a/entrypoint/api/handler/quiz_handler.go
+++ b/entrypoint/api/handler/quiz_handler.go
@@ -56,8 +56,9 @@ func (h *QuizHandler) GetChart(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "stock_brand_idは必須です", http.StatusBadRequest)
 		return
 	}
+	reveal := h.httpServer.GetQueryParam(r, "reveal") == "true"
 
-	chart, err := h.usecase.GetChart(r.Context(), *quizDate, stockBrandID)
+	chart, err := h.usecase.GetChart(r.Context(), *quizDate, stockBrandID, reveal)
 	if err != nil {
 		if errors.Is(err, usecase.ErrQuizQuestionNotFound) {
 			http.Error(w, "指定された設問が見つかりません", http.StatusNotFound)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Code0716/stock-price-repository
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0

--- a/mock/usecase/quiz_interactor.go
+++ b/mock/usecase/quiz_interactor.go
@@ -43,18 +43,18 @@ func (m *MockQuizInteractor) EXPECT() *MockQuizInteractorMockRecorder {
 }
 
 // GetChart mocks base method.
-func (m *MockQuizInteractor) GetChart(ctx context.Context, quizDate time.Time, stockBrandID string) (*models.QuizChart, error) {
+func (m *MockQuizInteractor) GetChart(ctx context.Context, quizDate time.Time, stockBrandID string, reveal bool) (*models.QuizChart, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChart", ctx, quizDate, stockBrandID)
+	ret := m.ctrl.Call(m, "GetChart", ctx, quizDate, stockBrandID, reveal)
 	ret0, _ := ret[0].(*models.QuizChart)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetChart indicates an expected call of GetChart.
-func (mr *MockQuizInteractorMockRecorder) GetChart(ctx, quizDate, stockBrandID any) *gomock.Call {
+func (mr *MockQuizInteractorMockRecorder) GetChart(ctx, quizDate, stockBrandID, reveal any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChart", reflect.TypeOf((*MockQuizInteractor)(nil).GetChart), ctx, quizDate, stockBrandID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChart", reflect.TypeOf((*MockQuizInteractor)(nil).GetChart), ctx, quizDate, stockBrandID, reveal)
 }
 
 // GetQuestions mocks base method.

--- a/models/quiz.go
+++ b/models/quiz.go
@@ -116,6 +116,7 @@ type QuizAnswerReveal struct {
 // QuizResultItem 採点済み1件の結果（銘柄名を公開）。
 type QuizResultItem struct {
 	QuestionOrder  int              `json:"questionOrder"`
+	StockBrandID   string           `json:"stockBrandId"`
 	TickerSymbol   string           `json:"tickerSymbol"`
 	Name           string           `json:"name"`
 	Prediction     QuizPrediction   `json:"prediction"`

--- a/usecase/quiz_interactor.go
+++ b/usecase/quiz_interactor.go
@@ -22,6 +22,9 @@ const quizChartWarmupMonths = 9
 // quizChartVisibleMonths チャートとして実際に表示する期間（月数）。
 const quizChartVisibleMonths = 6
 
+// quizChartRevealDays 答え合わせ用に出題基準日の翌営業日＋数日分を含める日数。
+const quizChartRevealDays = 7
+
 // ErrQuizQuestionNotFound 指定された quiz_date・銘柄の設問が存在しない。
 var ErrQuizQuestionNotFound = errors.New("quiz question not found")
 
@@ -36,7 +39,8 @@ type QuizInteractor interface {
 	// GetQuestions 出題日の設問一覧と回答状況を返す（銘柄名は含まない）。dateがnilの場合は最新の出題日を使う。
 	GetQuestions(ctx context.Context, date *time.Time) (*models.QuizQuestionSet, error)
 	// GetChart 指定設問の匿名チャート（ローソク足+MA5/25/75+出来高）を返す。
-	GetChart(ctx context.Context, quizDate time.Time, stockBrandID string) (*models.QuizChart, error)
+	// reveal=true の場合は答え合わせ用に出題基準日より後のローソク足も含める。
+	GetChart(ctx context.Context, quizDate time.Time, stockBrandID string, reveal bool) (*models.QuizChart, error)
 	// SubmitAnswer 回答を1件登録する。既に回答済みの場合は repositories.ErrQuizAnswerAlreadyExists を返す。
 	// 登録成功時は回答直後に公開する銘柄情報（コード・名称）を返す。
 	SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) (*models.QuizAnswerReveal, error)
@@ -112,7 +116,7 @@ func (qi *quizInteractorImpl) GetQuestions(ctx context.Context, date *time.Time)
 	}, nil
 }
 
-func (qi *quizInteractorImpl) GetChart(ctx context.Context, quizDate time.Time, stockBrandID string) (*models.QuizChart, error) {
+func (qi *quizInteractorImpl) GetChart(ctx context.Context, quizDate time.Time, stockBrandID string, reveal bool) (*models.QuizChart, error) {
 	entry, err := qi.quizDailyUniverseRepository.FindByQuizDateAndStockBrandID(ctx, quizDate, stockBrandID)
 	if err != nil {
 		return nil, pkgerrors.Wrap(err, "FindByQuizDateAndStockBrandID error")
@@ -122,11 +126,16 @@ func (qi *quizInteractorImpl) GetChart(ctx context.Context, quizDate time.Time, 
 	}
 
 	from := quizDate.AddDate(0, -quizChartWarmupMonths, 0)
+	dateTo := quizDate
+	if reveal {
+		// 答え合わせ用に出題基準日の翌営業日＋数日分のローソク足を含める。
+		dateTo = quizDate.AddDate(0, 0, quizChartRevealDays)
+	}
 	order := models.SortOrderAsc
 	prices, err := qi.stockBrandsDailyStockPriceRepository.ListDailyPricesBySymbol(ctx, models.ListDailyPricesBySymbolFilter{
 		TickerSymbol: entry.TickerSymbol,
 		DateFrom:     &from,
-		DateTo:       &quizDate,
+		DateTo:       &dateTo,
 		DateOrder:    &order,
 	})
 	if err != nil {
@@ -134,7 +143,11 @@ func (qi *quizInteractorImpl) GetChart(ctx context.Context, quizDate time.Time, 
 	}
 
 	visibleFrom := quizDate.AddDate(0, -quizChartVisibleMonths, 0)
-	return domain_service.BuildQuizChartSeries(prices, visibleFrom), nil
+	chart := domain_service.BuildQuizChartSeries(prices, visibleFrom)
+	// BuildQuizChartSeries は最終足の日付を QuizDate に入れるため、front がマーカー位置に
+	// 使う出題基準日を維持するようここで明示的に上書きする。
+	chart.QuizDate = quizDate.Format(util.DateLayout)
+	return chart, nil
 }
 
 func (qi *quizInteractorImpl) SubmitAnswer(ctx context.Context, quizDate time.Time, stockBrandID string, prediction models.QuizPrediction) (*models.QuizAnswerReveal, error) {
@@ -236,6 +249,7 @@ func (qi *quizInteractorImpl) GetResults(ctx context.Context, quizDate time.Time
 func buildQuizResultItem(a *models.QuizAnswer, questionOrder int, name string, baseClosePrice decimal.Decimal) *models.QuizResultItem {
 	return &models.QuizResultItem{
 		QuestionOrder:  questionOrder,
+		StockBrandID:   a.StockBrandID,
 		TickerSymbol:   a.TickerSymbol,
 		Name:           name,
 		Prediction:     a.Prediction,

--- a/usecase/quiz_interactor_test.go
+++ b/usecase/quiz_interactor_test.go
@@ -178,9 +178,101 @@ func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {
 	assert.Equal(t, "2026-07-02", got.QuizDate)
 	assert.Len(t, got.Items, 2)
 	assert.Equal(t, 1, got.Items[0].QuestionOrder)
+	assert.Equal(t, "brand-a", got.Items[0].StockBrandID)
 	assert.Equal(t, "A001", got.Items[0].TickerSymbol)
 	assert.Equal(t, 2, got.Items[1].QuestionOrder)
+	assert.Equal(t, "brand-b", got.Items[1].StockBrandID)
 	assert.Equal(t, "B001", got.Items[1].TickerSymbol)
+}
+
+func TestQuizInteractorImpl_GetChart(t *testing.T) {
+	quizDate := time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	from := quizDate.AddDate(0, -quizChartWarmupMonths, 0)
+	order := models.SortOrderAsc
+
+	t.Run("reveal=falseの場合はDateToが出題基準日のまま", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+		universeRepo.EXPECT().FindByQuizDateAndStockBrandID(gomock.Any(), quizDate, "brand-a").Return(
+			&models.QuizUniverseEntry{StockBrandID: "brand-a", TickerSymbol: "A001"}, nil)
+
+		priceRepo := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+		priceRepo.EXPECT().ListDailyPricesBySymbol(gomock.Any(), gomock.Eq(models.ListDailyPricesBySymbolFilter{
+			TickerSymbol: "A001",
+			DateFrom:     &from,
+			DateTo:       &quizDate,
+			DateOrder:    &order,
+		})).Return([]*models.StockBrandDailyPrice{
+			{Date: quizDate, Close: decimal.NewFromInt(100)},
+		}, nil)
+
+		interactor := NewQuizInteractor(
+			universeRepo,
+			mock_repositories.NewMockQuizAnswerRepository(ctrl),
+			priceRepo,
+			mock_repositories.NewMockStockBrandRepository(ctrl),
+		)
+
+		got, err := interactor.GetChart(context.Background(), quizDate, "brand-a", false)
+		assert.NoError(t, err)
+		assert.Equal(t, "2026-07-02", got.QuizDate)
+	})
+
+	t.Run("reveal=trueの場合はDateToが出題基準日+7日に延長され、QuizDateは出題基準日のまま", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		revealDateTo := quizDate.AddDate(0, 0, quizChartRevealDays)
+
+		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+		universeRepo.EXPECT().FindByQuizDateAndStockBrandID(gomock.Any(), quizDate, "brand-a").Return(
+			&models.QuizUniverseEntry{StockBrandID: "brand-a", TickerSymbol: "A001"}, nil)
+
+		priceRepo := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+		priceRepo.EXPECT().ListDailyPricesBySymbol(gomock.Any(), gomock.Eq(models.ListDailyPricesBySymbolFilter{
+			TickerSymbol: "A001",
+			DateFrom:     &from,
+			DateTo:       &revealDateTo,
+			DateOrder:    &order,
+		})).Return([]*models.StockBrandDailyPrice{
+			{Date: quizDate, Close: decimal.NewFromInt(100)},
+			// 答え合わせ用の翌営業日の足。BuildQuizChartSeriesは最終足の日付をQuizDateに
+			// 入れてしまうが、usecase側でquizDateへ上書きされることを検証する。
+			{Date: quizDate.AddDate(0, 0, 1), Close: decimal.NewFromInt(110)},
+		}, nil)
+
+		interactor := NewQuizInteractor(
+			universeRepo,
+			mock_repositories.NewMockQuizAnswerRepository(ctrl),
+			priceRepo,
+			mock_repositories.NewMockStockBrandRepository(ctrl),
+		)
+
+		got, err := interactor.GetChart(context.Background(), quizDate, "brand-a", true)
+		assert.NoError(t, err)
+		assert.Equal(t, "2026-07-02", got.QuizDate)
+		assert.Len(t, got.Candles, 2)
+	})
+
+	t.Run("設問が存在しなければErrQuizQuestionNotFound", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+		universeRepo.EXPECT().FindByQuizDateAndStockBrandID(gomock.Any(), quizDate, "brand-a").Return(nil, nil)
+
+		interactor := NewQuizInteractor(
+			universeRepo,
+			mock_repositories.NewMockQuizAnswerRepository(ctrl),
+			mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
+			mock_repositories.NewMockStockBrandRepository(ctrl),
+		)
+
+		_, err := interactor.GetChart(context.Background(), quizDate, "brand-a", false)
+		assert.ErrorIs(t, err, ErrQuizQuestionNotFound)
+	})
 }
 
 func TestQuizInteractorImpl_GetStats(t *testing.T) {


### PR DESCRIPTION
## Summary
- 成績レビューUI（front側の新機能）向けに、クイズ成績のチャートAPI呼び出しと答え合わせ表示を可能にするバックエンド変更。
- `QuizResultItem` に `stockBrandId` を追加し、front から `GET /quiz/chart` を呼べるようにした。
- `GET /quiz/chart` に `reveal=true` クエリパラメータを追加。指定時は出題基準日（quiz_date）+7日分のローソク足を含めて返す（答え合わせ用）。`QuizDate` はマーカー位置用に出題基準日のまま維持する。

## Test plan
- [x] `make test-unit` （GetChart の reveal true/false ケース、GetResults の stockBrandId アサーションを追加）
- [x] `make lint`
- [x] `make mock` で `mock/usecase/quiz_interactor.go` を再生成済み