### PR TITLE
fix: 出題日未指定時に採点確定済みの過去問を返さないようにする

### DIFF
--- a/usecase/quiz_interactor.go
+++ b/usecase/quiz_interactor.go
@@ -68,7 +68,22 @@ func (qi *quizInteractorImpl) resolveQuizDate(ctx context.Context, date *time.Ti
 	if date != nil {
 		return date, nil
 	}
-	return qi.quizDailyUniverseRepository.FindLatestQuizDate(ctx)
+	latest, err := qi.quizDailyUniverseRepository.FindLatestQuizDate(ctx)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "FindLatestQuizDate error")
+	}
+	if latest == nil {
+		return nil, nil
+	}
+	// 翌営業日の日足が既に存在する場合、採点基準となる終値が確定済みの過去問なので出題しない。
+	next, err := qi.stockBrandsDailyStockPriceRepository.FindNextTradingDate(ctx, *latest)
+	if err != nil {
+		return nil, pkgerrors.Wrap(err, "FindNextTradingDate error")
+	}
+	if next != nil {
+		return nil, nil
+	}
+	return latest, nil
 }
 
 func (qi *quizInteractorImpl) GetQuestions(ctx context.Context, date *time.Time) (*models.QuizQuestionSet, error) {

--- a/usecase/quiz_interactor_test.go
+++ b/usecase/quiz_interactor_test.go
@@ -110,35 +110,113 @@ func TestQuizInteractorImpl_SubmitAnswer(t *testing.T) {
 func TestQuizInteractorImpl_GetQuestions(t *testing.T) {
 	quizDate := time.Date(2026, 7, 3, 0, 0, 0, 0, time.UTC)
 
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+	t.Run("日付を明示指定した場合はFindNextTradingDateを呼ばずそのまま返す", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
-	universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizUniverseEntry{
-		{StockBrandID: "brand-a", QuestionOrder: 1},
-		{StockBrandID: "brand-b", QuestionOrder: 2},
-	}, nil)
+		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+		universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizUniverseEntry{
+			{StockBrandID: "brand-a", QuestionOrder: 1},
+			{StockBrandID: "brand-b", QuestionOrder: 2},
+		}, nil)
 
-	answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
-	answerRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizAnswer{
-		{StockBrandID: "brand-a", Prediction: models.QuizPredictionUp},
-	}, nil)
+		answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
+		answerRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizAnswer{
+			{StockBrandID: "brand-a", Prediction: models.QuizPredictionUp},
+		}, nil)
 
-	interactor := NewQuizInteractor(
-		universeRepo,
-		answerRepo,
-		mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
-		mock_repositories.NewMockStockBrandRepository(ctrl),
-	)
+		interactor := NewQuizInteractor(
+			universeRepo,
+			answerRepo,
+			// 日付指定時はFindNextTradingDateを呼ばないため、EXPECTを設定しないモックで
+			// 呼ばれたら即エラーになることを保証する。
+			mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
+			mock_repositories.NewMockStockBrandRepository(ctrl),
+		)
 
-	got, err := interactor.GetQuestions(context.Background(), &quizDate)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, got.TotalCount)
-	assert.Equal(t, 1, got.AnsweredCount)
-	assert.True(t, got.Questions[0].Answered)
-	assert.Equal(t, "up", *got.Questions[0].Prediction)
-	assert.False(t, got.Questions[1].Answered)
-	assert.Nil(t, got.Questions[1].Prediction)
+		got, err := interactor.GetQuestions(context.Background(), &quizDate)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, got.TotalCount)
+		assert.Equal(t, 1, got.AnsweredCount)
+		assert.True(t, got.Questions[0].Answered)
+		assert.Equal(t, "up", *got.Questions[0].Prediction)
+		assert.False(t, got.Questions[1].Answered)
+		assert.Nil(t, got.Questions[1].Prediction)
+	})
+
+	t.Run("日付未指定+翌営業日の日足が未到来なら最新のquiz_dateを出題する", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+		universeRepo.EXPECT().FindLatestQuizDate(gomock.Any()).Return(&quizDate, nil)
+		universeRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizUniverseEntry{
+			{StockBrandID: "brand-a", QuestionOrder: 1},
+		}, nil)
+
+		priceRepo := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+		priceRepo.EXPECT().FindNextTradingDate(gomock.Any(), quizDate).Return(nil, nil)
+
+		answerRepo := mock_repositories.NewMockQuizAnswerRepository(ctrl)
+		answerRepo.EXPECT().ListByQuizDate(gomock.Any(), quizDate).Return([]*models.QuizAnswer{}, nil)
+
+		interactor := NewQuizInteractor(
+			universeRepo,
+			answerRepo,
+			priceRepo,
+			mock_repositories.NewMockStockBrandRepository(ctrl),
+		)
+
+		got, err := interactor.GetQuestions(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "2026-07-03", got.QuizDate)
+		assert.Equal(t, 1, got.TotalCount)
+	})
+
+	t.Run("日付未指定+翌営業日の日足が既に存在するなら答えが確定済みの過去問なので空を返す（回帰テスト）", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		nextDate := quizDate.AddDate(0, 0, 3)
+
+		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+		universeRepo.EXPECT().FindLatestQuizDate(gomock.Any()).Return(&quizDate, nil)
+
+		priceRepo := mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl)
+		priceRepo.EXPECT().FindNextTradingDate(gomock.Any(), quizDate).Return(&nextDate, nil)
+
+		interactor := NewQuizInteractor(
+			universeRepo,
+			mock_repositories.NewMockQuizAnswerRepository(ctrl),
+			priceRepo,
+			mock_repositories.NewMockStockBrandRepository(ctrl),
+		)
+
+		got, err := interactor.GetQuestions(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, got.TotalCount)
+		assert.Empty(t, got.Questions)
+	})
+
+	t.Run("日付未指定+universeが0件なら空を返す", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		universeRepo := mock_repositories.NewMockQuizDailyUniverseRepository(ctrl)
+		universeRepo.EXPECT().FindLatestQuizDate(gomock.Any()).Return(nil, nil)
+
+		interactor := NewQuizInteractor(
+			universeRepo,
+			mock_repositories.NewMockQuizAnswerRepository(ctrl),
+			mock_repositories.NewMockStockBrandsDailyPriceRepository(ctrl),
+			mock_repositories.NewMockStockBrandRepository(ctrl),
+		)
+
+		got, err := interactor.GetQuestions(context.Background(), nil)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, got.TotalCount)
+		assert.Empty(t, got.Questions)
+	})
 }
 
 func TestQuizInteractorImpl_GetResults_SortedByQuestionOrder(t *testing.T) {


### PR DESCRIPTION
## Summary
- GET /quiz/questions を date 未指定で呼んだ際、翌営業日の日足がすでに存在する（＝採点結果が確定済みの）quiz_date を配信していたバグを修正
- 実際に2026-08-10、300問すべてが2026-08-07の問題として記録される事故が発生（出題バッチ生成の10秒前にアクセスしたため）
- `resolveQuizDate` に `FindNextTradingDate` によるガードを追加し、翌営業日の日足が既に存在する場合は空の設問セットを返すようにした
- 日付を明示指定した場合（結果確認用途）はガードしない

## Test plan
- [x] `ENVCODE=unit go test ./usecase/...` 全通過
- [x] `golangci-lint run ./usecase/...` issue 0件
- [x] `go build ./...` 成功
- [x] 回帰テスト追加: 翌営業日データ存在時に空を返すケース / 未到来時に正常出題するケース / 日付明示指定時はガードしないケース

🤖 Generated with [Claude Code](https://claude.com/claude-code)