### PR TITLE
chore: Docker イメージの Go を 1.26.5 に更新

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
PR #113 で go.mod を 1.26.5（GO-2026-5856 対応）に上げたが、Dockerfile.api / Dockerfile.grpc の base image が golang:1.26.4-alpine のままで、ローカル docker compose の air ビルドが「go.mod requires go >= 1.26.5」で失敗し API が起動しない。base image を 1.26.5-alpine に更新する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)