### PR TITLE
refactor: from/to 日付レンジ検証を parseDateRange に統合 (S3)

### DIFF
--- a/entrypoint/api/handler/backtest_handler.go
+++ b/entrypoint/api/handler/backtest_handler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Code0716/stock-price-repository/driver"
 	"github.com/Code0716/stock-price-repository/models"
 	"github.com/Code0716/stock-price-repository/usecase"
-	"github.com/Code0716/stock-price-repository/util"
 	"github.com/shopspring/decimal"
 	"go.uber.org/zap"
 )
@@ -92,16 +91,11 @@ func (h *BacktestHandler) validateGetBacktestParams(r *http.Request) (*getBackte
 		return nil, &validationError{message: "シンボルは英数字である必要があります"}
 	}
 
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		return nil, &validationError{message: "fromの日付形式が不正です"}
+		return nil, err
 	}
 	p.from = from
-
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		return nil, &validationError{message: "toの日付形式が不正です"}
-	}
 	p.to = to
 
 	takeProfit, ok := parsePositiveRate(h.httpServer.GetQueryParam(r, "takeProfit"), defaultTakeProfit)

--- a/entrypoint/api/handler/backtest_handler_test.go
+++ b/entrypoint/api/handler/backtest_handler_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestBacktestHandler_GetBacktest(t *testing.T) {
-	date, _ := time.Parse(util.DateLayout, "2021-01-04")
+	date, _ := time.ParseInLocation(util.DateLayout, "2021-01-04", time.Local)
 	defaultParams := models.BacktestParams{
 		TakeProfit:     decimal.NewFromFloat(0.10),
 		StopLoss:       decimal.NewFromFloat(0.05),
@@ -60,8 +60,6 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -107,8 +105,6 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("2")
 					return m
 				},
@@ -126,8 +122,6 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("0")
@@ -151,8 +145,6 @@ func TestBacktestHandler_GetBacktest(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -211,8 +203,6 @@ func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -233,8 +223,6 @@ func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -255,8 +243,6 @@ func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -277,8 +263,6 @@ func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -300,8 +284,6 @@ func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -333,7 +315,7 @@ func TestBacktestHandler_GetBacktest_CostParams(t *testing.T) {
 }
 
 func TestBacktestHandler_GetBacktest_ExitMode(t *testing.T) {
-	date, _ := time.Parse(util.DateLayout, "2021-01-04")
+	date, _ := time.ParseInLocation(util.DateLayout, "2021-01-04", time.Local)
 	type fields struct {
 		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockBacktestInteractor
 		httpServer func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer
@@ -354,8 +336,6 @@ func TestBacktestHandler_GetBacktest_ExitMode(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -396,8 +376,6 @@ func TestBacktestHandler_GetBacktest_ExitMode(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")
@@ -436,8 +414,6 @@ func TestBacktestHandler_GetBacktest_ExitMode(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "takeProfit").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "stopLoss").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "maxHoldDays").Return("")

--- a/entrypoint/api/handler/daytrade_handler.go
+++ b/entrypoint/api/handler/daytrade_handler.go
@@ -51,9 +51,9 @@ func (h *DaytradeHandler) ImportSBICsv(w http.ResponseWriter, r *http.Request) {
 }
 
 type daytradeSummaryResponse struct {
-	Granularity string                       `json:"granularity"`
-	From        *string                      `json:"from"`
-	To          *string                      `json:"to"`
+	Granularity string                          `json:"granularity"`
+	From        *string                         `json:"from"`
+	To          *string                         `json:"to"`
 	Buckets     []*models.DaytradeSummaryBucket `json:"buckets"`
 }
 
@@ -68,18 +68,9 @@ func (h *DaytradeHandler) GetSummary(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		http.Error(w, "fromの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		http.Error(w, "toの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	if from != nil && to != nil && from.After(*to) {
-		http.Error(w, "fromはto以前の日付である必要があります", http.StatusBadRequest)
+		writeError(w, h.logger, "daytrade summary date range invalid", err)
 		return
 	}
 
@@ -105,7 +96,7 @@ func (h *DaytradeHandler) GetSummary(w http.ResponseWriter, r *http.Request) {
 }
 
 type daytradeExecutionsResponse struct {
-	Date       string                    `json:"date"`
+	Date       string                      `json:"date"`
 	Executions []*models.DaytradeExecution `json:"executions"`
 }
 
@@ -134,24 +125,15 @@ func (h *DaytradeHandler) GetExecutionsByDate(w http.ResponseWriter, r *http.Req
 }
 
 type daytradeSymbolSummaryResponse struct {
-	From  *string                        `json:"from"`
-	To    *string                        `json:"to"`
+	From  *string                         `json:"from"`
+	To    *string                         `json:"to"`
 	Items []*models.DaytradeSymbolSummary `json:"items"`
 }
 
 func (h *DaytradeHandler) GetSummaryByTickerSymbol(w http.ResponseWriter, r *http.Request) {
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		http.Error(w, "fromの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		http.Error(w, "toの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	if from != nil && to != nil && from.After(*to) {
-		http.Error(w, "fromはto以前の日付である必要があります", http.StatusBadRequest)
+		writeError(w, h.logger, "daytrade summary by ticker symbol date range invalid", err)
 		return
 	}
 
@@ -174,18 +156,9 @@ func (h *DaytradeHandler) GetSummaryByTickerSymbol(w http.ResponseWriter, r *htt
 }
 
 func (h *DaytradeHandler) GetStats(w http.ResponseWriter, r *http.Request) {
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		http.Error(w, "fromの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		http.Error(w, "toの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	if from != nil && to != nil && from.After(*to) {
-		http.Error(w, "fromはto以前の日付である必要があります", http.StatusBadRequest)
+		writeError(w, h.logger, "daytrade stats date range invalid", err)
 		return
 	}
 
@@ -198,18 +171,9 @@ func (h *DaytradeHandler) GetStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *DaytradeHandler) GetInsights(w http.ResponseWriter, r *http.Request) {
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		http.Error(w, "fromの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		http.Error(w, "toの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	if from != nil && to != nil && from.After(*to) {
-		http.Error(w, "fromはto以前の日付である必要があります", http.StatusBadRequest)
+		writeError(w, h.logger, "daytrade insights date range invalid", err)
 		return
 	}
 
@@ -246,18 +210,9 @@ func (h *DaytradeHandler) GetCoveredRange(w http.ResponseWriter, r *http.Request
 }
 
 func (h *DaytradeHandler) GetTrades(w http.ResponseWriter, r *http.Request) {
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		http.Error(w, "fromの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		http.Error(w, "toの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	if from != nil && to != nil && from.After(*to) {
-		http.Error(w, "fromはto以前の日付である必要があります", http.StatusBadRequest)
+		writeError(w, h.logger, "daytrade trades date range invalid", err)
 		return
 	}
 
@@ -319,18 +274,9 @@ func (h *DaytradeHandler) UpsertTradeNote(w http.ResponseWriter, r *http.Request
 }
 
 func (h *DaytradeHandler) GetTagStats(w http.ResponseWriter, r *http.Request) {
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		http.Error(w, "fromの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		http.Error(w, "toの日付形式が不正です (YYYY-MM-DD)", http.StatusBadRequest)
-		return
-	}
-	if from != nil && to != nil && from.After(*to) {
-		http.Error(w, "fromはto以前の日付である必要があります", http.StatusBadRequest)
+		writeError(w, h.logger, "daytrade tag stats date range invalid", err)
 		return
 	}
 

--- a/entrypoint/api/handler/return_analysis_handler.go
+++ b/entrypoint/api/handler/return_analysis_handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Code0716/stock-price-repository/driver"
 	"github.com/Code0716/stock-price-repository/models"
 	"github.com/Code0716/stock-price-repository/usecase"
-	"github.com/Code0716/stock-price-repository/util"
 	"go.uber.org/zap"
 )
 
@@ -48,16 +47,11 @@ func (h *ReturnAnalysisHandler) validateGetReturnAnalysisParams(r *http.Request)
 		return nil, &validationError{message: "シンボルは英数字である必要があります"}
 	}
 
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		return nil, &validationError{message: "fromの日付形式が不正です"}
+		return nil, err
 	}
 	params.from = from
-
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		return nil, &validationError{message: "toの日付形式が不正です"}
-	}
 	params.to = to
 
 	// benchmark クエリパラメータ: "nikkei"（デフォルト）または "topix"

--- a/entrypoint/api/handler/return_analysis_handler_test.go
+++ b/entrypoint/api/handler/return_analysis_handler_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestReturnAnalysisHandler_GetReturnAnalysis(t *testing.T) {
-	date, _ := time.Parse(util.DateLayout, "2024-01-04")
+	date, _ := time.ParseInLocation(util.DateLayout, "2024-01-04", time.Local)
 
 	type fields struct {
 		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockReturnAnalysisInteractor
@@ -52,8 +52,6 @@ func TestReturnAnalysisHandler_GetReturnAnalysis(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "benchmark").Return("")
 					return m
 				},
@@ -88,13 +86,11 @@ func TestReturnAnalysisHandler_GetReturnAnalysis(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "benchmark").Return(models.BenchmarkTopix)
 					return m
 				},
 			},
-			req:            httptest.NewRequest(http.MethodGet, "/return-analysis?symbol=7203&benchmark=topix", nil),
+			req:            httptest.NewRequest(http.MethodGet, "/return-analysis?symbol=7203&from=2024-01-04&to=2024-01-04&benchmark=topix", nil),
 			wantStatusCode: http.StatusOK,
 			wantBody: &models.ReturnAnalysis{
 				Symbol:      "7203",
@@ -113,8 +109,6 @@ func TestReturnAnalysisHandler_GetReturnAnalysis(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "benchmark").Return("sp500")
 					return m
 				},
@@ -180,13 +174,12 @@ func TestReturnAnalysisHandler_GetReturnAnalysis(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/return-analysis?symbol=7203&from=invalid", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "fromの日付形式が不正です\n",
+			wantBody:       "fromの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: toの日付フォーマットが不正",
@@ -197,14 +190,12 @@ func TestReturnAnalysisHandler_GetReturnAnalysis(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/return-analysis?symbol=7203&from=2024-01-04&to=invalid", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "toの日付形式が不正です\n",
+			wantBody:       "toの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: UseCaseがエラーを返す",
@@ -219,8 +210,6 @@ func TestReturnAnalysisHandler_GetReturnAnalysis(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("7203")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "benchmark").Return("")
 					return m
 				},

--- a/entrypoint/api/handler/sector_performance_handler.go
+++ b/entrypoint/api/handler/sector_performance_handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Code0716/stock-price-repository/driver"
 	"github.com/Code0716/stock-price-repository/usecase"
-	"github.com/Code0716/stock-price-repository/util"
 	"go.uber.org/zap"
 )
 
@@ -35,26 +34,23 @@ func (h *SectorPerformanceHandler) validateParams(r *http.Request) (*sectorPerfo
 	now := time.Now()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
-	toParam, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
+	fromParam, toParam, err := parseDateRange(r)
 	if err != nil {
-		return nil, &validationError{message: "toの日付形式が不正です（YYYY-MM-DD）"}
+		return nil, err
 	}
+
 	to := today
 	if toParam != nil {
 		to = *toParam
 	}
 
-	fromParam, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
-	if err != nil {
-		return nil, &validationError{message: "fromの日付形式が不正です（YYYY-MM-DD）"}
-	}
 	from := to.AddDate(0, 0, -90)
 	if fromParam != nil {
 		from = *fromParam
 	}
 
 	if from.After(to) {
-		return nil, &validationError{message: "fromはtoより前の日付を指定してください"}
+		return nil, &validationError{message: "fromはto以前の日付である必要があります"}
 	}
 	if to.Sub(from).Hours()/24 > 366 {
 		return nil, &validationError{message: "期間は最大366日以内で指定してください"}

--- a/entrypoint/api/handler/sector_performance_handler_test.go
+++ b/entrypoint/api/handler/sector_performance_handler_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
-	fixedTo, _ := time.Parse(util.DateLayout, "2024-03-31")
+	fixedTo, _ := time.ParseInLocation(util.DateLayout, "2024-03-31", time.Local)
 	fixedFrom := fixedTo.AddDate(0, 0, -90)
 
 	pr := decimal.NewFromFloat(0.05)
@@ -74,8 +74,6 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&fixedFrom, nil)
 					return m
 				},
 			},
@@ -93,8 +91,6 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&fixedFrom, nil)
 					return m
 				},
 			},
@@ -117,8 +113,6 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&fixedFrom, nil)
 					return m
 				},
 			},
@@ -133,8 +127,6 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&fixedFrom, nil)
 					return m
 				},
 			},
@@ -166,8 +158,6 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
 					return m
 				},
 			},
@@ -181,16 +171,12 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 					return mock_usecase.NewMockSectorPerformanceInteractor(ctrl)
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
-					m := mock_driver.NewMockHTTPServer(ctrl)
-					from := fixedTo.AddDate(0, 0, 10)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&from, nil)
-					return m
+					return mock_driver.NewMockHTTPServer(ctrl)
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/sector-performance?from=2024-04-10&to=2024-03-31", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "fromはtoより前の日付を指定してください\n",
+			wantBody:       "fromはto以前の日付である必要があります\n",
 		},
 		{
 			name: "異常系: 期間 366 日超 → 400",
@@ -199,11 +185,7 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 					return mock_usecase.NewMockSectorPerformanceInteractor(ctrl)
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
-					m := mock_driver.NewMockHTTPServer(ctrl)
-					from := fixedTo.AddDate(-1, 0, -2)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&from, nil)
-					return m
+					return mock_driver.NewMockHTTPServer(ctrl)
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/sector-performance?from=2023-01-01&to=2024-03-31", nil),
@@ -218,13 +200,12 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/sector-performance?to=invalid", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "toの日付形式が不正です（YYYY-MM-DD）\n",
+			wantBody:       "toの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: from の日付形式が不正 → 400",
@@ -234,14 +215,12 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/sector-performance?from=invalid", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "fromの日付形式が不正です（YYYY-MM-DD）\n",
+			wantBody:       "fromの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: usecase がエラーを返す → 500",
@@ -253,8 +232,6 @@ func TestSectorPerformanceHandler_GetSectorPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedTo, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
 					return m
 				},
 			},

--- a/entrypoint/api/handler/signal_performance_handler.go
+++ b/entrypoint/api/handler/signal_performance_handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Code0716/stock-price-repository/driver"
 	"github.com/Code0716/stock-price-repository/models"
 	"github.com/Code0716/stock-price-repository/usecase"
-	"github.com/Code0716/stock-price-repository/util"
 	"go.uber.org/zap"
 )
 
@@ -29,26 +28,23 @@ func (h *SignalPerformanceHandler) validateParams(r *http.Request) (*models.Sign
 	now := time.Now()
 	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 
-	toParam, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
+	fromParam, toParam, err := parseDateRange(r)
 	if err != nil {
-		return nil, &validationError{message: "toの日付形式が不正です（YYYY-MM-DD）"}
+		return nil, err
 	}
+
 	to := today
 	if toParam != nil {
 		to = *toParam
 	}
 
-	fromParam, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
-	if err != nil {
-		return nil, &validationError{message: "fromの日付形式が不正です（YYYY-MM-DD）"}
-	}
 	from := to.AddDate(0, 0, -90)
 	if fromParam != nil {
 		from = *fromParam
 	}
 
 	if from.After(to) {
-		return nil, &validationError{message: "fromはtoより前の日付を指定してください"}
+		return nil, &validationError{message: "fromはto以前の日付である必要があります"}
 	}
 	if to.Sub(from).Hours()/24 > 366 {
 		return nil, &validationError{message: "期間は最大366日以内で指定してください"}

--- a/entrypoint/api/handler/signal_performance_handler_test.go
+++ b/entrypoint/api/handler/signal_performance_handler_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 	// 固定日付
-	fixedDate, _ := time.Parse(util.DateLayout, "2024-03-31")
+	fixedDate, _ := time.ParseInLocation(util.DateLayout, "2024-03-31", time.Local)
 
 	// 正常系レスポンスのサンプル
 	okResult := &models.SignalPerformance{
@@ -57,8 +57,6 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
 					return m
@@ -96,8 +94,6 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
 					return m
@@ -137,8 +133,6 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("find_macd_bullish_stock_v1")
 					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
 					return m
@@ -154,16 +148,12 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 					return mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
-					m := mock_driver.NewMockHTTPServer(ctrl)
-					from := fixedDate.AddDate(0, 0, 10) // to より後
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&from, nil)
-					return m
+					return mock_driver.NewMockHTTPServer(ctrl)
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?from=2024-04-10&to=2024-03-31", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "fromはtoより前の日付を指定してください\n",
+			wantBody:       "fromはto以前の日付である必要があります\n",
 		},
 		{
 			name: "異常系: 期間 366 日超 → 400",
@@ -172,11 +162,7 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 					return mock_usecase.NewMockSignalPerformanceInteractor(ctrl)
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
-					m := mock_driver.NewMockHTTPServer(ctrl)
-					from := fixedDate.AddDate(-1, 0, -2) // 367日以上前
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&from, nil)
-					return m
+					return mock_driver.NewMockHTTPServer(ctrl)
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?from=2023-01-01&to=2024-03-31", nil),
@@ -191,13 +177,12 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?to=invalid", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "toの日付形式が不正です（YYYY-MM-DD）\n",
+			wantBody:       "toの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: from の日付形式が不正 → 400",
@@ -207,14 +192,12 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
 			req:            httptest.NewRequest(http.MethodGet, "/signal-performance?from=invalid", nil),
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "fromの日付形式が不正です（YYYY-MM-DD）\n",
+			wantBody:       "fromの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: usecase がエラーを返す → 500",
@@ -226,8 +209,6 @@ func TestSignalPerformanceHandler_GetSignalPerformance(t *testing.T) {
 				},
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&fixedDate, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "method").Return("")
 					m.EXPECT().GetQueryParam(gomock.Any(), "action").Return("")
 					return m

--- a/entrypoint/api/handler/stock_price_handler.go
+++ b/entrypoint/api/handler/stock_price_handler.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Code0716/stock-price-repository/driver"
 	"github.com/Code0716/stock-price-repository/models"
 	"github.com/Code0716/stock-price-repository/usecase"
-	"github.com/Code0716/stock-price-repository/util"
 	"go.uber.org/zap"
 )
 
@@ -58,18 +57,12 @@ func (h *StockPriceHandler) validateGetDailyPricesParams(r *http.Request) (*getD
 		return nil, &validationError{message: "シンボルは英数字である必要があります"}
 	}
 
-	// from パラメータの取得とバリデーション
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	// from/to パラメータの取得とバリデーション
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		return nil, &validationError{message: "fromの日付形式が不正です"}
+		return nil, err
 	}
 	params.from = from
-
-	// to パラメータの取得とバリデーション
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		return nil, &validationError{message: "toの日付形式が不正です"}
-	}
 	params.to = to
 
 	// order パラメータの取得とバリデーション
@@ -121,18 +114,12 @@ func (h *StockPriceHandler) validateGetDailyPriceChartParams(r *http.Request) (*
 		return nil, &validationError{message: "シンボルは英数字である必要があります"}
 	}
 
-	// from パラメータの取得とバリデーション
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	// from/to パラメータの取得とバリデーション
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		return nil, &validationError{message: "fromの日付形式が不正です"}
+		return nil, err
 	}
 	params.from = from
-
-	// to パラメータの取得とバリデーション
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		return nil, &validationError{message: "toの日付形式が不正です"}
-	}
 	params.to = to
 
 	return params, nil

--- a/entrypoint/api/handler/stock_price_handler_test.go
+++ b/entrypoint/api/handler/stock_price_handler_test.go
@@ -24,7 +24,7 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 
 	// テスト用の日付
 	dateStr := "2023-10-01"
-	date, _ := time.Parse(util.DateLayout, dateStr)
+	date, _ := time.ParseInLocation(util.DateLayout, dateStr, time.Local)
 
 	type fields struct {
 		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor
@@ -64,8 +64,6 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "order").Return("") // orderパラメータはなし
 					return m
 				},
@@ -150,7 +148,6 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
@@ -158,7 +155,7 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				req: httptest.NewRequest(http.MethodGet, "/daily-prices?symbol=1234&from=invalid", nil),
 			},
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "fromの日付形式が不正です\n",
+			wantBody:       "fromの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: toの日付フォーマットが不正",
@@ -169,8 +166,6 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
@@ -178,7 +173,7 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				req: httptest.NewRequest(http.MethodGet, "/daily-prices?symbol=1234&from=2023-10-01&to=invalid", nil),
 			},
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "toの日付形式が不正です\n",
+			wantBody:       "toの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: UseCaseがエラーを返す",
@@ -193,8 +188,6 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "order").Return("") // orderパラメータはなし
 					return m
 				},
@@ -226,8 +219,6 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "order").Return("desc")
 					return m
 				},
@@ -254,8 +245,6 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					m.EXPECT().GetQueryParam(gomock.Any(), "order").Return("invalid")
 					return m
 				},
@@ -297,7 +286,7 @@ func TestStockPriceHandler_GetDailyPrices(t *testing.T) {
 func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
 	// テスト用の日付
 	dateStr := "2023-10-01"
-	date, _ := time.Parse(util.DateLayout, dateStr)
+	date, _ := time.ParseInLocation(util.DateLayout, dateStr, time.Local)
 
 	type fields struct {
 		usecase    func(ctrl *gomock.Controller) *mock_usecase.MockStockBrandsDailyPriceInteractor
@@ -340,8 +329,6 @@ func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					return m
 				},
 			},
@@ -428,7 +415,6 @@ func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
@@ -436,7 +422,7 @@ func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
 				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=1234&from=invalid", nil),
 			},
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "fromの日付形式が不正です\n",
+			wantBody:       "fromの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: toの日付フォーマットが不正",
@@ -447,8 +433,6 @@ func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(nil, errors.New("invalid date"))
 					return m
 				},
 			},
@@ -456,7 +440,7 @@ func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
 				req: httptest.NewRequest(http.MethodGet, "/daily-prices/chart?symbol=1234&from=2023-10-01&to=invalid", nil),
 			},
 			wantStatusCode: http.StatusBadRequest,
-			wantBody:       "toの日付形式が不正です\n",
+			wantBody:       "toの日付形式が不正です (YYYY-MM-DD)\n",
 		},
 		{
 			name: "異常系: UseCaseがエラーを返す",
@@ -471,8 +455,6 @@ func TestStockPriceHandler_GetDailyPriceChart(t *testing.T) {
 				httpServer: func(ctrl *gomock.Controller) *mock_driver.MockHTTPServer {
 					m := mock_driver.NewMockHTTPServer(ctrl)
 					m.EXPECT().GetQueryParam(gomock.Any(), "symbol").Return("1234")
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "from", util.DateLayout).Return(&date, nil)
-					m.EXPECT().GetQueryParamDate(gomock.Any(), "to", util.DateLayout).Return(&date, nil)
 					return m
 				},
 			},

--- a/entrypoint/api/handler/technical_indicators_handler.go
+++ b/entrypoint/api/handler/technical_indicators_handler.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Code0716/stock-price-repository/driver"
 	"github.com/Code0716/stock-price-repository/usecase"
-	"github.com/Code0716/stock-price-repository/util"
 	"go.uber.org/zap"
 )
 
@@ -44,16 +43,11 @@ func (h *TechnicalIndicatorsHandler) validateGetTechnicalIndicatorsParams(r *htt
 		return nil, &validationError{message: "シンボルは英数字である必要があります"}
 	}
 
-	from, err := h.httpServer.GetQueryParamDate(r, "from", util.DateLayout)
+	from, to, err := parseDateRange(r)
 	if err != nil {
-		return nil, &validationError{message: "fromの日付形式が不正です"}
+		return nil, err
 	}
 	params.from = from
-
-	to, err := h.httpServer.GetQueryParamDate(r, "to", util.DateLayout)
-	if err != nil {
-		return nil, &validationError{message: "toの日付形式が不正です"}
-	}
 	params.to = to
 
 	return params, nil

--- a/entrypoint/api/handler/validation.go
+++ b/entrypoint/api/handler/validation.go
@@ -1,6 +1,12 @@
 package handler
 
-import "regexp"
+import (
+	"net/http"
+	"regexp"
+	"time"
+
+	"github.com/Code0716/stock-price-repository/util"
+)
 
 var (
 	// alphanumericRequiredRegex 英数字1文字以上のパターン（必須フィールド用）
@@ -9,3 +15,29 @@ var (
 	// alphanumericOptionalRegex 英数字0文字以上のパターン（任意フィールド用）
 	alphanumericOptionalRegex = regexp.MustCompile(`^[a-zA-Z0-9]*$`)
 )
+
+// parseDateRange from/to クエリを解析し from<=to を検証する。
+// from/to はいずれも省略可能で、指定されなければ nil を返す。
+func parseDateRange(r *http.Request) (from, to *time.Time, err error) {
+	if fromStr := r.URL.Query().Get("from"); fromStr != "" {
+		t, parseErr := time.ParseInLocation(util.DateLayout, fromStr, time.Local)
+		if parseErr != nil {
+			return nil, nil, &validationError{message: "fromの日付形式が不正です (YYYY-MM-DD)"}
+		}
+		from = &t
+	}
+
+	if toStr := r.URL.Query().Get("to"); toStr != "" {
+		t, parseErr := time.ParseInLocation(util.DateLayout, toStr, time.Local)
+		if parseErr != nil {
+			return nil, nil, &validationError{message: "toの日付形式が不正です (YYYY-MM-DD)"}
+		}
+		to = &t
+	}
+
+	if from != nil && to != nil && from.After(*to) {
+		return nil, nil, &validationError{message: "fromはto以前の日付である必要があります"}
+	}
+
+	return from, to, nil
+}

--- a/entrypoint/api/handler/validation_test.go
+++ b/entrypoint/api/handler/validation_test.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Code0716/stock-price-repository/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDateRange(t *testing.T) {
+	from, _ := time.ParseInLocation(util.DateLayout, "2024-01-01", time.Local)
+	to, _ := time.ParseInLocation(util.DateLayout, "2024-01-31", time.Local)
+
+	tests := []struct {
+		name       string
+		url        string
+		wantFrom   *time.Time
+		wantTo     *time.Time
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name:     "正常系: from/to とも指定",
+			url:      "/?from=2024-01-01&to=2024-01-31",
+			wantFrom: &from,
+			wantTo:   &to,
+		},
+		{
+			name:     "正常系: from のみ指定",
+			url:      "/?from=2024-01-01",
+			wantFrom: &from,
+			wantTo:   nil,
+		},
+		{
+			name:     "正常系: to のみ指定",
+			url:      "/?to=2024-01-31",
+			wantFrom: nil,
+			wantTo:   &to,
+		},
+		{
+			name:     "正常系: from/to とも省略",
+			url:      "/",
+			wantFrom: nil,
+			wantTo:   nil,
+		},
+		{
+			name:       "異常系: from の日付形式が不正",
+			url:        "/?from=invalid",
+			wantErr:    true,
+			wantErrMsg: "fromの日付形式が不正です (YYYY-MM-DD)",
+		},
+		{
+			name:       "異常系: to の日付形式が不正",
+			url:        "/?to=invalid",
+			wantErr:    true,
+			wantErrMsg: "toの日付形式が不正です (YYYY-MM-DD)",
+		},
+		{
+			name:       "異常系: from が to より後",
+			url:        "/?from=2024-01-31&to=2024-01-01",
+			wantErr:    true,
+			wantErrMsg: "fromはto以前の日付である必要があります",
+		},
+		{
+			name:     "正常系: from と to が同一日",
+			url:      "/?from=2024-01-01&to=2024-01-01",
+			wantFrom: &from,
+			wantTo:   &from,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, tt.url, nil)
+
+			gotFrom, gotTo, err := parseDateRange(r)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				var verr *validationError
+				assert.ErrorAs(t, err, &verr)
+				assert.Equal(t, tt.wantErrMsg, err.Error())
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantFrom, gotFrom)
+			assert.Equal(t, tt.wantTo, gotTo)
+		})
+	}
+}


### PR DESCRIPTION
## 概要
リファクタ計画 S3。7ハンドラ13メソッドにコピペされていた from/to のパース+前後検証を `validation.go` の `parseDateRange(r)` に集約し、S2 の `writeError` と接続。14ファイルで +189/-251 行(daytrade_handler は -90 行)。

## エラー文言の統一(応答本文の変更あり)
- backtest / return_analysis / technical_indicators / stock_price(2件): `(YYYY-MM-DD)` なし → 付きに統一
- signal_performance / sector_performance: 全角括弧 → 半角、`fromはtoより前の…` → `fromはto以前の日付である必要があります`
- daytrade 6メソッド: 変化なし(既に統一形)

## ⚠️ 挙動追加(要認識)
backtest / return_analysis / technical_indicators / stock_price の **5メソッドには従来 from>to の検証が存在せず**、本PRで新たに 400 を返すようになります(従来はそのまま通していた)。front は不正順を送らないため実影響は限定的ですが、文言統一を超えた変更点として明記します。

## 共通化しなかった箇所
sector/signal performance のデフォルト値ロジック(to=今日、from=to-90日)と366日上限、symbol 検証などの個別バリデーションは各ハンドラに残置。

## 検証
- 旧 `GetQueryParamDate` と同じ `time.ParseInLocation(..., time.Local)` でタイムゾーン挙動一致(実装比較で確認)
- `make lint` 0 issues / unit・e2e 全緑 / govulncheck クリーン
- ローカル API 起動で5エンドポイントに不正 from/to・from>to を投げて 400+統一文言を実機確認
- `parseDateRange` 単体テスト新規。モック依存だったハンドラテストを実 URL クエリ依存に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)