### PR TITLE
refactor: ハンドラのエラー応答を writeError に統一 (S2)

### DIFF
--- a/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
+++ b/entrypoint/api/handler/analyze_stock_brand_price_history_handler.go
@@ -172,11 +172,7 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) validateGetAnalyzeStockBrandPrice
 func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistories(w http.ResponseWriter, r *http.Request) {
 	params, err := h.validateGetAnalyzeStockBrandPriceHistoriesParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get analyze stock brand price histories params", err)
 		return
 	}
 
@@ -192,8 +188,7 @@ func (h *AnalyzeStockBrandPriceHistoryHandler) GetAnalyzeStockBrandPriceHistorie
 		DateLimit:    params.dateLimit,
 	})
 	if err != nil {
-		h.logger.Error("failed to get analyze stock brand price histories", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get analyze stock brand price histories", err)
 		return
 	}
 

--- a/entrypoint/api/handler/backtest_handler.go
+++ b/entrypoint/api/handler/backtest_handler.go
@@ -150,18 +150,13 @@ func (h *BacktestHandler) validateGetBacktestParams(r *http.Request) (*getBackte
 func (h *BacktestHandler) GetBacktest(w http.ResponseWriter, r *http.Request) {
 	p, err := h.validateGetBacktestParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get backtest params", err)
 		return
 	}
 
 	result, err := h.usecase.GetBacktestComparison(r.Context(), p.symbol, p.from, p.to, p.params)
 	if err != nil {
-		h.logger.Error("failed to get backtest", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get backtest", err)
 		return
 	}
 

--- a/entrypoint/api/handler/daytrade_handler.go
+++ b/entrypoint/api/handler/daytrade_handler.go
@@ -44,8 +44,7 @@ func (h *DaytradeHandler) ImportSBICsv(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
-		h.logger.Error("daytrade import failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade import failed", err)
 		return
 	}
 	respondJSON(w, h.logger, result)
@@ -86,8 +85,7 @@ func (h *DaytradeHandler) GetSummary(w http.ResponseWriter, r *http.Request) {
 
 	buckets, err := h.usecase.GetSummary(r.Context(), from, to, g)
 	if err != nil {
-		h.logger.Error("daytrade summary failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade summary failed", err)
 		return
 	}
 
@@ -125,8 +123,7 @@ func (h *DaytradeHandler) GetExecutionsByDate(w http.ResponseWriter, r *http.Req
 
 	executions, err := h.usecase.GetExecutionsByDate(r.Context(), date)
 	if err != nil {
-		h.logger.Error("daytrade executions by date failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade executions by date failed", err)
 		return
 	}
 
@@ -160,8 +157,7 @@ func (h *DaytradeHandler) GetSummaryByTickerSymbol(w http.ResponseWriter, r *htt
 
 	items, err := h.usecase.GetSummaryByTickerSymbol(r.Context(), from, to)
 	if err != nil {
-		h.logger.Error("daytrade summary by ticker symbol failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade summary by ticker symbol failed", err)
 		return
 	}
 
@@ -195,8 +191,7 @@ func (h *DaytradeHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := h.usecase.GetPeriodStats(r.Context(), from, to)
 	if err != nil {
-		h.logger.Error("daytrade stats failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade stats failed", err)
 		return
 	}
 	respondJSON(w, h.logger, stats)
@@ -220,8 +215,7 @@ func (h *DaytradeHandler) GetInsights(w http.ResponseWriter, r *http.Request) {
 
 	insights, err := h.usecase.GetInsights(r.Context(), from, to)
 	if err != nil {
-		h.logger.Error("daytrade insights failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade insights failed", err)
 		return
 	}
 	respondJSON(w, h.logger, insights)
@@ -235,8 +229,7 @@ type daytradeRangeResponse struct {
 func (h *DaytradeHandler) GetCoveredRange(w http.ResponseWriter, r *http.Request) {
 	minDate, maxDate, err := h.usecase.GetCoveredRange(r.Context())
 	if err != nil {
-		h.logger.Error("daytrade covered range failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade covered range failed", err)
 		return
 	}
 
@@ -270,8 +263,7 @@ func (h *DaytradeHandler) GetTrades(w http.ResponseWriter, r *http.Request) {
 
 	trades, err := h.usecase.GetTrades(r.Context(), from, to)
 	if err != nil {
-		h.logger.Error("daytrade trades failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade trades failed", err)
 		return
 	}
 	respondJSON(w, h.logger, trades)
@@ -320,8 +312,7 @@ func (h *DaytradeHandler) UpsertTradeNote(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := h.usecase.UpsertTradeNote(r.Context(), rec); err != nil {
-		h.logger.Error("daytrade upsert trade note failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade upsert trade note failed", err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
@@ -345,8 +336,7 @@ func (h *DaytradeHandler) GetTagStats(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := h.usecase.GetTagStats(r.Context(), from, to)
 	if err != nil {
-		h.logger.Error("daytrade tag stats failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "daytrade tag stats failed", err)
 		return
 	}
 	respondJSON(w, h.logger, stats)

--- a/entrypoint/api/handler/fin_announcement_handler.go
+++ b/entrypoint/api/handler/fin_announcement_handler.go
@@ -83,30 +83,21 @@ func (h *FinAnnouncementHandler) GetFinAnnouncements(w http.ResponseWriter, r *h
 
 	page, err := parseBoundedInt(h.httpServer, r, "page", 1, 0)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate fin announcements page param", err)
 		return
 	}
 	filter.Page = page
 
 	limit, err := parseBoundedInt(h.httpServer, r, "limit", 100, 1000)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate fin announcements limit param", err)
 		return
 	}
 	filter.Limit = limit
 
 	result, err := h.usecase.GetFinAnnouncements(r.Context(), filter)
 	if err != nil {
-		h.logger.Error("failed to get fin announcements", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get fin announcements", err)
 		return
 	}
 
@@ -136,8 +127,7 @@ func (h *FinAnnouncementHandler) GetNextFinAnnouncement(w http.ResponseWriter, r
 
 	result, err := h.usecase.GetNextFinAnnouncement(r.Context(), symbol)
 	if err != nil {
-		h.logger.Error("failed to get next fin announcement", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get next fin announcement", err)
 		return
 	}
 

--- a/entrypoint/api/handler/fin_statement_handler.go
+++ b/entrypoint/api/handler/fin_statement_handler.go
@@ -117,11 +117,7 @@ func (h *FinStatementHandler) GetFinStatements(w http.ResponseWriter, r *http.Re
 
 	limit, err := parseBoundedInt(h.httpServer, r, "limit", 8, 20)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get fin statements params", err)
 		return
 	}
 
@@ -130,8 +126,7 @@ func (h *FinStatementHandler) GetFinStatements(w http.ResponseWriter, r *http.Re
 		Limit:        limit,
 	})
 	if err != nil {
-		h.logger.Error("failed to get fin statements", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get fin statements", err)
 		return
 	}
 

--- a/entrypoint/api/handler/multiple_signal_stocks_handler.go
+++ b/entrypoint/api/handler/multiple_signal_stocks_handler.go
@@ -81,11 +81,7 @@ func (h *MultipleSignalStocksHandler) validateGetMultipleSignalStocksParams(r *h
 func (h *MultipleSignalStocksHandler) GetMultipleSignalStocks(w http.ResponseWriter, r *http.Request) {
 	params, err := h.validateGetMultipleSignalStocksParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get multiple signal stocks params", err)
 		return
 	}
 
@@ -95,8 +91,7 @@ func (h *MultipleSignalStocksHandler) GetMultipleSignalStocks(w http.ResponseWri
 		Limit:  params.limit,
 	})
 	if err != nil {
-		h.logger.Error("failed to get multiple signal stocks", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get multiple signal stocks", err)
 		return
 	}
 

--- a/entrypoint/api/handler/quiz_handler.go
+++ b/entrypoint/api/handler/quiz_handler.go
@@ -38,8 +38,7 @@ func (h *QuizHandler) GetQuestions(w http.ResponseWriter, r *http.Request) {
 
 	questions, err := h.usecase.GetQuestions(r.Context(), date)
 	if err != nil {
-		h.logger.Error("quiz get questions failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "quiz get questions failed", err)
 		return
 	}
 	respondJSON(w, h.logger, questions)
@@ -64,8 +63,7 @@ func (h *QuizHandler) GetChart(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "指定された設問が見つかりません", http.StatusNotFound)
 			return
 		}
-		h.logger.Error("quiz get chart failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "quiz get chart failed", err)
 		return
 	}
 	respondJSON(w, h.logger, chart)
@@ -110,8 +108,7 @@ func (h *QuizHandler) SubmitAnswer(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "既に回答済みです", http.StatusConflict)
 			return
 		}
-		h.logger.Error("quiz submit answer failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "quiz submit answer failed", err)
 		return
 	}
 	respondJSONStatus(w, h.logger, http.StatusCreated, reveal)
@@ -126,8 +123,7 @@ func (h *QuizHandler) GetResults(w http.ResponseWriter, r *http.Request) {
 
 	results, err := h.usecase.GetResults(r.Context(), *quizDate)
 	if err != nil {
-		h.logger.Error("quiz get results failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "quiz get results failed", err)
 		return
 	}
 	respondJSON(w, h.logger, results)
@@ -136,8 +132,7 @@ func (h *QuizHandler) GetResults(w http.ResponseWriter, r *http.Request) {
 func (h *QuizHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 	stats, err := h.usecase.GetStats(r.Context())
 	if err != nil {
-		h.logger.Error("quiz get stats failed", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "quiz get stats failed", err)
 		return
 	}
 	respondJSON(w, h.logger, stats)

--- a/entrypoint/api/handler/response.go
+++ b/entrypoint/api/handler/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -20,4 +21,15 @@ func respondJSONStatus(w http.ResponseWriter, logger *zap.Logger, status int, da
 		logger.Error("failed to encode response", zap.Error(err))
 		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
 	}
+}
+
+// writeError validationError は 400、それ以外はログ出力の上 500 を返す。
+func writeError(w http.ResponseWriter, logger *zap.Logger, logMsg string, err error) {
+	var verr *validationError
+	if errors.As(err, &verr) {
+		http.Error(w, verr.Error(), http.StatusBadRequest)
+		return
+	}
+	logger.Error(logMsg, zap.Error(err))
+	http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
 }

--- a/entrypoint/api/handler/response_test.go
+++ b/entrypoint/api/handler/response_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestWriteError(t *testing.T) {
+	type args struct {
+		logMsg string
+		err    error
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantStatusCode int
+		wantBody       string
+		wantLogCount   int
+		wantLogMsg     string
+	}{
+		{
+			name: "validationError の場合は400を返しログは出力しない",
+			args: args{
+				logMsg: "should not be logged",
+				err:    &validationError{message: "バリデーションエラーです"},
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "バリデーションエラーです\n",
+			wantLogCount:   0,
+		},
+		{
+			name: "wrap された validationError の場合も400を返す",
+			args: args{
+				logMsg: "should not be logged",
+				err:    pkgerrors.Wrap(&validationError{message: "wrapされたバリデーションエラーです"}, "wrapped"),
+			},
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "wrapされたバリデーションエラーです\n",
+			wantLogCount:   0,
+		},
+		{
+			name: "一般エラーの場合はログ出力の上500を返す",
+			args: args{
+				logMsg: "failed to do something",
+				err:    pkgerrors.New("boom"),
+			},
+			wantStatusCode: http.StatusInternalServerError,
+			wantBody:       "内部サーバーエラー\n",
+			wantLogCount:   1,
+			wantLogMsg:     "failed to do something",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zapcore.DebugLevel)
+			logger := zap.New(core)
+
+			w := httptest.NewRecorder()
+			writeError(w, logger, tt.args.logMsg, tt.args.err)
+
+			assert.Equal(t, tt.wantStatusCode, w.Code)
+			assert.Equal(t, tt.wantBody, w.Body.String())
+			assert.Equal(t, tt.wantLogCount, logs.Len())
+			if tt.wantLogCount > 0 {
+				entry := logs.All()[0]
+				assert.Equal(t, tt.wantLogMsg, entry.Message)
+				assert.Equal(t, zapcore.ErrorLevel, entry.Level)
+			}
+		})
+	}
+}

--- a/entrypoint/api/handler/return_analysis_handler.go
+++ b/entrypoint/api/handler/return_analysis_handler.go
@@ -76,18 +76,13 @@ func (h *ReturnAnalysisHandler) validateGetReturnAnalysisParams(r *http.Request)
 func (h *ReturnAnalysisHandler) GetReturnAnalysis(w http.ResponseWriter, r *http.Request) {
 	params, err := h.validateGetReturnAnalysisParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get return analysis params", err)
 		return
 	}
 
 	result, err := h.usecase.GetReturnAnalysis(r.Context(), params.symbol, params.from, params.to, params.benchmark)
 	if err != nil {
-		h.logger.Error("failed to get return analysis", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get return analysis", err)
 		return
 	}
 

--- a/entrypoint/api/handler/sector_performance_handler.go
+++ b/entrypoint/api/handler/sector_performance_handler.go
@@ -75,18 +75,13 @@ func (h *SectorPerformanceHandler) validateParams(r *http.Request) (*sectorPerfo
 func (h *SectorPerformanceHandler) GetSectorPerformance(w http.ResponseWriter, r *http.Request) {
 	params, err := h.validateParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate sector performance params", err)
 		return
 	}
 
 	result, err := h.usecase.GetSectorPerformance(r.Context(), params.from, params.to, params.granularity)
 	if err != nil {
-		h.logger.Error("failed to get sector performance", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get sector performance", err)
 		return
 	}
 

--- a/entrypoint/api/handler/signal_performance_handler.go
+++ b/entrypoint/api/handler/signal_performance_handler.go
@@ -66,18 +66,13 @@ func (h *SignalPerformanceHandler) validateParams(r *http.Request) (*models.Sign
 func (h *SignalPerformanceHandler) GetSignalPerformance(w http.ResponseWriter, r *http.Request) {
 	filter, err := h.validateParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate signal performance params", err)
 		return
 	}
 
 	result, err := h.usecase.GetSignalPerformance(r.Context(), filter)
 	if err != nil {
-		h.logger.Error("failed to get signal performance", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get signal performance", err)
 		return
 	}
 

--- a/entrypoint/api/handler/stock_brand_handler.go
+++ b/entrypoint/api/handler/stock_brand_handler.go
@@ -126,19 +126,14 @@ func (h *StockBrandHandler) GetStockBrands(w http.ResponseWriter, r *http.Reques
 	// パラメータのバリデーション
 	params, err := h.validateGetStockBrandsParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get stock brands params", err)
 		return
 	}
 
 	// ユースケース呼び出し
 	result, err := h.usecase.GetStockBrands(r.Context(), params.keyword, params.symbolFrom, params.limit, params.onlyMainMarkets)
 	if err != nil {
-		h.logger.Error("failed to get stock brands", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get stock brands", err)
 		return
 	}
 

--- a/entrypoint/api/handler/stock_price_handler.go
+++ b/entrypoint/api/handler/stock_price_handler.go
@@ -89,19 +89,14 @@ func (h *StockPriceHandler) GetDailyPrices(w http.ResponseWriter, r *http.Reques
 	// パラメータのバリデーション
 	params, err := h.validateGetDailyPricesParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get daily prices params", err)
 		return
 	}
 
 	// ユースケース呼び出し
 	prices, err := h.usecase.GetDailyStockPricesWithOrder(r.Context(), params.symbol, params.from, params.to, params.sortOrder)
 	if err != nil {
-		h.logger.Error("failed to get daily stock prices", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get daily stock prices", err)
 		return
 	}
 
@@ -148,19 +143,14 @@ func (h *StockPriceHandler) GetDailyPriceChart(w http.ResponseWriter, r *http.Re
 	// パラメータのバリデーション
 	params, err := h.validateGetDailyPriceChartParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get daily price chart params", err)
 		return
 	}
 
 	// ユースケース呼び出し
 	chart, err := h.usecase.GetDailyStockPriceChart(r.Context(), params.symbol, params.from, params.to)
 	if err != nil {
-		h.logger.Error("failed to get daily stock price chart", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get daily stock price chart", err)
 		return
 	}
 

--- a/entrypoint/api/handler/strategy_ranking_handler.go
+++ b/entrypoint/api/handler/strategy_ranking_handler.go
@@ -33,8 +33,7 @@ func NewStrategyRankingHandler(u usecase.StrategyRankingInteractor, h driver.HTT
 func (h *StrategyRankingHandler) GetStrategyRanking(w http.ResponseWriter, r *http.Request) {
 	result, err := h.usecase.GetStrategyRanking(r.Context())
 	if err != nil {
-		h.logger.Error("failed to get strategy ranking", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get strategy ranking", err)
 		return
 	}
 	respondJSON(w, h.logger, result)

--- a/entrypoint/api/handler/technical_indicators_handler.go
+++ b/entrypoint/api/handler/technical_indicators_handler.go
@@ -62,18 +62,13 @@ func (h *TechnicalIndicatorsHandler) validateGetTechnicalIndicatorsParams(r *htt
 func (h *TechnicalIndicatorsHandler) GetTechnicalIndicators(w http.ResponseWriter, r *http.Request) {
 	params, err := h.validateGetTechnicalIndicatorsParams(r)
 	if err != nil {
-		if verr, ok := err.(*validationError); ok {
-			http.Error(w, verr.message, http.StatusBadRequest)
-			return
-		}
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to validate get technical indicators params", err)
 		return
 	}
 
 	result, err := h.usecase.GetTechnicalIndicators(r.Context(), params.symbol, params.from, params.to)
 	if err != nil {
-		h.logger.Error("failed to get technical indicators", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get technical indicators", err)
 		return
 	}
 

--- a/entrypoint/api/handler/valuation_handler.go
+++ b/entrypoint/api/handler/valuation_handler.go
@@ -36,8 +36,7 @@ func (h *ValuationHandler) GetValuation(w http.ResponseWriter, r *http.Request) 
 
 	result, err := h.usecase.GetValuation(r.Context(), symbol)
 	if err != nil {
-		h.logger.Error("failed to get valuation", zap.Error(err))
-		http.Error(w, "内部サーバーエラー", http.StatusInternalServerError)
+		writeError(w, h.logger, "failed to get valuation", err)
 		return
 	}
 	respondJSON(w, h.logger, result)


### PR DESCRIPTION
## 概要
リファクタ計画 S2。validationError→400 / その他→ログ+500 の手書き分岐を `response.go` の `writeError(w, logger, logMsg, err)` に集約。**ログ文言・レスポンスボディは不変**。

## 変更内容
- validationError 分岐+500 のセット 13 箇所、500 単独 30 箇所、計 43 箇所を置換(17 ファイル)
- 型アサート → `errors.As` に変更(wrap された validationError も 400 になる一般化。現状 wrap して返す箇所はないことを grep で確認済み → 実挙動差なし)
- `writeError` の単体テスト 3 ケース新規

## 意図的に残した箇所
- daytrade `ErrParse`→422、quiz の 404/409 分岐(500 フォールバックのみ置換)
- `strategy_ranking_handler.go` の 1 箇所: `zap.String("strategy", ...)` 付きログのため未置換(フィールドが失われるのを回避)

## 検証
`make lint` 0 issues / unit・e2e 全緑(既存テスト期待値変更なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)