### PR TITLE
fix: Go toolchainをgo1.26.6に更新しstdlib既知脆弱性を解消する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install dependencies
         run: go mod download
@@ -51,7 +51,7 @@ jobs:
           submodules: recursive
       - uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Run govulncheck
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
 
       - name: Install dependencies
         run: go mod download

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine
+FROM golang:1.26.6-alpine
 
 WORKDIR /app
 

--- a/Dockerfile.grpc
+++ b/Dockerfile.grpc
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine
+FROM golang:1.26.6-alpine
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Code0716/stock-price-repository
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alicebob/miniredis/v2 v2.38.0


### PR DESCRIPTION
## Summary
- `govulncheck` が検出していた stdlib の既知脆弱性（GO-2026-6089/6090/6091/6218: net/http・crypto/tls・html/template・net/url、いずれも go1.26.5 止まりが原因）を go1.26.6 で解消
- `go.mod` の `go` ディレクティブ、CI（`.github/workflows/test.yml` の `setup-go`）、`Dockerfile.api`/`Dockerfile.grpc` のベースイメージを go1.26.6 に統一
- コード変更は無し。バージョン指定のみ

## 背景
#127（クイズ出題時の銘柄名公開）のCIで `Vulnerability Check` が失敗していたが、内容を確認したところ本件の差分とは無関係な stdlib 脆弱性が原因だった。`go.mod`/`go.sum` を一切触っていないPRでも同じ理由でブロックされる状態だったため、直接の原因を切り離して別PRで対応。

## Test plan
- [x] `go build ./...`
- [x] `govulncheck ./...` → `No vulnerabilities found.`
- [x] `make lint`
- [x] `go test ./usecase/... ./domain_service/... ./util/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)