### PR TITLE
refactor: GetTxQuery のフォールバック定型を TxOrDefault に集約 (S1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,19 +102,18 @@ return fmt.Errorf("...: %w", err) // パッケージ違い
 _ = riskyCall()                   // エラー無視禁止
 ```
 
-### 2. DB トランザクション — `GetTxQuery(ctx)` パターン
+### 2. DB トランザクション — `TxOrDefault(ctx, q)` パターン
 
 書き込みを行う全リポジトリメソッドでトランザクションを引き継ぐ:
 
 ```go
 func (r *MyRepositoryImpl) Write(ctx context.Context, ...) error {
-    tx, ok := GetTxQuery(ctx)
-    if !ok {
-        tx = r.query
-    }
+    tx := TxOrDefault(ctx, r.query)
     // r.query ではなく tx を使用する
 }
 ```
+
+`TxOrDefault` は `GetTxQuery(ctx)` のフォールバック定型（`infrastructure/database/transaction.go`）を集約したヘルパー。
 
 トランザクションの開始は **usecase 層のみ**（`tx.DoInTx`）。repository や infrastructure では開始しない。
 

--- a/infrastructure/database/CLAUDE.md
+++ b/infrastructure/database/CLAUDE.md
@@ -11,21 +11,18 @@ database/
   setup_test.go E2E テスト用 DB セットアップ
 ```
 
-## GetTxQuery パターン（必須）
+## TxOrDefault パターン（必須）
 
 書き込みを行う全メソッドで使用する。`transaction.go` を参照:
 
 ```go
 func (r *MyRepositoryImpl) Upsert(ctx context.Context, items []*models.MyModel) error {
-    tx, ok := GetTxQuery(ctx)
-    if !ok {
-        tx = r.query  // トランザクション外の場合は通常クエリを使用
-    }
+    tx := TxOrDefault(ctx, r.query) // ctx にトランザクションがあればそれを、なければ r.query を使用
     // tx.MyTable.xxx() で操作
 }
 ```
 
-読み取り専用メソッドでも GetTxQuery パターンを統一して使うこと（トランザクション内で読み取る場合があるため）。
+読み取り専用メソッドでも TxOrDefault パターンを統一して使うこと（トランザクション内で読み取る場合があるため）。
 
 ## GORM Gen の使い方
 

--- a/infrastructure/database/analyze_stock_brand_price_history.go
+++ b/infrastructure/database/analyze_stock_brand_price_history.go
@@ -346,10 +346,7 @@ func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) FindMultipleSignals(ctx c
 
 // DeleteByStockBrandIDs 銘柄IDと一致したものを削除する
 func (ai *AnalyzeStockBrandPriceHistoryRepositoryImpl) DeleteByStockBrandIDs(ctx context.Context, ids []string) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = ai.query
-	}
+	tx := TxOrDefault(ctx, ai.query)
 
 	if _, err := tx.AnalyzeStockBrandPriceHistory.WithContext(ctx).
 		Where(tx.AnalyzeStockBrandPriceHistory.StockBrandID.In(ids...)).

--- a/infrastructure/database/applied_stock_consolidation_history.go
+++ b/infrastructure/database/applied_stock_consolidation_history.go
@@ -23,10 +23,7 @@ func NewAppliedStockConsolidationsHistoryRepositoryImpl(db *gorm.DB) repositorie
 }
 
 func (r *AppliedStockConsolidationsHistoryRepositoryImpl) Exists(ctx context.Context, symbol string, consolidationDate time.Time) (bool, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	count, err := tx.AppliedStockConsolidationsHistory.WithContext(ctx).
 		Where(tx.AppliedStockConsolidationsHistory.Symbol.Eq(symbol)).
@@ -36,10 +33,7 @@ func (r *AppliedStockConsolidationsHistoryRepositoryImpl) Exists(ctx context.Con
 }
 
 func (r *AppliedStockConsolidationsHistoryRepositoryImpl) Create(ctx context.Context, history *models.AppliedStockConsolidationHistory) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	ratioVal, _ := history.Ratio.Float64()
 

--- a/infrastructure/database/applied_stock_split_history.go
+++ b/infrastructure/database/applied_stock_split_history.go
@@ -23,10 +23,7 @@ func NewAppliedStockSplitsHistoryRepositoryImpl(db *gorm.DB) repositories.Applie
 }
 
 func (r *AppliedStockSplitsHistoryRepositoryImpl) Exists(ctx context.Context, symbol string, splitDate time.Time) (bool, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	count, err := tx.AppliedStockSplitsHistory.WithContext(ctx).
 		Where(tx.AppliedStockSplitsHistory.Symbol.Eq(symbol)).
@@ -36,10 +33,7 @@ func (r *AppliedStockSplitsHistoryRepositoryImpl) Exists(ctx context.Context, sy
 }
 
 func (r *AppliedStockSplitsHistoryRepositoryImpl) Create(ctx context.Context, history *models.AppliedStockSplitHistory) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	ratioVal, _ := history.Ratio.Float64()
 

--- a/infrastructure/database/daytrade_execution.go
+++ b/infrastructure/database/daytrade_execution.go
@@ -268,10 +268,7 @@ func (r *DaytradeExecutionRepositoryImpl) AggregateStats(ctx context.Context, fr
 }
 
 func (r *DaytradeExecutionRepositoryImpl) FindByDate(ctx context.Context, date time.Time) ([]*models.DaytradeExecution, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	q := tx.DaytradeExecution
 	rows, err := q.WithContext(ctx).
@@ -290,10 +287,7 @@ func (r *DaytradeExecutionRepositoryImpl) FindByDate(ctx context.Context, date t
 }
 
 func (r *DaytradeExecutionRepositoryImpl) FindByDateRange(ctx context.Context, from, to *time.Time) ([]*models.DaytradeExecution, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	q := tx.DaytradeExecution
 	stmt := q.WithContext(ctx)

--- a/infrastructure/database/dji.go
+++ b/infrastructure/database/dji.go
@@ -27,10 +27,7 @@ func NewDjiRepositoryImpl(db *gorm.DB) repositories.DjiRepository {
 }
 
 func (ni *DjiRepositoryImpl) CreateDjiStockAverageDailyPrices(ctx context.Context, averageDailyPrices models.IndexStockAverageDailyPrices) error {
-	query, ok := GetTxQuery(ctx)
-	if !ok {
-		query = ni.query
-	}
+	query := TxOrDefault(ctx, ni.query)
 
 	if err := query.DjiStockAverageDailyStockPrice.WithContext(ctx).
 		Clauses(clause.OnConflict{

--- a/infrastructure/database/high_volume_stock_brand.go
+++ b/infrastructure/database/high_volume_stock_brand.go
@@ -46,10 +46,7 @@ func (r *HighVolumeStockBrandRepositoryImpl) FindWithPagination(
 		return nil, errors.New("limit must be non-negative")
 	}
 
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	// Build GORM Gen query
 	hvb := tx.HighVolumeStockBrand.As("hvb")

--- a/infrastructure/database/nikkei.go
+++ b/infrastructure/database/nikkei.go
@@ -28,10 +28,7 @@ func NewNikkeiRepositoryImpl(db *gorm.DB) repositories.NikkeiRepository {
 }
 
 func (ni *NikkeiRepositoryImpl) CreateNikkeiStockAverageDailyPrices(ctx context.Context, averageDailyPrices models.IndexStockAverageDailyPrices) error {
-	query, ok := GetTxQuery(ctx)
-	if !ok {
-		query = ni.query
-	}
+	query := TxOrDefault(ctx, ni.query)
 
 	if err := query.
 		NikkeiStockAverageDailyPrice.WithContext(ctx).
@@ -54,10 +51,7 @@ func (ni *NikkeiRepositoryImpl) CreateNikkeiStockAverageDailyPrices(ctx context.
 }
 
 func (ni *NikkeiRepositoryImpl) ListNikkeiStockAverageDailyPrices(ctx context.Context, from, to *time.Time) (models.IndexStockAverageDailyPrices, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = ni.query
-	}
+	tx := TxOrDefault(ctx, ni.query)
 
 	do := tx.NikkeiStockAverageDailyPrice.WithContext(ctx)
 	if from != nil {

--- a/infrastructure/database/quiz_answer.go
+++ b/infrastructure/database/quiz_answer.go
@@ -30,10 +30,7 @@ func NewQuizAnswerRepositoryImpl(db *gorm.DB) repositories.QuizAnswerRepository 
 }
 
 func (qi *QuizAnswerRepositoryImpl) Create(ctx context.Context, answer *models.QuizAnswer) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	if err := tx.QuizAnswer.WithContext(ctx).Create(qi.convertToDBModel(answer)); err != nil {
 		var mysqlErr *mysql.MySQLError
@@ -46,10 +43,7 @@ func (qi *QuizAnswerRepositoryImpl) Create(ctx context.Context, answer *models.Q
 }
 
 func (qi *QuizAnswerRepositoryImpl) ListByQuizDate(ctx context.Context, quizDate time.Time) ([]*models.QuizAnswer, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	rows, err := tx.QuizAnswer.WithContext(ctx).
 		Where(tx.QuizAnswer.QuizDate.Eq(dateOnlyOf(quizDate))).
@@ -66,10 +60,7 @@ func (qi *QuizAnswerRepositoryImpl) ListByQuizDate(ctx context.Context, quizDate
 }
 
 func (qi *QuizAnswerRepositoryImpl) ListUngraded(ctx context.Context) ([]*models.QuizAnswer, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	rows, err := tx.QuizAnswer.WithContext(ctx).
 		Where(tx.QuizAnswer.Outcome.IsNull()).
@@ -86,10 +77,7 @@ func (qi *QuizAnswerRepositoryImpl) ListUngraded(ctx context.Context) ([]*models
 }
 
 func (qi *QuizAnswerRepositoryImpl) UpdateGrading(ctx context.Context, answers []*models.QuizAnswer) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	for _, a := range answers {
 		if _, err := tx.QuizAnswer.WithContext(ctx).
@@ -102,10 +90,7 @@ func (qi *QuizAnswerRepositoryImpl) UpdateGrading(ctx context.Context, answers [
 }
 
 func (qi *QuizAnswerRepositoryImpl) ListAllGraded(ctx context.Context) ([]*models.QuizAnswer, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	rows, err := tx.QuizAnswer.WithContext(ctx).
 		Where(tx.QuizAnswer.Outcome.IsNotNull()).
@@ -123,10 +108,7 @@ func (qi *QuizAnswerRepositoryImpl) ListAllGraded(ctx context.Context) ([]*model
 }
 
 func (qi *QuizAnswerRepositoryImpl) ListAll(ctx context.Context) ([]*models.QuizAnswer, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	rows, err := tx.QuizAnswer.WithContext(ctx).
 		Order(tx.QuizAnswer.AnsweredAt).

--- a/infrastructure/database/quiz_daily_universe.go
+++ b/infrastructure/database/quiz_daily_universe.go
@@ -26,10 +26,7 @@ func NewQuizDailyUniverseRepositoryImpl(db *gorm.DB) repositories.QuizDailyUnive
 }
 
 func (qi *QuizDailyUniverseRepositoryImpl) BulkCreate(ctx context.Context, entries []*models.QuizUniverseEntry) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	if len(entries) == 0 {
 		return nil
@@ -43,10 +40,7 @@ func (qi *QuizDailyUniverseRepositoryImpl) BulkCreate(ctx context.Context, entri
 }
 
 func (qi *QuizDailyUniverseRepositoryImpl) ListByQuizDate(ctx context.Context, quizDate time.Time) ([]*models.QuizUniverseEntry, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	dateOnly := dateOnlyOf(quizDate)
 
@@ -66,10 +60,7 @@ func (qi *QuizDailyUniverseRepositoryImpl) ListByQuizDate(ctx context.Context, q
 }
 
 func (qi *QuizDailyUniverseRepositoryImpl) FindLatestQuizDate(ctx context.Context) (*time.Time, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	row, err := tx.QuizDailyUniverse.WithContext(ctx).
 		Order(tx.QuizDailyUniverse.QuizDate.Desc()).
@@ -85,10 +76,7 @@ func (qi *QuizDailyUniverseRepositoryImpl) FindLatestQuizDate(ctx context.Contex
 }
 
 func (qi *QuizDailyUniverseRepositoryImpl) FindByQuizDateAndStockBrandID(ctx context.Context, quizDate time.Time, stockBrandID string) (*models.QuizUniverseEntry, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	row, err := tx.QuizDailyUniverse.WithContext(ctx).
 		Where(tx.QuizDailyUniverse.QuizDate.Eq(dateOnlyOf(quizDate))).
@@ -105,10 +93,7 @@ func (qi *QuizDailyUniverseRepositoryImpl) FindByQuizDateAndStockBrandID(ctx con
 }
 
 func (qi *QuizDailyUniverseRepositoryImpl) ExistsByQuizDate(ctx context.Context, quizDate time.Time) (bool, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = qi.query
-	}
+	tx := TxOrDefault(ctx, qi.query)
 
 	count, err := tx.QuizDailyUniverse.WithContext(ctx).
 		Where(tx.QuizDailyUniverse.QuizDate.Eq(dateOnlyOf(quizDate))).

--- a/infrastructure/database/sector.go
+++ b/infrastructure/database/sector.go
@@ -29,10 +29,7 @@ func NewSector33AverageDailyPriceRepositoryImpl(db *gorm.DB) repositories.Sector
 }
 
 func (r *Sector33AverageDailyPriceRepositoryImpl) ListRangeAll(ctx context.Context, from, to time.Time) ([]*models.Sector33AverageDailyPrice, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	q := tx.Sector33AverageDailyPrice.WithContext(ctx)
 
@@ -89,10 +86,7 @@ func NewSector17AverageDailyPriceRepositoryImpl(db *gorm.DB) repositories.Sector
 }
 
 func (r *Sector17AverageDailyPriceRepositoryImpl) ListRangeAll(ctx context.Context, from, to time.Time) ([]*models.Sector17AverageDailyPrice, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = r.query
-	}
+	tx := TxOrDefault(ctx, r.query)
 
 	q := tx.Sector17AverageDailyPrice.WithContext(ctx)
 

--- a/infrastructure/database/stock_brand.go
+++ b/infrastructure/database/stock_brand.go
@@ -40,10 +40,7 @@ func (si *StockBrandRepositoryImpl) FindAll(ctx context.Context) ([]*models.Stoc
 }
 
 func (si *StockBrandRepositoryImpl) UpsertStockBrands(ctx context.Context, stockBrands []*models.StockBrand) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	err := tx.StockBrand.WithContext(ctx).
 		Clauses(clause.OnConflict{
@@ -88,10 +85,7 @@ func (si *StockBrandRepositoryImpl) FindFromSymbolMainMarkets(ctx context.Contex
 
 // FindWithFilter フィルタ条件に基づいて銘柄を取得する
 func (si *StockBrandRepositoryImpl) FindWithFilter(ctx context.Context, filter *models.StockBrandFilter) ([]*models.StockBrand, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	// ベースクエリ: 削除済み除外、シンボル順
 	q := tx.StockBrand.WithContext(ctx).
@@ -149,10 +143,7 @@ func (si *StockBrandRepositoryImpl) FindWithFilter(ctx context.Context, filter *
 
 // FindByIDs IDのリストから銘柄を取得する（クイズ結果画面での銘柄名解決用）。
 func (si *StockBrandRepositoryImpl) FindByIDs(ctx context.Context, ids []string) ([]*models.StockBrand, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if len(ids) == 0 {
 		return []*models.StockBrand{}, nil
@@ -176,10 +167,7 @@ func (si *StockBrandRepositoryImpl) FindByIDs(ctx context.Context, ids []string)
 }
 
 func (si *StockBrandRepositoryImpl) FindDelistingStockBrandsFromUpdateTime(ctx context.Context, now time.Time) ([]string, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	resultRow, err := tx.StockBrand.Where(tx.StockBrand.UpdatedAt.Lt(now)).Find()
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
@@ -195,10 +183,7 @@ func (si *StockBrandRepositoryImpl) FindDelistingStockBrandsFromUpdateTime(ctx c
 }
 
 func (si *StockBrandRepositoryImpl) DeleteDelistingStockBrands(ctx context.Context, ids []string) ([]*models.StockBrand, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if len(ids) == 0 {
 		return nil, nil

--- a/infrastructure/database/stock_brands_daily_price_for_analyze.go
+++ b/infrastructure/database/stock_brands_daily_price_for_analyze.go
@@ -28,10 +28,7 @@ func NewStockBrandsDailyPriceForAnalyzeRepositoryImpl(db *gorm.DB) repositories.
 }
 
 func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) CreateStockBrandDailyPriceForAnalyze(ctx context.Context, dailyPrices []*models.StockBrandDailyPriceForAnalyze) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if err := tx.StockBrandsDailyPriceForAnalyze.WithContext(ctx).
 		Clauses(clause.OnConflict{
@@ -54,10 +51,7 @@ func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) CreateStockBrandDailyPr
 }
 
 func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) ListLatestPriceBySymbols(ctx context.Context, symbols []*string) ([]*models.StockBrandDailyPriceForAnalyze, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	// シンボルをstring型に変換
 	var symbolStrings []string
@@ -94,10 +88,7 @@ func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) ListLatestPriceBySymbol
 }
 
 func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) DeleteBySymbols(ctx context.Context, deleteSymbols []string) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if _, err := tx.StockBrandsDailyPriceForAnalyze.WithContext(ctx).
 		Where(tx.StockBrandsDailyPriceForAnalyze.TickerSymbol.In(deleteSymbols...)).
@@ -108,10 +99,7 @@ func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) DeleteBySymbols(ctx con
 }
 
 func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) DeleteBeforeDate(ctx context.Context, date time.Time) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if _, err := tx.StockBrandsDailyPriceForAnalyze.WithContext(ctx).
 		Where(tx.StockBrandsDailyPriceForAnalyze.Date.Lt(date)).
@@ -122,10 +110,7 @@ func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) DeleteBeforeDate(ctx co
 }
 
 func (si *StockBrandsDailyPriceForAnalyzeRepositoryImpl) ListDailyPricesBySymbol(ctx context.Context, filter models.ListDailyPricesBySymbolFilter) ([]*models.StockBrandDailyPriceForAnalyze, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if filter.TickerSymbol == "" {
 		return nil, errors.New("TickerSymbol is required")

--- a/infrastructure/database/stock_brands_daily_stock_price.go
+++ b/infrastructure/database/stock_brands_daily_stock_price.go
@@ -27,10 +27,7 @@ func NewStockBrandsDailyPriceRepositoryImpl(db *gorm.DB) repositories.StockBrand
 }
 func (si *StockBrandsDailyPriceRepositoryImpl) GetLatestPriceBySymbol(ctx context.Context, symbol string) (*models.StockBrandDailyPrice, error) {
 
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 	price, err := tx.StockBrandsDailyPrice.WithContext(ctx).
 		Where(tx.StockBrandsDailyPrice.TickerSymbol.Eq(symbol)).
 		Order(tx.StockBrandsDailyPrice.Date.Desc()).
@@ -45,10 +42,7 @@ func (si *StockBrandsDailyPriceRepositoryImpl) GetLatestPriceBySymbol(ctx contex
 }
 
 func (si *StockBrandsDailyPriceRepositoryImpl) CreateStockBrandDailyPrice(ctx context.Context, dailyPrices []*models.StockBrandDailyPrice) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if err := tx.StockBrandsDailyPrice.WithContext(ctx).
 		Clauses(clause.OnConflict{
@@ -71,10 +65,7 @@ func (si *StockBrandsDailyPriceRepositoryImpl) CreateStockBrandDailyPrice(ctx co
 }
 
 func (si *StockBrandsDailyPriceRepositoryImpl) DeleteByIDs(ctx context.Context, ids []string) error {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if _, err := tx.StockBrandsDailyPrice.WithContext(ctx).
 		Where(tx.StockBrandsDailyPrice.StockBrandID.In(ids...)).
@@ -85,10 +76,7 @@ func (si *StockBrandsDailyPriceRepositoryImpl) DeleteByIDs(ctx context.Context, 
 }
 
 func (si *StockBrandsDailyPriceRepositoryImpl) ListDailyPricesBySymbol(ctx context.Context, filter models.ListDailyPricesBySymbolFilter) ([]*models.StockBrandDailyPrice, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if filter.TickerSymbol == "" {
 		return nil, errors.New("TickerSymbol is required")
@@ -146,10 +134,7 @@ func (si *StockBrandsDailyPriceRepositoryImpl) ListDailyPricesBySymbol(ctx conte
 
 // ListRangePricesBySymbols 複数銘柄の期間中日足を一括取得する（シグナル精度評価用）
 func (si *StockBrandsDailyPriceRepositoryImpl) ListRangePricesBySymbols(ctx context.Context, filter models.ListRangePricesBySymbolsFilter) ([]*models.StockBrandDailyPrice, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	if len(filter.Symbols) == 0 {
 		return []*models.StockBrandDailyPrice{}, nil
@@ -184,10 +169,7 @@ func (si *StockBrandsDailyPriceRepositoryImpl) ListRangePricesBySymbols(ctx cont
 
 // ListRecentTradingDates onOrBefore以前の直近の営業日（データが存在する日）を新しい順にlimit件取得する（クイズのユニバース選定用）。
 func (si *StockBrandsDailyPriceRepositoryImpl) ListRecentTradingDates(ctx context.Context, onOrBefore time.Time, limit int) ([]time.Time, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	dateOnly := time.Date(onOrBefore.Year(), onOrBefore.Month(), onOrBefore.Day(), 0, 0, 0, 0, onOrBefore.Location())
 
@@ -206,10 +188,7 @@ func (si *StockBrandsDailyPriceRepositoryImpl) ListRecentTradingDates(ctx contex
 
 // ListPricesByDateRange 期間中の全銘柄の日足を取得する（クイズのユニバース選定用）。
 func (si *StockBrandsDailyPriceRepositoryImpl) ListPricesByDateRange(ctx context.Context, from, to time.Time) ([]*models.StockBrandDailyPrice, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	dateFrom := time.Date(from.Year(), from.Month(), from.Day(), 0, 0, 0, 0, from.Location())
 	dateTo := time.Date(to.Year(), to.Month(), to.Day(), 0, 0, 0, 0, to.Location())
@@ -233,10 +212,7 @@ func (si *StockBrandsDailyPriceRepositoryImpl) ListPricesByDateRange(ctx context
 
 // FindNextTradingDate afterより後の直近の営業日を1件取得する（存在しなければnil。クイズ採点用）。
 func (si *StockBrandsDailyPriceRepositoryImpl) FindNextTradingDate(ctx context.Context, after time.Time) (*time.Time, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = si.query
-	}
+	tx := TxOrDefault(ctx, si.query)
 
 	dateOnly := time.Date(after.Year(), after.Month(), after.Day(), 0, 0, 0, 0, after.Location())
 

--- a/infrastructure/database/topix.go
+++ b/infrastructure/database/topix.go
@@ -28,10 +28,7 @@ func NewTopixRepositoryImpl(db *gorm.DB) repositories.TopixRepository {
 }
 
 func (tr *TopixRepositoryImpl) CreateTopixDailyPrices(ctx context.Context, dailyPrices models.IndexStockAverageDailyPrices) error {
-	query, ok := GetTxQuery(ctx)
-	if !ok {
-		query = tr.query
-	}
+	query := TxOrDefault(ctx, tr.query)
 
 	if err := query.
 		TopixDailyPrice.WithContext(ctx).
@@ -54,10 +51,7 @@ func (tr *TopixRepositoryImpl) CreateTopixDailyPrices(ctx context.Context, daily
 }
 
 func (tr *TopixRepositoryImpl) ListTopixDailyPrices(ctx context.Context, from, to *time.Time) (models.IndexStockAverageDailyPrices, error) {
-	tx, ok := GetTxQuery(ctx)
-	if !ok {
-		tx = tr.query
-	}
+	tx := TxOrDefault(ctx, tr.query)
 
 	do := tx.TopixDailyPrice.WithContext(ctx)
 	if from != nil {

--- a/infrastructure/database/transaction.go
+++ b/infrastructure/database/transaction.go
@@ -82,6 +82,14 @@ func GetTxDB(ctx context.Context) (*gorm.DB, bool) {
 	return tx, ok
 }
 
+// TxOrDefault ctx にトランザクションがあればそれを、なければ q を返す。
+func TxOrDefault(ctx context.Context, q *genQuery.Query) *genQuery.Query {
+	if tx, ok := GetTxQuery(ctx); ok {
+		return tx
+	}
+	return q
+}
+
 //  gormでテーブルをsql export するなら。
 // package main
 

--- a/infrastructure/database/transaction_test.go
+++ b/infrastructure/database/transaction_test.go
@@ -1,0 +1,64 @@
+package database
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	gormtests "gorm.io/gorm/utils/tests"
+
+	genQuery "github.com/Code0716/stock-price-repository/infrastructure/database/gen_query"
+)
+
+func newTestGormDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(gormtests.DummyDialector{}, &gorm.Config{})
+	require.NoError(t, err)
+	return db
+}
+
+func TestTxOrDefault(t *testing.T) {
+	fallbackDB := newTestGormDB(t)
+	fallbackQuery := genQuery.Use(fallbackDB)
+
+	txDB := newTestGormDB(t)
+
+	tests := []struct {
+		name     string
+		ctx      func() context.Context
+		wantDB   *gorm.DB
+		wantSame bool
+	}{
+		{
+			name: "ctxにtxが無い場合はqをそのまま返す",
+			ctx: func() context.Context {
+				return context.Background()
+			},
+			wantDB:   fallbackDB,
+			wantSame: true,
+		},
+		{
+			name: "ctxにtxがある場合はtx由来のqueryを返す",
+			ctx: func() context.Context {
+				return setTx(context.Background(), txDB)
+			},
+			wantDB:   txDB,
+			wantSame: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := TxOrDefault(tt.ctx(), fallbackQuery)
+
+			assert.Equal(t, tt.wantDB, got.UnderlyingDB())
+			if tt.wantSame {
+				assert.Same(t, fallbackQuery, got)
+			} else {
+				assert.NotSame(t, fallbackQuery, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
リファクタ計画 S1。`infrastructure/database` の全リポジトリメソッド冒頭にコピペされていた 4 行のトランザクションフォールバックを `TxOrDefault(ctx, query)` の 1 行に統一。挙動変更なし。

## 変更内容
- `transaction.go` に `TxOrDefault(ctx, q *genQuery.Query) *genQuery.Query` を追加
- 44 箇所を機械置換(16 ファイル)。変数名は各所の既存名を維持
- `transaction_test.go` 新規: tx あり/なしのテーブル駆動テスト(DummyDialector で実 DB 不要)
- ルートと `infrastructure/database` の CLAUDE.md のパターン記載を更新

## 対象外
- `daytrade_trade_note.go:33` は逆条件+フィールド代入の別パターンのため残置

## 検証
`make lint` 0 issues / unit(`-race`)全緑 / e2e 全緑 / govulncheck クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)